### PR TITLE
Refine Bar

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -270,24 +270,19 @@ fn spawn_camera(commands: &mut Commands) {
 }
 
 fn spawn_void_spheres(commands: &mut Commands) {
-	commands.spawn((
-		Name::new("Sphere A"),
-		VoidSphere,
-		SpatialBundle::from_transform(Transform::from_xyz(2., 0., 2.)),
-	));
-	commands.spawn((
-		Name::new("Sphere B"),
-		VoidSphere,
-		SpatialBundle::from_transform(Transform::from_xyz(-2., 0., 2.)),
-	));
-	commands.spawn((
-		Name::new("Sphere C"),
-		VoidSphere,
-		SpatialBundle::from_transform(Transform::from_xyz(2., 0., -2.)),
-	));
-	commands.spawn((
-		Name::new("Sphere D"),
-		VoidSphere,
-		SpatialBundle::from_transform(Transform::from_xyz(-2., 0., -2.)),
-	));
+	let directions = [
+		("Sphere A", Vec3::new(1., 0., 1.)),
+		("Sphere B", Vec3::new(-1., 0., 1.)),
+		("Sphere C", Vec3::new(1., 0., -1.)),
+		("Sphere D", Vec3::new(-1., 0., -1.)),
+	];
+	let distance = 10.;
+
+	for (name, direction) in directions {
+		commands.spawn((
+			Name::new(name),
+			VoidSphere,
+			SpatialBundle::from_transform(Transform::from_translation(direction * distance)),
+		));
+	}
 }

--- a/src/plugins/bars/src/components.rs
+++ b/src/plugins/bars/src/components.rs
@@ -41,7 +41,7 @@ impl<T> Default for BarValues<T> {
 	}
 }
 
-#[derive(Component)]
+#[derive(Component, Debug, PartialEq)]
 pub struct Bar {
 	pub offset: Vec3,
 	pub scale: f32,

--- a/src/plugins/bars/src/lib.rs
+++ b/src/plugins/bars/src/lib.rs
@@ -7,13 +7,15 @@ use bevy::{
 	ecs::schedule::IntoSystemConfigs,
 	render::camera::Camera,
 };
-use common::components::Health;
+use common::{components::Health, traits::ownership_relation::OwnershipRelation};
+use components::Bar;
 use systems::{bar::bar, render_bar::render_bar};
 
 pub struct BarsPlugin;
 
 impl Plugin for BarsPlugin {
 	fn build(&self, app: &mut App) {
+		app.manage_ownership::<Bar>(Update);
 		app.add_systems(
 			Update,
 			(bar::<Health, Camera>, render_bar::<Health>).chain(),

--- a/src/plugins/bars/src/systems/render_bar.rs
+++ b/src/plugins/bars/src/systems/render_bar.rs
@@ -1,53 +1,29 @@
-use std::marker::PhantomData;
-
 use crate::{
 	components::{Bar, BarValues, UI},
 	traits::UIBarColors,
 };
 use bevy::{
 	ecs::{
-		component::Component,
 		entity::Entity,
 		system::{Commands, Query},
 		world::Mut,
 	},
-	hierarchy::{BuildChildren, DespawnRecursiveExt},
+	hierarchy::BuildChildren,
 	math::Vec2,
 	prelude::default,
 	ui::{node_bundles::NodeBundle, BackgroundColor, PositionType, Style, Val},
 };
+use common::components::OwnedBy;
 
 const BASE_DIMENSIONS: Vec2 = Vec2::new(100., 10.);
-
-#[derive(Component)]
-pub struct Owned<TOwner> {
-	owner: Entity,
-	owner_type: PhantomData<TOwner>,
-}
-
-impl<T> Owned<T> {
-	fn by(owner: Entity) -> Self {
-		Self {
-			owner,
-			owner_type: PhantomData,
-		}
-	}
-}
 
 pub(crate) fn render_bar<T: Send + Sync + 'static>(
 	mut commands: Commands,
 	mut bars: Query<(Entity, &Bar, &mut BarValues<T>)>,
 	mut styles: Query<&mut Style>,
-	backgrounds: Query<(Entity, &Owned<Bar>)>,
 ) where
 	BarValues<T>: UIBarColors,
 {
-	let not_owned = |(_, owned): &(Entity, &Owned<Bar>)| bars.get(owned.owner).is_err();
-
-	for (background, ..) in backgrounds.iter().filter(not_owned) {
-		remove(&mut commands, background);
-	}
-
 	for (bar_id, bar, bar_values) in &mut bars {
 		match (bar.position, bar_values.ui) {
 			(Some(position), None) => add_ui(&mut commands, bar_id, bar, bar_values, position),
@@ -69,7 +45,7 @@ fn add_ui<T: Send + Sync + 'static>(
 	let scaled_dimension = BASE_DIMENSIONS * bar.scale;
 	let background = commands
 		.spawn((
-			Owned::<Bar>::by(bar_id),
+			OwnedBy::<Bar>::with(bar_id),
 			NodeBundle {
 				style: Style {
 					width: Val::Px(scaled_dimension.x),
@@ -119,13 +95,6 @@ fn update_ui<T>(
 	}
 }
 
-fn remove(commands: &mut Commands, id: Entity) {
-	let Some(entity) = commands.get_entity(id) else {
-		return;
-	};
-	entity.despawn_recursive();
-}
-
 fn noop() {}
 
 #[cfg(test)]
@@ -133,8 +102,8 @@ mod tests {
 	use super::*;
 	use bevy::{
 		app::{App, Update},
-		ecs::{component::Component, world::EntityRef},
-		hierarchy::{BuildWorldChildren, Parent},
+		ecs::world::EntityRef,
+		hierarchy::Parent,
 		math::Vec2,
 		render::color::Color,
 		ui::{BackgroundColor, Node},
@@ -194,6 +163,34 @@ mod tests {
 				foreground
 			}),
 			bar.ui
+		);
+	}
+
+	#[test]
+	fn add_ownership_on_top_node() {
+		let mut app = App::new();
+		app.add_systems(Update, render_bar::<_Display>);
+
+		let bar = Bar {
+			position: Some(default()),
+			..default()
+		};
+		let bar_values = BarValues::<_Display>::new(0., 0.);
+		let bar = app.world.spawn((bar, bar_values)).id();
+
+		app.update();
+
+		let (background, ..) = app
+			.world
+			.iter_entities()
+			.filter(no_parent)
+			.find_map(|e| Some((e.id(), e.get::<Node>()?)))
+			.unwrap();
+		let background = app.world.entity(background);
+
+		assert_eq!(
+			Some(&OwnedBy::<Bar>::with(bar)),
+			background.get::<OwnedBy<Bar>>()
 		);
 	}
 
@@ -499,41 +496,5 @@ mod tests {
 			.unwrap();
 
 		assert_eq!(Val::Percent(120. / 200. * 100.), style.width);
-	}
-
-	#[test]
-	fn remove_node_recursive_when_bar_removed() {
-		#[derive(Component)]
-		struct _Child;
-
-		let mut app = App::new();
-		app.add_systems(Update, render_bar::<_Display>);
-
-		let bar = Bar {
-			position: Some(default()),
-			..default()
-		};
-		let bar_values = BarValues::<_Display>::new(0., 0.);
-		let bar = app.world.spawn((bar, bar_values)).id();
-
-		app.update();
-
-		let (node_id, ..) = app
-			.world
-			.iter_entities()
-			.filter(no_parent)
-			.find_map(|e| Some((e.id(), e.get::<Node>()?)))
-			.unwrap();
-		app.world.entity_mut(node_id).with_children(|parent| {
-			parent.spawn(_Child);
-		});
-		app.world.entity_mut(bar).despawn();
-
-		app.update();
-
-		let nodes = app.world.iter_entities().filter_map(|e| e.get::<Node>());
-		let children = app.world.iter_entities().filter_map(|e| e.get::<_Child>());
-
-		assert_eq!((0, 0), (nodes.count(), children.count()));
 	}
 }

--- a/src/plugins/common/src/components.rs
+++ b/src/plugins/common/src/components.rs
@@ -2,6 +2,7 @@ use bevy::{
 	ecs::{component::Component, entity::Entity},
 	math::Vec3,
 };
+use std::marker::PhantomData;
 
 #[derive(Debug, PartialEq)]
 pub struct Swap<T1, T2>(pub T1, pub T2);
@@ -67,4 +68,19 @@ pub enum Animate<T: Copy + Clone> {
 pub struct Outdated<TComponent: Component> {
 	pub entity: Entity,
 	pub component: TComponent,
+}
+
+#[derive(Component, Debug, PartialEq)]
+pub struct OwnedBy<TOwner> {
+	pub owner: Entity,
+	owner_type: PhantomData<TOwner>,
+}
+
+impl<T> OwnedBy<T> {
+	pub fn with(owner: Entity) -> Self {
+		Self {
+			owner,
+			owner_type: PhantomData,
+		}
+	}
 }

--- a/src/plugins/common/src/systems.rs
+++ b/src/plugins/common/src/systems.rs
@@ -1,3 +1,4 @@
 pub mod log;
+pub(crate) mod remove_not_owned;
 pub(crate) mod set_cam_ray;
 pub(crate) mod set_mouse_hover;

--- a/src/plugins/common/src/systems/remove_not_owned.rs
+++ b/src/plugins/common/src/systems/remove_not_owned.rs
@@ -1,0 +1,89 @@
+use crate::components::OwnedBy;
+use bevy::{
+	ecs::{
+		component::Component,
+		entity::Entity,
+		query::With,
+		system::{Commands, Query},
+	},
+	hierarchy::DespawnRecursiveExt,
+};
+
+pub(crate) fn remove_not_owned<TOwner: Component>(
+	mut commands: Commands,
+	owners: Query<Entity, With<TOwner>>,
+	owned: Query<(Entity, &OwnedBy<TOwner>)>,
+) {
+	let not_owned = |(.., owned): &(Entity, &OwnedBy<TOwner>)| owners.get(owned.owner).is_err();
+
+	for (id, ..) in owned.iter().filter(not_owned) {
+		remove(&mut commands, id);
+	}
+}
+
+fn remove(commands: &mut Commands, id: Entity) {
+	let Some(entity) = commands.get_entity(id) else {
+		return;
+	};
+	entity.despawn_recursive();
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::test_tools::utils::SingleThreadedApp;
+	use bevy::{
+		app::{App, Update},
+		hierarchy::BuildWorldChildren,
+	};
+
+	#[derive(Component)]
+	struct _Owner;
+
+	fn setup() -> App {
+		let mut app = App::new_single_threaded([Update]);
+		app.add_systems(Update, remove_not_owned::<_Owner>);
+
+		app
+	}
+
+	#[test]
+	fn remove_when_owner_not_found() {
+		let mut app = setup();
+		let owner_without_owner_component = app.world.spawn_empty().id();
+		let owned = app
+			.world
+			.spawn(OwnedBy::<_Owner>::with(owner_without_owner_component))
+			.id();
+
+		app.update();
+
+		assert!(app.world.get_entity(owned).is_none());
+	}
+
+	#[test]
+	fn remove_recursive_when_owner_not_found() {
+		let mut app = setup();
+		let owner_without_owner_component = app.world.spawn_empty().id();
+		let owned = app
+			.world
+			.spawn(OwnedBy::<_Owner>::with(owner_without_owner_component))
+			.id();
+		let child = app.world.spawn_empty().set_parent(owned).id();
+
+		app.update();
+
+		assert!(app.world.get_entity(child).is_none());
+	}
+
+	#[test]
+	fn do_not_remove_when_owner_found() {
+		let mut app = setup();
+		let owner = app.world.spawn(_Owner).id();
+		let owned = app.world.spawn(OwnedBy::<_Owner>::with(owner)).id();
+
+		app.update();
+
+		assert!(app.world.get_entity(owned).is_some());
+	}
+}

--- a/src/plugins/common/src/traits.rs
+++ b/src/plugins/common/src/traits.rs
@@ -5,5 +5,6 @@ pub mod get_state;
 pub mod intersect_at;
 pub mod iteration;
 pub mod load_asset;
+pub mod ownership_relation;
 pub mod remove_conditionally;
 pub mod state_duration;

--- a/src/plugins/common/src/traits/ownership_relation.rs
+++ b/src/plugins/common/src/traits/ownership_relation.rs
@@ -1,0 +1,16 @@
+use crate::systems::remove_not_owned::remove_not_owned;
+use bevy::{
+	app::App,
+	ecs::{component::Component, schedule::ScheduleLabel},
+};
+
+pub trait OwnershipRelation {
+	fn manage_ownership<TOwner: Component>(&mut self, label: impl ScheduleLabel) -> &mut Self;
+}
+
+impl OwnershipRelation for App {
+	fn manage_ownership<TOwner: Component>(&mut self, label: impl ScheduleLabel) -> &mut Self {
+		self.add_systems(label, remove_not_owned::<TOwner>);
+		self
+	}
+}


### PR DESCRIPTION
- spawn void sphere out of screen (which initially caused problems with premature bar removal)
- simplify bar system (and remove bar de-spawn when bar position cannot be determined)
- extract bar removal (when bar entity not found) into a generic ownership concept