### PR TITLE
Consistent skill lifetime

### DIFF
--- a/src/plugins/skills/src/behaviors.rs
+++ b/src/plugins/skills/src/behaviors.rs
@@ -1,7 +1,10 @@
 pub mod build_skill_shape;
 pub mod start_behavior;
 
-use crate::{skills::SelectInfo, traits::skill_builder::SkillShape};
+use crate::{
+	skills::SelectInfo,
+	traits::skill_builder::{LifeTimeDefinition, SkillShape},
+};
 use bevy::{
 	ecs::system::EntityCommands,
 	math::Ray3d,
@@ -69,14 +72,18 @@ impl Target {
 }
 
 #[derive(PartialEq, Debug, Clone)]
-pub struct SkillBehaviorConfig {
-	shape: BuildSkillShape,
+pub struct SkillBehaviorConfig<T> {
+	shape: BuildSkillShape<T>,
 	contact: Vec<SkillBehavior>,
 	projection: Vec<SkillBehavior>,
 }
 
-impl SkillBehaviorConfig {
-	pub(crate) fn from_shape(shape: BuildSkillShape) -> Self {
+impl<T> SkillBehaviorConfig<T>
+where
+	LifeTimeDefinition: From<T>,
+	T: Clone,
+{
+	pub(crate) fn from_shape(shape: BuildSkillShape<T>) -> Self {
 		Self {
 			shape,
 			contact: vec![],

--- a/src/plugins/skills/src/behaviors/build_skill_shape.rs
+++ b/src/plugins/skills/src/behaviors/build_skill_shape.rs
@@ -3,7 +3,7 @@ pub mod spawn_projectile;
 pub mod spawn_shield;
 
 use super::{SkillCaster, SkillSpawner, Target};
-use crate::traits::skill_builder::{SkillBuilder, SkillShape};
+use crate::traits::skill_builder::{LifeTimeDefinition, SkillBuilder, SkillShape};
 use bevy::prelude::{BuildChildren, Commands, Entity};
 use spawn_ground_target::SpawnGroundTargetedAoe;
 use spawn_projectile::SpawnProjectile;
@@ -19,14 +19,14 @@ pub enum OnSkillStop {
 }
 
 #[derive(PartialEq, Debug, Clone)]
-pub(crate) enum BuildSkillShape {
+pub(crate) enum BuildSkillShape<T> {
 	Fn(BuildSkillShapeFn),
-	GroundTargetedAoe(SpawnGroundTargetedAoe),
+	GroundTargetedAoe(SpawnGroundTargetedAoe<T>),
 	Projectile(SpawnProjectile),
 	Shield(SpawnShield),
 }
 
-impl Default for BuildSkillShape {
+impl<T> Default for BuildSkillShape<T> {
 	fn default() -> Self {
 		Self::Fn(|commands, _, _, _| {
 			let contact = commands.spawn_empty().id();
@@ -40,8 +40,12 @@ impl Default for BuildSkillShape {
 	}
 }
 
-impl BuildSkillShape {
-	pub(crate) const NO_SHAPE: BuildSkillShape = BuildSkillShape::Fn(Self::no_shape);
+impl<TLifeTime> BuildSkillShape<TLifeTime>
+where
+	LifeTimeDefinition: From<TLifeTime>,
+	TLifeTime: Clone,
+{
+	pub(crate) const NO_SHAPE: BuildSkillShape<TLifeTime> = BuildSkillShape::Fn(Self::no_shape);
 
 	fn no_shape(
 		commands: &mut Commands,

--- a/src/plugins/skills/src/behaviors/build_skill_shape/spawn_ground_target.rs
+++ b/src/plugins/skills/src/behaviors/build_skill_shape/spawn_ground_target.rs
@@ -11,13 +11,13 @@ use common::tools::Units;
 use serde::{Deserialize, Serialize};
 
 #[derive(Default, Debug, PartialEq, Clone, Serialize, Deserialize)]
-pub struct SpawnGroundTargetedAoe {
-	pub lifetime: LifeTimeDefinition,
+pub struct SpawnGroundTargetedAoe<TLifeTime> {
+	pub lifetime: TLifeTime,
 	pub max_range: Units,
 	pub radius: Units,
 }
 
-impl BuildContact for SpawnGroundTargetedAoe {
+impl<T> BuildContact for SpawnGroundTargetedAoe<T> {
 	fn build_contact(
 		&self,
 		caster: &SkillCaster,
@@ -36,7 +36,7 @@ impl BuildContact for SpawnGroundTargetedAoe {
 	}
 }
 
-impl BuildProjection for SpawnGroundTargetedAoe {
+impl<T> BuildProjection for SpawnGroundTargetedAoe<T> {
 	fn build_projection(&self, _: &SkillCaster, _: &SkillSpawner, _: &Target) -> impl Bundle {
 		GroundTargetedAoeProjection {
 			radius: self.radius,
@@ -44,8 +44,12 @@ impl BuildProjection for SpawnGroundTargetedAoe {
 	}
 }
 
-impl SkillLifetime for SpawnGroundTargetedAoe {
+impl<T> SkillLifetime for SpawnGroundTargetedAoe<T>
+where
+	LifeTimeDefinition: From<T>,
+	T: Clone,
+{
 	fn lifetime(&self) -> LifeTimeDefinition {
-		self.lifetime
+		LifeTimeDefinition::from(self.lifetime.clone())
 	}
 }

--- a/src/plugins/skills/src/skills.rs
+++ b/src/plugins/skills/src/skills.rs
@@ -14,6 +14,7 @@ use bevy::{
 	reflect::TypePath,
 };
 use common::resources::ColliderInfo;
+use skill_data::skill_behavior_data::{OnActiveLifetime, OnAimLifeTime};
 use std::{
 	collections::HashSet,
 	fmt::{Display, Formatter, Result},
@@ -142,8 +143,8 @@ pub(crate) enum SkillState {
 
 #[derive(PartialEq, Debug, Clone)]
 pub enum RunSkillBehavior {
-	OnActive(SkillBehaviorConfig),
-	OnAim(SkillBehaviorConfig),
+	OnActive(SkillBehaviorConfig<OnActiveLifetime>),
+	OnAim(SkillBehaviorConfig<OnAimLifeTime>),
 }
 
 impl Default for RunSkillBehavior {

--- a/src/plugins/skills/src/skills/skill_data/skill_behavior_data/shape_data.rs
+++ b/src/plugins/skills/src/skills/skill_data/skill_behavior_data/shape_data.rs
@@ -7,14 +7,14 @@ use crate::behaviors::build_skill_shape::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]
-pub(crate) enum SkillShapeData {
-	GroundTargetedAoe(SpawnGroundTargetedAoe),
+pub(crate) enum SkillShapeData<T> {
+	GroundTargetedAoe(SpawnGroundTargetedAoe<T>),
 	Projectile(SpawnProjectile),
 	Shield(SpawnShield),
 }
 
-impl From<SkillShapeData> for BuildSkillShape {
-	fn from(value: SkillShapeData) -> Self {
+impl<TLifeTime> From<SkillShapeData<TLifeTime>> for BuildSkillShape<TLifeTime> {
+	fn from(value: SkillShapeData<TLifeTime>) -> Self {
 		match value {
 			SkillShapeData::GroundTargetedAoe(v) => Self::GroundTargetedAoe(v),
 			SkillShapeData::Projectile(v) => Self::Projectile(v),

--- a/src/plugins/skills/src/traits.rs
+++ b/src/plugins/skills/src/traits.rs
@@ -9,7 +9,7 @@ pub(crate) mod state;
 pub(crate) mod swap_commands;
 
 use crate::{
-	behaviors::{SkillBehaviorConfig, SkillCaster, SkillSpawner, Target},
+	behaviors::{SkillCaster, SkillSpawner, Target},
 	components::slots::Slots,
 	items::slot_key::SlotKey,
 	skills::{Animate, RunSkillBehavior, Skill, SkillAnimation},
@@ -130,7 +130,7 @@ pub trait InputState<TMap: TryMapBackwards<TKey, SlotKey>, TKey: Eq + Hash> {
 }
 
 pub trait Schedule {
-	fn schedule(&mut self, shape: SkillBehaviorConfig);
+	fn schedule(&mut self, shape: RunSkillBehavior);
 }
 
 pub trait Execute {


### PR DESCRIPTION
Disallows invalid combinations of activation type and lifetime, for instance `RunSkillBehavior::OnActive` and `LifetimeDefinition::UntilStopped`. Both trigger on key release, so it makes no sense to combine them.