### PR TITLE
Split projectile spawn and start

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3986,6 +3986,7 @@ dependencies = [
  "bevy",
  "bevy_rapier3d",
  "common",
+ "interactions",
  "macros",
  "mockall",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,6 +358,7 @@ dependencies = [
  "macros",
  "mockall",
  "prefabs",
+ "serde",
  "tracing",
 ]
 

--- a/assets/skills/shoot_hand_gun.skill
+++ b/assets/skills/shoot_hand_gun.skill
@@ -13,7 +13,7 @@
 				"spawn": {
 					"Projectile": {
 						"stoppable": false,
-						"projectile_type": "Plasma"
+						"sub_type": "Plasma"
 					}
 				},
 				"start": []

--- a/assets/skills/shoot_hand_gun.skill
+++ b/assets/skills/shoot_hand_gun.skill
@@ -16,7 +16,13 @@
 						"sub_type": "Plasma"
 					}
 				},
-				"start": []
+				"start": [
+					{
+						"Damage": {
+							"amount": 1
+						}
+					}
+				]
 			},
 			"projection": {
 				"spawn": "Placeholder",

--- a/src/plugins/behaviors/Cargo.toml
+++ b/src/plugins/behaviors/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 [dependencies]
 bevy.workspace = true
 bevy_rapier3d.workspace = true
+serde.workspace = true
 tracing.workspace = true
 animations.workspace = true
 bars.workspace = true

--- a/src/plugins/behaviors/src/components.rs
+++ b/src/plugins/behaviors/src/components.rs
@@ -1,13 +1,14 @@
 pub mod gravity_well;
 pub mod ground_target;
+pub mod projectile;
 
 use crate::traits::{RemoveComponent, SpawnAttack};
 use bevy::{
 	color::{Color, LinearRgba},
 	ecs::{bundle::Bundle, component::Component, entity::Entity, system::EntityCommands},
-	math::{Dir3, Vec3},
+	math::Vec3,
 };
-use common::{test_tools::utils::ApproxEqual, tools::UnitsPerSecond};
+use common::tools::UnitsPerSecond;
 use std::{fmt::Debug, marker::PhantomData, sync::Arc, time::Duration};
 
 #[derive(Component)]
@@ -30,45 +31,6 @@ pub struct OverrideFace(pub Face);
 
 #[derive(Component, Debug, PartialEq)]
 pub struct SetFace(pub Face);
-
-#[derive(Debug, PartialEq)]
-pub struct Plasma;
-
-#[derive(Component, Debug, PartialEq)]
-pub struct Projectile<T> {
-	pub direction: Dir3,
-	pub range: f32,
-	phantom_data: PhantomData<T>,
-}
-
-impl<T> Default for Projectile<T> {
-	fn default() -> Self {
-		Self {
-			direction: Dir3::NEG_Z,
-			range: Default::default(),
-			phantom_data: Default::default(),
-		}
-	}
-}
-
-impl<T> ApproxEqual<f32> for Projectile<T> {
-	fn approx_equal(&self, other: &Self, tolerance: &f32) -> bool {
-		self.direction
-			.as_vec3()
-			.approx_equal(&other.direction.as_vec3(), tolerance)
-			&& self.range == other.range
-	}
-}
-
-impl<T> Projectile<T> {
-	pub fn new(direction: Dir3, range: f32) -> Self {
-		Self {
-			direction,
-			range,
-			phantom_data: PhantomData,
-		}
-	}
-}
 
 #[derive(Component, Debug, PartialEq)]
 pub struct ForceShield {

--- a/src/plugins/behaviors/src/components/projectile.rs
+++ b/src/plugins/behaviors/src/components/projectile.rs
@@ -17,7 +17,7 @@ use common::{
 	tools::UnitsPerSecond,
 	traits::clamp_zero_positive::ClampZeroPositive,
 };
-use interactions::components::{DealsDamage, Fragile};
+use interactions::components::Fragile;
 use prefabs::traits::{GetOrCreateAssets, Instantiate};
 use sub_type::SubType;
 
@@ -66,7 +66,6 @@ impl Instantiate for Projectile {
 	) -> Result<(), Error> {
 		on.try_insert((
 			RigidBody::Fixed,
-			DealsDamage(1),
 			Fragile,
 			MovementConfig::Constant {
 				mode: MovementMode::Fast,

--- a/src/plugins/behaviors/src/components/projectile.rs
+++ b/src/plugins/behaviors/src/components/projectile.rs
@@ -1,71 +1,54 @@
+pub mod sub_type;
+
 use super::{MovementConfig, MovementMode};
 use crate::traits::ProjectileBehavior;
 use bevy::{
 	self,
-	color::Color,
 	ecs::system::EntityCommands,
 	hierarchy::BuildChildren,
-	math::{Dir3, Vec3},
-	pbr::{PbrBundle, PointLight, PointLightBundle, StandardMaterial},
-	prelude::{Component, Transform},
+	math::Dir3,
+	prelude::Component,
 	utils::default,
 };
-use bevy_rapier3d::{
-	geometry::{Collider, Sensor},
-	prelude::RigidBody,
-};
+use bevy_rapier3d::prelude::RigidBody;
 use common::{
-	bundles::ColliderTransformBundle,
-	components::ColliderRoot,
 	errors::Error,
 	test_tools::utils::ApproxEqual,
 	tools::UnitsPerSecond,
-	traits::{cache::GetOrCreateTypeAsset, clamp_zero_positive::ClampZeroPositive},
+	traits::clamp_zero_positive::ClampZeroPositive,
 };
 use interactions::components::{DealsDamage, Fragile};
-use prefabs::traits::{sphere, GetOrCreateAssets, Instantiate};
-use std::marker::PhantomData;
-
-#[derive(Debug, PartialEq)]
-pub struct Plasma;
+use prefabs::traits::{GetOrCreateAssets, Instantiate};
+use sub_type::SubType;
 
 #[derive(Component, Debug, PartialEq)]
-pub struct Projectile<T> {
+pub struct Projectile {
 	pub direction: Dir3,
 	pub range: f32,
-	phantom_data: PhantomData<T>,
+	pub sub_type: SubType,
 }
 
-impl<T> Default for Projectile<T> {
+impl Default for Projectile {
 	fn default() -> Self {
 		Self {
 			direction: Dir3::NEG_Z,
-			range: Default::default(),
-			phantom_data: Default::default(),
+			range: default(),
+			sub_type: default(),
 		}
 	}
 }
 
-impl<T> ApproxEqual<f32> for Projectile<T> {
+impl ApproxEqual<f32> for Projectile {
 	fn approx_equal(&self, other: &Self, tolerance: &f32) -> bool {
 		self.direction
 			.as_vec3()
 			.approx_equal(&other.direction.as_vec3(), tolerance)
 			&& self.range == other.range
+			&& self.sub_type == other.sub_type
 	}
 }
 
-impl<T> Projectile<T> {
-	pub fn new(direction: Dir3, range: f32) -> Self {
-		Self {
-			direction,
-			range,
-			phantom_data: PhantomData,
-		}
-	}
-}
-
-impl<T> ProjectileBehavior for Projectile<T> {
+impl ProjectileBehavior for Projectile {
 	fn direction(&self) -> Dir3 {
 		self.direction
 	}
@@ -75,22 +58,12 @@ impl<T> ProjectileBehavior for Projectile<T> {
 	}
 }
 
-const PLASMA_RADIUS: f32 = 0.05;
-
-impl Instantiate for Projectile<Plasma> {
+impl Instantiate for Projectile {
 	fn instantiate(
 		&self,
 		on: &mut EntityCommands,
 		mut assets: impl GetOrCreateAssets,
 	) -> Result<(), Error> {
-		let transform = Transform::from_translation(Vec3::ZERO);
-		let color = Color::srgb(0., 1., 1.);
-		let mesh = assets.get_or_create_for::<Projectile<Plasma>>(|| sphere(PLASMA_RADIUS));
-		let material = assets.get_or_create_for::<Projectile<Plasma>>(|| StandardMaterial {
-			emissive: color.to_linear() * 2300.0,
-			..default()
-		});
-
 		on.try_insert((
 			RigidBody::Fixed,
 			DealsDamage(1),
@@ -100,31 +73,7 @@ impl Instantiate for Projectile<Plasma> {
 				speed: UnitsPerSecond::new(15.),
 			},
 		))
-		.with_children(|parent| {
-			parent.spawn(PbrBundle {
-				transform,
-				mesh,
-				material,
-				..default()
-			});
-			parent.spawn((
-				ColliderTransformBundle::new_static_collider(
-					transform,
-					Collider::ball(PLASMA_RADIUS),
-				),
-				Sensor,
-				ColliderRoot(parent.parent_entity()),
-			));
-			parent.spawn(PointLightBundle {
-				point_light: PointLight {
-					color,
-					intensity: 8000.,
-					shadows_enabled: true,
-					..default()
-				},
-				..default()
-			});
-		});
+		.with_children(|parent| self.sub_type.spawn(parent, &mut assets));
 
 		Ok(())
 	}

--- a/src/plugins/behaviors/src/components/projectile/sub_type.rs
+++ b/src/plugins/behaviors/src/components/projectile/sub_type.rs
@@ -1,0 +1,22 @@
+mod plasma_projectile;
+mod traits;
+
+use bevy::prelude::ChildBuilder;
+use plasma_projectile::PlasmaProjectile;
+use prefabs::traits::GetOrCreateAssets;
+use serde::{Deserialize, Serialize};
+use traits::Spawn;
+
+#[derive(Debug, PartialEq, Default, Clone, Copy, Serialize, Deserialize)]
+pub enum SubType {
+	#[default]
+	Plasma,
+}
+
+impl SubType {
+	pub fn spawn(&self, parent: &mut ChildBuilder, assets: &mut impl GetOrCreateAssets) {
+		match self {
+			SubType::Plasma => PlasmaProjectile::spawn(parent, assets),
+		};
+	}
+}

--- a/src/plugins/behaviors/src/components/projectile/sub_type/plasma_projectile.rs
+++ b/src/plugins/behaviors/src/components/projectile/sub_type/plasma_projectile.rs
@@ -1,0 +1,22 @@
+use super::traits::ProjectileTypeParameters;
+use bevy::color::Color;
+use common::{
+	tools::{Intensity, Units},
+	traits::clamp_zero_positive::ClampZeroPositive,
+};
+
+pub(super) struct PlasmaProjectile;
+
+impl ProjectileTypeParameters for PlasmaProjectile {
+	fn radius() -> Units {
+		Units::new(0.05)
+	}
+
+	fn base_color() -> Color {
+		Color::WHITE
+	}
+
+	fn emissive() -> (Color, Intensity) {
+		(Color::srgb(0., 1., 1.), Intensity::new(2300.0))
+	}
+}

--- a/src/plugins/behaviors/src/components/projectile/sub_type/traits.rs
+++ b/src/plugins/behaviors/src/components/projectile/sub_type/traits.rs
@@ -1,0 +1,60 @@
+use bevy::{
+	color::Color,
+	math::Vec3,
+	pbr::{PbrBundle, PointLight, PointLightBundle, StandardMaterial},
+	prelude::{default, ChildBuilder, Transform},
+};
+use bevy_rapier3d::prelude::{Collider, Sensor};
+use common::{
+	bundles::ColliderTransformBundle,
+	components::ColliderRoot,
+	tools::{Intensity, Units},
+	traits::cache::GetOrCreateTypeAsset,
+};
+use prefabs::traits::{sphere, GetOrCreateAssets};
+
+pub(super) trait ProjectileTypeParameters {
+	fn radius() -> Units;
+	fn base_color() -> Color;
+	fn emissive() -> (Color, Intensity);
+}
+
+pub(super) trait Spawn {
+	fn spawn(parent: &mut ChildBuilder, assets: &mut impl GetOrCreateAssets);
+}
+
+impl<T: ProjectileTypeParameters + 'static> Spawn for T {
+	fn spawn(parent: &mut ChildBuilder, assets: &mut impl GetOrCreateAssets) {
+		let transform = Transform::from_translation(Vec3::ZERO);
+		let radius = *T::radius();
+		let (emissive_color, emissive_intensity) = T::emissive();
+
+		let mesh = assets.get_or_create_for::<T>(|| sphere(radius));
+		let material = assets.get_or_create_for::<T>(|| StandardMaterial {
+			emissive: emissive_color.to_linear() * *emissive_intensity,
+			base_color: T::base_color(),
+			..default()
+		});
+
+		parent.spawn(PbrBundle {
+			mesh,
+			material,
+			transform,
+			..default()
+		});
+		parent.spawn((
+			ColliderTransformBundle::new_static_collider(transform, Collider::ball(radius)),
+			Sensor,
+			ColliderRoot(parent.parent_entity()),
+		));
+		parent.spawn(PointLightBundle {
+			point_light: PointLight {
+				color: emissive_color,
+				intensity: 8000.,
+				shadows_enabled: true,
+				..default()
+			},
+			..default()
+		});
+	}
+}

--- a/src/plugins/behaviors/src/lib.rs
+++ b/src/plugins/behaviors/src/lib.rs
@@ -23,14 +23,13 @@ use common::{
 use components::{
 	gravity_well::GravityWell,
 	ground_target::GroundTarget,
+	projectile::{Plasma, Projectile},
 	Beam,
 	CamOrbit,
 	ForceShield,
 	Movement,
 	MovementConfig,
-	Plasma,
 	PositionBased,
-	Projectile,
 	VelocityBased,
 	VoidSphere,
 };

--- a/src/plugins/behaviors/src/lib.rs
+++ b/src/plugins/behaviors/src/lib.rs
@@ -23,7 +23,7 @@ use common::{
 use components::{
 	gravity_well::GravityWell,
 	ground_target::GroundTarget,
-	projectile::{Plasma, Projectile},
+	projectile::Projectile,
 	Beam,
 	CamOrbit,
 	ForceShield,
@@ -63,7 +63,7 @@ pub struct BehaviorsPlugin;
 impl Plugin for BehaviorsPlugin {
 	fn build(&self, app: &mut App) {
 		app.add_event::<MoveInputEvent>()
-			.register_prefab::<Projectile<Plasma>>()
+			.register_prefab::<Projectile>()
 			.register_prefab::<VoidSphere>()
 			.register_prefab::<Beam>()
 			.register_prefab::<ForceShield>()
@@ -115,7 +115,7 @@ impl Plugin for BehaviorsPlugin {
 					>,
 				),
 			)
-			.add_systems(Update, projectile_behavior::<Projectile<Plasma>>)
+			.add_systems(Update, projectile_behavior::<Projectile>)
 			.add_systems(Update, (enemy, chase::<MovementConfig>, attack).chain())
 			.add_systems(Update, execute_beam)
 			.add_systems(Update, position_force_shield)

--- a/src/plugins/behaviors/src/traits.rs
+++ b/src/plugins/behaviors/src/traits.rs
@@ -5,7 +5,6 @@ pub(crate) mod cam_orbit;
 pub(crate) mod force_shield;
 pub(crate) mod movement;
 pub(crate) mod movement_config;
-pub(crate) mod projectile;
 pub(crate) mod void_sphere;
 
 use crate::components::{Attacker, MovementMode, Target};

--- a/src/plugins/interactions/src/components.rs
+++ b/src/plugins/interactions/src/components.rs
@@ -95,7 +95,7 @@ impl Destroy {
 #[derive(Component)]
 pub struct Fragile;
 
-#[derive(Component, Clone)]
+#[derive(Component, Clone, Debug, PartialEq)]
 pub struct DealsDamage(pub i16);
 
 #[derive(Component, Debug, PartialEq)]

--- a/src/plugins/skills/Cargo.toml
+++ b/src/plugins/skills/Cargo.toml
@@ -8,11 +8,12 @@ bevy.workspace = true
 bevy_rapier3d.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+tracing.workspace = true
 uuid.workspace = true
 animations.workspace = true
 behaviors.workspace = true
-tracing.workspace = true
 common.workspace = true
+interactions.workspace = true
 
 [dev-dependencies]
 mockall.workspace = true

--- a/src/plugins/skills/src/behaviors/spawn_behavior/spawn_projectile.rs
+++ b/src/plugins/skills/src/behaviors/spawn_behavior/spawn_projectile.rs
@@ -1,6 +1,6 @@
 use super::OnSkillStop;
 use crate::behaviors::{SkillCaster, SkillSpawner, Target};
-use behaviors::components::{Plasma, Projectile};
+use behaviors::components::projectile::{Plasma, Projectile};
 use bevy::{
 	ecs::system::EntityCommands,
 	prelude::{Commands, SpatialBundle, Transform},
@@ -50,7 +50,6 @@ impl SpawnProjectile {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use behaviors::components::{Plasma, Projectile};
 	use bevy::{
 		app::{App, Update},
 		ecs::system::RunSystemOnce,

--- a/src/plugins/skills/src/behaviors/spawn_behavior/spawn_projectile.rs
+++ b/src/plugins/skills/src/behaviors/spawn_behavior/spawn_projectile.rs
@@ -1,6 +1,6 @@
 use super::OnSkillStop;
 use crate::behaviors::{SkillCaster, SkillSpawner, Target};
-use behaviors::components::projectile::{Plasma, Projectile};
+use behaviors::components::projectile::{sub_type::SubType, Projectile};
 use bevy::{
 	ecs::system::EntityCommands,
 	prelude::{Commands, SpatialBundle, Transform},
@@ -10,12 +10,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct SpawnProjectile {
 	stoppable: bool,
-	projectile_type: ProjectileType,
-}
-
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-pub enum ProjectileType {
-	Plasma,
+	sub_type: SubType,
 }
 
 impl SpawnProjectile {
@@ -29,12 +24,12 @@ impl SpawnProjectile {
 		let SkillCaster(.., caster) = caster;
 		let SkillSpawner(.., spawner) = spawner;
 
-		let projectile = match self.projectile_type {
-			ProjectileType::Plasma => Projectile::<Plasma>::new(caster.forward(), 10.),
-		};
-
 		let entity = commands.spawn((
-			projectile,
+			Projectile {
+				direction: caster.forward(),
+				range: 10.,
+				sub_type: self.sub_type,
+			},
 			SpatialBundle::from_transform(Transform::from(*spawner)),
 		));
 
@@ -82,7 +77,7 @@ mod tests {
 		let (entity, ..) = app.world_mut().run_system_once(projectile(
 			SpawnProjectile {
 				stoppable: true,
-				projectile_type: ProjectileType::Plasma,
+				sub_type: SubType::Plasma,
 			},
 			SkillCaster::from(Entity::from_raw(42)),
 			SkillSpawner::from(Entity::from_raw(43)).with_transform(spawner_transform),
@@ -106,20 +101,24 @@ mod tests {
 		let (entity, ..) = app.world_mut().run_system_once(projectile(
 			SpawnProjectile {
 				stoppable: true,
-				projectile_type: ProjectileType::Plasma,
+				sub_type: SubType::Plasma,
 			},
 			SkillCaster::from(Entity::from_raw(42)).with_transform(caster_transform),
 			SkillSpawner::from(Entity::from_raw(43)),
 			Target::default(),
 		));
 
-		let projectile = app
-			.world()
-			.entity(entity)
-			.get::<Projectile<Plasma>>()
-			.unwrap();
+		let projectile = app.world().entity(entity).get::<Projectile>().unwrap();
 
-		assert_eq_approx!(Projectile::new(caster_forward, 10.), projectile, 0.001);
+		assert_eq_approx!(
+			Projectile {
+				direction: caster_forward,
+				range: 10.,
+				sub_type: SubType::Plasma
+			},
+			projectile,
+			0.001
+		);
 	}
 
 	#[test]
@@ -129,7 +128,7 @@ mod tests {
 		let (entity, on_skill_stop) = app.world_mut().run_system_once(projectile(
 			SpawnProjectile {
 				stoppable: true,
-				projectile_type: ProjectileType::Plasma,
+				sub_type: SubType::Plasma,
 			},
 			SkillCaster::from(Entity::from_raw(42)),
 			SkillSpawner::from(Entity::from_raw(43)),
@@ -146,7 +145,7 @@ mod tests {
 		let (.., on_skill_stop) = app.world_mut().run_system_once(projectile(
 			SpawnProjectile {
 				stoppable: false,
-				projectile_type: ProjectileType::Plasma,
+				sub_type: SubType::Plasma,
 			},
 			SkillCaster::from(Entity::from_raw(42)),
 			SkillSpawner::from(Entity::from_raw(43)),

--- a/src/plugins/skills/src/behaviors/start_behavior.rs
+++ b/src/plugins/skills/src/behaviors/start_behavior.rs
@@ -1,7 +1,9 @@
+pub mod start_deal_damage;
 pub mod start_gravity;
 
 use super::{SkillCaster, SkillSpawner, Target};
 use bevy::ecs::system::EntityCommands;
+use start_deal_damage::StartDealingDamage;
 use start_gravity::StartGravity;
 
 pub type StartBehaviorFn = fn(&mut EntityCommands, &SkillCaster, &SkillSpawner, &Target);
@@ -10,6 +12,7 @@ pub type StartBehaviorFn = fn(&mut EntityCommands, &SkillCaster, &SkillSpawner, 
 pub enum StartBehavior {
 	Fn(StartBehaviorFn),
 	Gravity(StartGravity),
+	Damage(StartDealingDamage),
 }
 
 impl StartBehavior {
@@ -23,6 +26,7 @@ impl StartBehavior {
 		match self {
 			StartBehavior::Fn(func) => func(entity, caster, spawn, target),
 			StartBehavior::Gravity(gr) => gr.apply(entity, caster, spawn, target),
+			StartBehavior::Damage(dm) => dm.apply(entity, caster, spawn, target),
 		}
 	}
 }

--- a/src/plugins/skills/src/behaviors/start_behavior/start_deal_damage.rs
+++ b/src/plugins/skills/src/behaviors/start_behavior/start_deal_damage.rs
@@ -1,0 +1,65 @@
+use crate::behaviors::{SkillCaster, SkillSpawner, Target};
+use bevy::ecs::system::EntityCommands;
+use interactions::components::DealsDamage;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+pub struct StartDealingDamage {
+	amount: i16,
+}
+
+impl StartDealingDamage {
+	pub fn apply(
+		&self,
+		entity: &mut EntityCommands,
+		_: &SkillCaster,
+		_: &SkillSpawner,
+		_: &Target,
+	) {
+		entity.insert(DealsDamage(self.amount));
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use bevy::{
+		app::{App, Update},
+		ecs::system::RunSystemOnce,
+		prelude::{Commands, Entity},
+	};
+	use common::test_tools::utils::SingleThreadedApp;
+	use interactions::components::DealsDamage;
+
+	fn damage(damage: StartDealingDamage) -> impl Fn(Commands) -> Entity {
+		move |mut commands| {
+			let mut entity = commands.spawn_empty();
+			damage.apply(
+				&mut entity,
+				&SkillCaster::from(Entity::from_raw(42)),
+				&SkillSpawner::from(Entity::from_raw(43)),
+				&Target::default(),
+			);
+			entity.id()
+		}
+	}
+
+	fn setup() -> App {
+		App::new().single_threaded(Update)
+	}
+
+	#[test]
+	fn insert_deals_damage() {
+		let mut app = setup();
+
+		let start_dealing_damage = StartDealingDamage { amount: 42 };
+		let entity = app
+			.world_mut()
+			.run_system_once(damage(start_dealing_damage));
+
+		assert_eq!(
+			Some(&DealsDamage(42)),
+			app.world().entity(entity).get::<DealsDamage>()
+		);
+	}
+}

--- a/src/plugins/skills/src/skills/skill_data/skill_behavior_data/start_behavior_data.rs
+++ b/src/plugins/skills/src/skills/skill_data/skill_behavior_data/start_behavior_data.rs
@@ -1,15 +1,21 @@
-use crate::behaviors::start_behavior::{start_gravity::StartGravity, StartBehavior};
+use crate::behaviors::start_behavior::{
+	start_deal_damage::StartDealingDamage,
+	start_gravity::StartGravity,
+	StartBehavior,
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub(crate) enum StartBehaviorData {
 	Gravity(StartGravity),
+	Damage(StartDealingDamage),
 }
 
 impl From<StartBehaviorData> for StartBehavior {
 	fn from(value: StartBehaviorData) -> Self {
 		match value {
 			StartBehaviorData::Gravity(v) => Self::Gravity(v),
+			StartBehaviorData::Damage(v) => Self::Damage(v),
 		}
 	}
 }


### PR DESCRIPTION
As part of #199, we split `Projectile` damage as a start behavior component from the spawn behavior. Also reworked `Projectile` instantiation a bit.

closes #201 