### PR TITLE
pass component to trackers

### DIFF
--- a/src/plugins/animations/src/components/animation_dispatch.rs
+++ b/src/plugins/animations/src/components/animation_dispatch.rs
@@ -61,7 +61,7 @@ impl<TAnimation> Default for AnimationDispatch<TAnimation> {
 }
 
 impl Track<AnimationPlayer> for AnimationDispatch {
-	fn track(&mut self, entity: Entity) {
+	fn track(&mut self, entity: Entity, _: &AnimationPlayer) {
 		self.animation_players.insert(entity);
 	}
 }
@@ -79,7 +79,7 @@ impl Untrack<AnimationPlayer> for AnimationDispatch {
 }
 
 impl Track<AnimationTransitions> for AnimationDispatch {
-	fn track(&mut self, entity: Entity) {
+	fn track(&mut self, entity: Entity, _: &AnimationTransitions) {
 		self.animation_transitions.insert(entity);
 	}
 }
@@ -305,8 +305,10 @@ mod tests {
 	#[test]
 	fn track_animation_player() {
 		let dispatch = &mut AnimationDispatch::default();
-		as_track::<AnimationPlayer>(dispatch).track(Entity::from_raw(1));
-		as_track::<AnimationPlayer>(dispatch).track(Entity::from_raw(2));
+		as_track::<AnimationPlayer>(dispatch)
+			.track(Entity::from_raw(1), &AnimationPlayer::default());
+		as_track::<AnimationPlayer>(dispatch)
+			.track(Entity::from_raw(2), &AnimationPlayer::default());
 
 		assert_eq!(
 			HashSet::from([Entity::from_raw(1), Entity::from_raw(2)]),
@@ -347,8 +349,10 @@ mod tests {
 	#[test]
 	fn track_animation_transition() {
 		let dispatch = &mut AnimationDispatch::default();
-		as_track::<AnimationTransitions>(dispatch).track(Entity::from_raw(1));
-		as_track::<AnimationTransitions>(dispatch).track(Entity::from_raw(2));
+		as_track::<AnimationTransitions>(dispatch)
+			.track(Entity::from_raw(1), &AnimationTransitions::default());
+		as_track::<AnimationTransitions>(dispatch)
+			.track(Entity::from_raw(2), &AnimationTransitions::default());
 
 		assert_eq!(
 			HashSet::from([Entity::from_raw(1), Entity::from_raw(2)]),

--- a/src/plugins/common/src/traits/track.rs
+++ b/src/plugins/common/src/traits/track.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::Entity;
 
 pub trait Track<TComponent> {
-	fn track(&mut self, entity: Entity);
+	fn track(&mut self, entity: Entity, component: &TComponent);
 }
 
 pub trait IsTracking<TComponent> {

--- a/src/plugins/shaders/src/components/effect_shader.rs
+++ b/src/plugins/shaders/src/components/effect_shader.rs
@@ -19,7 +19,7 @@ pub struct EffectShaders {
 }
 
 impl Track<Handle<Mesh>> for EffectShaders {
-	fn track(&mut self, entity: Entity) {
+	fn track(&mut self, entity: Entity, _: &Handle<Mesh>) {
 		self.meshes.insert(entity);
 	}
 }
@@ -100,7 +100,7 @@ mod tests {
 		let mut shader = EffectShaders::default();
 		let entity = Entity::from_raw(42);
 
-		shader.track(entity);
+		shader.track(entity, &new_handle());
 
 		assert_eq!(HashSet::from([entity]), shader.meshes);
 	}
@@ -111,7 +111,7 @@ mod tests {
 		let entities = [Entity::from_raw(11), Entity::from_raw(66)];
 
 		for entity in &entities {
-			shader.track(*entity);
+			shader.track(*entity, &new_handle());
 		}
 
 		assert_eq!(HashSet::from(entities), shader.meshes);


### PR DESCRIPTION
This allows tracker to decide, weather they do want to track the component's entity or not.