### PR TITLE
derive used render method for item from `Renderer` struct alone

### DIFF
--- a/src/plugins/skills/src/components/renderer.rs
+++ b/src/plugins/skills/src/components/renderer.rs
@@ -7,8 +7,16 @@ use shaders::materials::essence_material::EssenceMaterial;
 
 #[derive(Debug, PartialEq, Default, Clone)]
 pub struct Renderer {
-	pub model: AssetModel,
+	pub model: ModelRender,
 	pub essence: EssenceRender,
+}
+
+#[derive(Debug, PartialEq, Default, Clone)]
+pub enum ModelRender {
+	#[default]
+	None,
+	Hand(AssetModel),
+	Forearm(AssetModel),
 }
 
 #[derive(Component, Debug, PartialEq, Clone, Default)]

--- a/src/plugins/skills/src/item.rs
+++ b/src/plugins/skills/src/item.rs
@@ -1,7 +1,7 @@
 pub mod item_type;
 
 use crate::{
-	components::renderer::{EssenceRender, Renderer},
+	components::renderer::{EssenceRender, ModelRender, Renderer},
 	definitions::{
 		item_slots::{ForearmSlots, HandSlots},
 		sub_models::SubModels,
@@ -23,37 +23,29 @@ pub struct SkillItemContent<TSkill = Skill> {
 
 impl<TAgent> UsesView<HandSlots<TAgent>> for SkillItemContent {
 	fn uses_view(&self) -> bool {
-		match self.item_type {
-			SkillItemType::Pistol => true,
-			SkillItemType::Bracer => false,
-			SkillItemType::ForceEssence => false,
-		}
+		matches!(self.render.model, ModelRender::Hand(_))
 	}
 }
 
 impl<TAgent> UsesView<ForearmSlots<TAgent>> for SkillItemContent {
 	fn uses_view(&self) -> bool {
-		match self.item_type {
-			SkillItemType::Pistol => false,
-			SkillItemType::Bracer => true,
-			SkillItemType::ForceEssence => false,
-		}
+		matches!(self.render.model, ModelRender::Forearm(_))
 	}
 }
 
 impl<TAgent> UsesView<SubModels<TAgent>> for SkillItemContent {
 	fn uses_view(&self) -> bool {
-		match self.item_type {
-			SkillItemType::Pistol => false,
-			SkillItemType::Bracer => false,
-			SkillItemType::ForceEssence => true,
-		}
+		matches!(self.render.essence, EssenceRender::Material(_))
 	}
 }
 
 impl Getter<AssetModel> for SkillItemContent {
 	fn get(&self) -> AssetModel {
-		self.render.model
+		match self.render.model {
+			ModelRender::Hand(model) => model,
+			ModelRender::Forearm(model) => model,
+			ModelRender::None => AssetModel::None,
+		}
 	}
 }
 

--- a/src/plugins/skills/src/lib.rs
+++ b/src/plugins/skills/src/lib.rs
@@ -36,7 +36,7 @@ use components::{
 	combos_time_out::CombosTimeOut,
 	inventory::Inventory,
 	queue::Queue,
-	renderer::{EssenceRender, Renderer},
+	renderer::{EssenceRender, ModelRender, Renderer},
 	skill_executer::SkillExecuter,
 	skill_spawners::SkillSpawners,
 	slots::Slots,
@@ -167,6 +167,13 @@ fn set_player_items(mut commands: Commands, players: Query<Entity, Added<Player>
 }
 
 fn get_loadout() -> Loadout {
+	let force_essence_material = EssenceMaterial {
+		texture_color: CYAN_100.into(),
+		fill_color: CYAN_200.into(),
+		fresnel_color: (LIGHT_CYAN * 1.5).into(),
+		..default()
+	};
+
 	Loadout::new([
 		(
 			SlotKey::TopHand(Side::Left),
@@ -174,7 +181,7 @@ fn get_loadout() -> Loadout {
 				name: "Plasma Pistol A",
 				content: SkillItemContent {
 					render: Renderer {
-						model: AssetModel::Path("models/pistol.glb"),
+						model: ModelRender::Hand(AssetModel::Path("models/pistol.glb")),
 						essence: EssenceRender::StandardMaterial,
 					},
 					skill: Some(SkillId(uuid!("b2d5b9cb-b09d-42d4-a0cc-556cb118ef2e"))),
@@ -188,7 +195,7 @@ fn get_loadout() -> Loadout {
 				name: "Plasma Pistol B",
 				content: SkillItemContent {
 					render: Renderer {
-						model: AssetModel::Path("models/pistol.glb"),
+						model: ModelRender::Hand(AssetModel::Path("models/pistol.glb")),
 						essence: EssenceRender::StandardMaterial,
 					},
 					skill: Some(SkillId(uuid!("b2d5b9cb-b09d-42d4-a0cc-556cb118ef2e"))),
@@ -202,13 +209,8 @@ fn get_loadout() -> Loadout {
 				name: "Force Essence A",
 				content: SkillItemContent {
 					render: Renderer {
-						model: AssetModel::None,
-						essence: EssenceRender::Material(EssenceMaterial {
-							texture_color: CYAN_100.into(),
-							fill_color: CYAN_200.into(),
-							fresnel_color: (LIGHT_CYAN * 1.5).into(),
-							..default()
-						}),
+						model: ModelRender::None,
+						essence: EssenceRender::Material(force_essence_material.clone()),
 					},
 					skill: Some(SkillId(uuid!("a27de679-0fab-4e21-b4f0-b5a6cddc6aba"))),
 					item_type: SkillItemType::ForceEssence,
@@ -221,13 +223,8 @@ fn get_loadout() -> Loadout {
 				name: "Force Essence B",
 				content: SkillItemContent {
 					render: Renderer {
-						model: AssetModel::None,
-						essence: EssenceRender::Material(EssenceMaterial {
-							texture_color: CYAN_100.into(),
-							fill_color: CYAN_200.into(),
-							fresnel_color: (LIGHT_CYAN * 1.5).into(),
-							..default()
-						}),
+						model: ModelRender::None,
+						essence: EssenceRender::Material(force_essence_material.clone()),
 					},
 					skill: Some(SkillId(uuid!("a27de679-0fab-4e21-b4f0-b5a6cddc6aba"))),
 					item_type: SkillItemType::ForceEssence,
@@ -243,7 +240,7 @@ fn get_inventory() -> Inventory<SkillId> {
 			name: "Plasma Pistol C",
 			content: SkillItemContent {
 				render: Renderer {
-					model: AssetModel::Path("models/pistol.glb"),
+					model: ModelRender::Hand(AssetModel::Path("models/pistol.glb")),
 					essence: EssenceRender::StandardMaterial,
 				},
 				skill: Some(SkillId(uuid!("b2d5b9cb-b09d-42d4-a0cc-556cb118ef2e"))),
@@ -254,7 +251,7 @@ fn get_inventory() -> Inventory<SkillId> {
 			name: "Plasma Pistol D",
 			content: SkillItemContent {
 				render: Renderer {
-					model: AssetModel::Path("models/pistol.glb"),
+					model: ModelRender::Hand(AssetModel::Path("models/pistol.glb")),
 					essence: EssenceRender::StandardMaterial,
 				},
 				skill: Some(SkillId(uuid!("b2d5b9cb-b09d-42d4-a0cc-556cb118ef2e"))),
@@ -265,7 +262,7 @@ fn get_inventory() -> Inventory<SkillId> {
 			name: "Plasma Pistol E",
 			content: SkillItemContent {
 				render: Renderer {
-					model: AssetModel::Path("models/pistol.glb"),
+					model: ModelRender::Hand(AssetModel::Path("models/pistol.glb")),
 					essence: EssenceRender::StandardMaterial,
 				},
 				skill: Some(SkillId(uuid!("b2d5b9cb-b09d-42d4-a0cc-556cb118ef2e"))),

--- a/src/plugins/skills/src/systems/visualize_slot_items.rs
+++ b/src/plugins/skills/src/systems/visualize_slot_items.rs
@@ -29,8 +29,8 @@ pub(crate) fn visualize_slot_items<TView>(
 mod tests {
 	use super::*;
 	use crate::{
-		components::renderer::Renderer,
-		item::{item_type::SkillItemType, SkillItem, SkillItemContent},
+		components::renderer::{ModelRender, Renderer},
+		item::{SkillItem, SkillItemContent},
 		skills::Skill,
 		slot_key::SlotKey,
 	};
@@ -78,7 +78,7 @@ mod tests {
 		let item = SkillItem {
 			content: SkillItemContent {
 				render: Renderer {
-					model: AssetModel::Path("my model"),
+					model: ModelRender::Hand(AssetModel::Path("my model")),
 					..default()
 				},
 				..default()
@@ -112,10 +112,9 @@ mod tests {
 		let item_a = SkillItem {
 			content: SkillItemContent {
 				render: Renderer {
-					model: AssetModel::Path("my bracer model"),
+					model: ModelRender::Hand(AssetModel::Path("my hand model")),
 					..default()
 				},
-				item_type: SkillItemType::Pistol,
 				..default()
 			},
 			..default()
@@ -123,10 +122,9 @@ mod tests {
 		let item_b = SkillItem {
 			content: SkillItemContent {
 				render: Renderer {
-					model: AssetModel::Path("my forearm model"),
+					model: ModelRender::Forearm(AssetModel::Path("my forearm model")),
 					..default()
 				},
-				item_type: SkillItemType::Bracer,
 				..default()
 			},
 			..default()
@@ -159,7 +157,7 @@ mod tests {
 		let item = SkillItem {
 			content: SkillItemContent {
 				render: Renderer {
-					model: AssetModel::Path("my model"),
+					model: ModelRender::Hand(AssetModel::Path("my model")),
 					..default()
 				},
 				..default()
@@ -195,7 +193,7 @@ mod tests {
 				Some(SkillItem {
 					content: SkillItemContent {
 						render: Renderer {
-							model: AssetModel::Path("my model"),
+							model: ModelRender::Hand(AssetModel::Path("my model")),
 							..default()
 						},
 						..default()
@@ -212,7 +210,7 @@ mod tests {
 		let item = SkillItem {
 			content: SkillItemContent {
 				render: Renderer {
-					model: AssetModel::Path("my other model"),
+					model: ModelRender::Hand(AssetModel::Path("my other model")),
 					..default()
 				},
 				..default()


### PR DESCRIPTION
Allows rendering of model and shading the custom equipping arm at the same time.