### PR TITLE
Reduce mut derefs in skills

### DIFF
--- a/src/plugins/common/src/test_tools.rs
+++ b/src/plugins/common/src/test_tools.rs
@@ -24,6 +24,7 @@ pub mod utils {
 	};
 	use std::{
 		any::{type_name, Any, TypeId},
+		marker::PhantomData,
 		time::Duration,
 	};
 	use uuid::Uuid;
@@ -281,5 +282,26 @@ pub mod utils {
 		Handle::Weak(AssetId::Uuid {
 			uuid: Uuid::new_v4(),
 		})
+	}
+
+	#[derive(Component, Debug, PartialEq)]
+	pub struct Changed<T: Component> {
+		pub changed: bool,
+		phantom_date: PhantomData<T>,
+	}
+
+	impl<T: Component> Changed<T> {
+		pub fn new(changed: bool) -> Self {
+			Self {
+				changed,
+				phantom_date: PhantomData,
+			}
+		}
+
+		pub fn detect(mut query: Query<(Ref<T>, &mut Changed<T>)>) {
+			for (component, mut changed) in &mut query {
+				changed.changed = component.is_changed();
+			}
+		}
 	}
 }

--- a/src/plugins/skills/src/traits.rs
+++ b/src/plugins/skills/src/traits.rs
@@ -37,6 +37,7 @@ pub(crate) trait IterMut<TItem> {
 }
 
 pub(crate) trait IterAddedMut<TItem> {
+	fn added_none(&self) -> bool;
 	fn iter_added_mut<'a>(&'a mut self) -> impl DoubleEndedIterator<Item = &'a mut TItem>
 	where
 		TItem: 'a;


### PR DESCRIPTION
Reduce mutable access to some key components in the skills plugin. This aims to:
- elevate logical performance concerns
- avoid updating animation dispatch each frame -> closes #246 
