### PR TITLE
tooltip despawn error fix

### DIFF
--- a/src/plugins/ingame_menu/src/lib.rs
+++ b/src/plugins/ingame_menu/src/lib.rs
@@ -104,7 +104,13 @@ impl AddTooltip for App {
 		T: Sync + Send + 'static,
 		Tooltip<T>: InstantiateContentOn + GetNode,
 	{
-		self.add_systems(Update, tooltip::<T, TooltipUI, TooltipUIControl, Window>)
+		self.add_systems(
+			Update,
+			(
+				tooltip::<T, TooltipUI<T>, TooltipUIControl, Window>,
+				tooltip_visibility::<Real, T>,
+			),
+		)
 	}
 }
 
@@ -139,7 +145,6 @@ impl Plugin for IngameMenuPlugin {
 		ui_overlay_systems(app);
 		combo_overview_systems(app);
 		inventory_screen_systems(app);
-		tooltip_systems(app);
 
 		#[cfg(debug_assertions)]
 		{
@@ -221,8 +226,4 @@ fn inventory_screen_systems(app: &mut App) {
 			Update,
 			(swap_equipped_items.pipe(log_many), swap_inventory_items),
 		);
-}
-
-fn tooltip_systems(app: &mut App) {
-	app.add_systems(Update, tooltip_visibility::<Real>);
 }

--- a/src/plugins/ingame_menu/src/systems/tooltip_visibility.rs
+++ b/src/plugins/ingame_menu/src/systems/tooltip_visibility.rs
@@ -2,8 +2,11 @@ use crate::components::tooltip::TooltipUI;
 use bevy::{ecs::system::Res, prelude::Query, render::view::Visibility, time::Time};
 use std::time::Duration;
 
-pub(crate) fn tooltip_visibility<TTime: Send + Sync + 'static + Default>(
-	mut uis: Query<(&mut TooltipUI, &mut Visibility)>,
+pub(crate) fn tooltip_visibility<
+	TTime: Send + Sync + 'static + Default,
+	T: Send + Sync + 'static,
+>(
+	mut uis: Query<(&mut TooltipUI<T>, &mut Visibility)>,
 	time: Res<Time<TTime>>,
 ) {
 	let delta = time.delta();
@@ -33,7 +36,7 @@ mod tests {
 		let mut app = App::new().single_threaded(Update);
 		app.init_resource::<Time<Real>>();
 		app.tick_time(Duration::ZERO);
-		app.add_systems(Update, tooltip_visibility::<Real>);
+		app.add_systems(Update, tooltip_visibility::<Real, ()>);
 
 		app
 	}
@@ -44,10 +47,7 @@ mod tests {
 		let tooltip_ui = app
 			.world_mut()
 			.spawn((
-				TooltipUI {
-					source: Entity::from_raw(42),
-					delay: Duration::from_millis(100),
-				},
+				TooltipUI::<()>::new(Entity::from_raw(42), Duration::from_millis(100)),
 				Visibility::Hidden,
 			))
 			.id();
@@ -66,10 +66,7 @@ mod tests {
 		let tooltip_ui = app
 			.world_mut()
 			.spawn((
-				TooltipUI {
-					source: Entity::from_raw(42),
-					delay: Duration::from_millis(10),
-				},
+				TooltipUI::<()>::new(Entity::from_raw(42), Duration::from_millis(10)),
 				Visibility::Hidden,
 			))
 			.id();
@@ -88,10 +85,7 @@ mod tests {
 		let tooltip_ui = app
 			.world_mut()
 			.spawn((
-				TooltipUI {
-					source: Entity::from_raw(42),
-					delay: Duration::from_millis(1000),
-				},
+				TooltipUI::<()>::new(Entity::from_raw(42), Duration::from_millis(1000)),
 				Visibility::Hidden,
 			))
 			.id();
@@ -113,10 +107,7 @@ mod tests {
 		let tooltip_ui = app
 			.world_mut()
 			.spawn((
-				TooltipUI {
-					source: Entity::from_raw(42),
-					delay: Duration::from_millis(10),
-				},
+				TooltipUI::<()>::new(Entity::from_raw(42), Duration::from_millis(10)),
 				Visibility::Hidden,
 			))
 			.id();
@@ -127,11 +118,8 @@ mod tests {
 		let tooltip_ui = app.world().entity(tooltip_ui);
 
 		assert_eq!(
-			Some(&TooltipUI {
-				source: Entity::from_raw(42),
-				delay: Duration::ZERO,
-			}),
-			tooltip_ui.get::<TooltipUI>()
+			Some(&TooltipUI::<()>::new(Entity::from_raw(42), Duration::ZERO)),
+			tooltip_ui.get::<TooltipUI<()>>()
 		);
 	}
 }


### PR DESCRIPTION
The tool tip system tried to to despawn entities for each time tool tip type. Fixed by making `TooltipUI` generic with the same type as the tool tip, so each registered tool tip system only deals with its own tool tips.