### PR TITLE
Simplify Combos

### DIFF
--- a/src/plugins/skills/src/lib.rs
+++ b/src/plugins/skills/src/lib.rs
@@ -49,10 +49,7 @@ use skills::{
 	Queued,
 	Skill,
 };
-use std::{
-	collections::{HashMap, HashSet, VecDeque},
-	time::Duration,
-};
+use std::{collections::HashSet, time::Duration};
 use systems::{
 	advance_active_skill::advance_active_skill,
 	enqueue::enqueue,
@@ -205,26 +202,26 @@ fn get_inventory() -> Inventory {
 }
 
 fn get_combos() -> Combos {
-	let left = (
-		SlotKey::Hand(Side::Off),
+	Combos::new(ComboNode::new([
 		(
-			ForceShieldSkill::skill(),
-			ComboNode::Circle(VecDeque::from([
-				(SlotKey::Hand(Side::Off), GravityWellSkill::skill()),
-				(SlotKey::Hand(Side::Off), ForceShieldSkill::skill()),
-			])),
+			SlotKey::Hand(Side::Off),
+			(
+				ForceShieldSkill::skill(),
+				ComboNode::new([(
+					SlotKey::Hand(Side::Off),
+					(GravityWellSkill::skill(), ComboNode::default()),
+				)]),
+			),
 		),
-	);
-	let right = (
-		SlotKey::Hand(Side::Main),
 		(
-			ForceShieldSkill::skill(),
-			ComboNode::Circle(VecDeque::from([
-				(SlotKey::Hand(Side::Main), GravityWellSkill::skill()),
-				(SlotKey::Hand(Side::Main), ForceShieldSkill::skill()),
-			])),
+			SlotKey::Hand(Side::Main),
+			(
+				ForceShieldSkill::skill(),
+				ComboNode::new([(
+					SlotKey::Hand(Side::Main),
+					(GravityWellSkill::skill(), ComboNode::default()),
+				)]),
+			),
 		),
-	);
-
-	Combos::new(ComboNode::Tree(HashMap::from([left, right])))
+	]))
 }

--- a/src/plugins/skills/src/traits/advance_combo.rs
+++ b/src/plugins/skills/src/traits/advance_combo.rs
@@ -62,16 +62,16 @@ mod tests {
 	}
 
 	fn node() -> ComboNode {
-		ComboNode::Tree(HashMap::from([(
+		ComboNode::new([(
 			SlotKey::Hand(Side::Main),
 			(
 				Skill {
 					name: "some skill",
 					..default()
 				},
-				ComboNode::Tree(HashMap::default()),
+				ComboNode::default(),
 			),
-		)]))
+		)])
 	}
 
 	#[test]

--- a/src/plugins/skills/src/traits/peek_next.rs
+++ b/src/plugins/skills/src/traits/peek_next.rs
@@ -54,16 +54,16 @@ mod tests {
 	}
 
 	fn node() -> ComboNode {
-		ComboNode::Tree(HashMap::from([(
+		ComboNode::new([(
 			SlotKey::Hand(Side::Main),
 			(
 				Skill {
 					name: "some skill",
 					..default()
 				},
-				ComboNode::Tree(HashMap::default()),
+				ComboNode::default(),
 			),
-		)]))
+		)])
 	}
 
 	#[test]


### PR DESCRIPTION
A circling skill combo is not actually needed. Its existence is a relic of the time when dual wield animations depended on combos. Circle would also complicate the building of combos in the planned layout of the user GUI. Therefore the circle variant for skill combos is a hindrance and needs to be removed.