### PR TITLE
using the correct prefabs plugin

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,7 @@ fn prepare_game(app: &mut App) {
 	app.add_plugins(DefaultPlugins)
 		.add_plugins(RapierPhysicsPlugin::<NoUserData>::default())
 		.add_plugins(CommonPlugin)
-		.add_plugins(PrefabsPlugin)
+		.add_plugins(prefabs_plugin)
 		.add_plugins(ShaderPlugin)
 		.add_plugins(InteractionsPlugin)
 		.add_plugins(BarsPlugin)


### PR DESCRIPTION
We used a new prefabs plugin in the running app as was used for configuring dependencies. This didn't cause any issue, because the dependencies solely relied on type info not on instance data. But this might change in the future.