### PR TITLE
Readd libraries to fix fail on main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Install libraries
+      run: |
+        sudo apt update
+        sudo apt install -y librust-alsa-sys-dev libudev-dev
     - name: Rust Toolchain Clippy
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:


### PR DESCRIPTION
Installation of `librust-alsa-sys-dev` and `libudev-dev` was previously removed from linting  job. However, this causes the main branch  to fail (it should not have worked ever  the first place). Re-adding them to fix main  fails.