### PR TITLE
address compiler warnings

### DIFF
--- a/src/plugins/animations/src/components/animation_dispatch.rs
+++ b/src/plugins/animations/src/components/animation_dispatch.rs
@@ -134,7 +134,7 @@ pub struct IterWithoutTransitions<'a> {
 	iter: Iter<'a, Entity>,
 }
 
-impl<'a> Iterator for IterWithoutTransitions<'a> {
+impl Iterator for IterWithoutTransitions<'_> {
 	type Item = Entity;
 
 	fn next(&mut self) -> Option<Self::Item> {

--- a/src/plugins/animations/src/systems/play_animation_clip.rs
+++ b/src/plugins/animations/src/systems/play_animation_clip.rs
@@ -120,19 +120,19 @@ mod tests {
 		mock: Mock_AnimationPlayer,
 	}
 
-	impl<'a> ReplayAnimation<AnimationNodeIndex> for Mut<'a, _AnimationPlayer> {
+	impl ReplayAnimation<AnimationNodeIndex> for Mut<'_, _AnimationPlayer> {
 		fn replay(&mut self, index: AnimationNodeIndex) {
 			self.mock.replay(index);
 		}
 	}
 
-	impl<'a> RepeatAnimation<AnimationNodeIndex> for Mut<'a, _AnimationPlayer> {
+	impl RepeatAnimation<AnimationNodeIndex> for Mut<'_, _AnimationPlayer> {
 		fn repeat(&mut self, index: AnimationNodeIndex) {
 			self.mock.repeat(index);
 		}
 	}
 
-	impl<'a> IsPlaying<AnimationNodeIndex> for Mut<'a, _AnimationPlayer> {
+	impl IsPlaying<AnimationNodeIndex> for Mut<'_, _AnimationPlayer> {
 		fn is_playing(&self, index: AnimationNodeIndex) -> bool {
 			self.mock.is_playing(index)
 		}

--- a/src/plugins/animations/src/traits/tuple_animation_player_transitions.rs
+++ b/src/plugins/animations/src/traits/tuple_animation_player_transitions.rs
@@ -4,14 +4,14 @@ use std::time::Duration;
 
 type AnimationPlayerComponents<'a> = (Mut<'a, AnimationPlayer>, Mut<'a, AnimationTransitions>);
 
-impl<'a> IsPlaying<AnimationNodeIndex> for AnimationPlayerComponents<'a> {
+impl IsPlaying<AnimationNodeIndex> for AnimationPlayerComponents<'_> {
 	fn is_playing(&self, index: AnimationNodeIndex) -> bool {
 		let (player, _) = self;
 		player.is_playing_animation(index)
 	}
 }
 
-impl<'a> ReplayAnimation<AnimationNodeIndex> for AnimationPlayerComponents<'a> {
+impl ReplayAnimation<AnimationNodeIndex> for AnimationPlayerComponents<'_> {
 	fn replay(&mut self, index: AnimationNodeIndex) {
 		let (player, transitions) = self;
 		transitions
@@ -20,7 +20,7 @@ impl<'a> ReplayAnimation<AnimationNodeIndex> for AnimationPlayerComponents<'a> {
 	}
 }
 
-impl<'a> RepeatAnimation<AnimationNodeIndex> for AnimationPlayerComponents<'a> {
+impl RepeatAnimation<AnimationNodeIndex> for AnimationPlayerComponents<'_> {
 	fn repeat(&mut self, index: AnimationNodeIndex) {
 		let (player, transitions) = self;
 		transitions

--- a/src/plugins/common/src/systems/insert_associated.rs
+++ b/src/plugins/common/src/systems/insert_associated.rs
@@ -19,6 +19,7 @@ where
 	TComponent: Component,
 	(TFilter1, TFilter2): QueryFilter,
 {
+	#[allow(clippy::type_complexity)]
 	fn associated<TBundle>(
 		configure: Configure<TComponent, TBundle>,
 	) -> impl Fn(Commands, Query<(Entity, &TComponent), (TFilter1, TFilter2)>)

--- a/src/plugins/common/src/tools.rs
+++ b/src/plugins/common/src/tools.rs
@@ -20,7 +20,7 @@ pub struct Factory<T>(PhantomData<T>);
 #[derive(Debug, PartialEq)]
 pub struct This<'a, T: Debug + PartialEq>(pub &'a mut T);
 
-impl<'a, T: Debug + PartialEq> Deref for This<'a, T> {
+impl<T: Debug + PartialEq> Deref for This<'_, T> {
 	type Target = T;
 
 	fn deref(&self) -> &Self::Target {
@@ -28,7 +28,7 @@ impl<'a, T: Debug + PartialEq> Deref for This<'a, T> {
 	}
 }
 
-impl<'a, T: Debug + PartialEq> DerefMut for This<'a, T> {
+impl<T: Debug + PartialEq> DerefMut for This<'_, T> {
 	fn deref_mut(&mut self) -> &mut Self::Target {
 		self.0
 	}
@@ -37,7 +37,7 @@ impl<'a, T: Debug + PartialEq> DerefMut for This<'a, T> {
 #[derive(Debug, PartialEq)]
 pub struct Last<'a, T: Debug + PartialEq>(pub &'a T);
 
-impl<'a, T: Debug + PartialEq> Deref for Last<'a, T> {
+impl<T: Debug + PartialEq> Deref for Last<'_, T> {
 	type Target = T;
 
 	fn deref(&self) -> &Self::Target {

--- a/src/plugins/common/src/tools/ordered_hash_map.rs
+++ b/src/plugins/common/src/tools/ordered_hash_map.rs
@@ -208,7 +208,7 @@ where
 	entry: HashMapOccupiedEntry<'a, TKey, TValue>,
 }
 
-impl<'a, TKey, TValue> OccupiedEntry<'a, TKey, TValue>
+impl<TKey, TValue> OccupiedEntry<'_, TKey, TValue>
 where
 	TKey: Eq + Hash + Copy,
 {

--- a/src/plugins/common/src/traits/clear/removed_components.rs
+++ b/src/plugins/common/src/traits/clear/removed_components.rs
@@ -1,7 +1,7 @@
 use super::Clear;
 use bevy::prelude::*;
 
-impl<'w, 's, TComponent> Clear for RemovedComponents<'w, 's, TComponent>
+impl<TComponent> Clear for RemovedComponents<'_, '_, TComponent>
 where
 	TComponent: Component,
 {

--- a/src/plugins/common/src/traits/load_asset.rs
+++ b/src/plugins/common/src/traits/load_asset.rs
@@ -25,7 +25,7 @@ impl<'a> From<&'a str> for Path {
 	}
 }
 
-impl<'a> From<Path> for AssetPath<'a> {
+impl From<Path> for AssetPath<'_> {
 	fn from(value: Path) -> Self {
 		AssetPath::from(value.0)
 	}

--- a/src/plugins/common/src/traits/load_asset/load_context.rs
+++ b/src/plugins/common/src/traits/load_asset/load_context.rs
@@ -1,7 +1,7 @@
 use super::LoadAsset;
 use bevy::asset::{Asset, AssetPath, Handle, LoadContext};
 
-impl<'a> LoadAsset for LoadContext<'a> {
+impl LoadAsset for LoadContext<'_> {
 	fn load_asset<TAsset, TPath>(&mut self, path: TPath) -> Handle<TAsset>
 	where
 		TAsset: Asset,

--- a/src/plugins/common/src/traits/read/removed_components.rs
+++ b/src/plugins/common/src/traits/read/removed_components.rs
@@ -1,7 +1,7 @@
 use super::Read;
 use bevy::{ecs::removal_detection::RemovedIter, prelude::*};
 
-impl<'w, 's, 'a, TComponent> Read<'a> for RemovedComponents<'w, 's, TComponent>
+impl<'a, TComponent> Read<'a> for RemovedComponents<'_, '_, TComponent>
 where
 	TComponent: Component,
 {

--- a/src/plugins/common/src/traits/try_despawn_recursive/commands.rs
+++ b/src/plugins/common/src/traits/try_despawn_recursive/commands.rs
@@ -1,7 +1,7 @@
 use super::TryDespawnRecursive;
 use bevy::prelude::*;
 
-impl<'w, 's> TryDespawnRecursive for Commands<'w, 's> {
+impl TryDespawnRecursive for Commands<'_, '_> {
 	fn try_despawn_recursive(&mut self, entity: Entity) {
 		let Some(entity) = self.get_entity(entity) else {
 			return;

--- a/src/plugins/common/src/traits/try_insert_on/commands.rs
+++ b/src/plugins/common/src/traits/try_insert_on/commands.rs
@@ -1,7 +1,7 @@
 use super::TryInsertOn;
 use bevy::ecs::{bundle::Bundle, entity::Entity, system::Commands};
 
-impl<'w, 's> TryInsertOn for Commands<'w, 's> {
+impl TryInsertOn for Commands<'_, '_> {
 	fn try_insert_on<TBundle: Bundle>(&mut self, entity: Entity, bundle: TBundle) {
 		let Some(mut entity) = self.get_entity(entity) else {
 			return;

--- a/src/plugins/common/src/traits/try_remove_from/commands.rs
+++ b/src/plugins/common/src/traits/try_remove_from/commands.rs
@@ -1,7 +1,7 @@
 use super::TryRemoveFrom;
 use bevy::prelude::*;
 
-impl<'w, 's> TryRemoveFrom for Commands<'w, 's> {
+impl TryRemoveFrom for Commands<'_, '_> {
 	fn try_remove_from<TBundle: Bundle>(&mut self, entity: Entity) {
 		let Some(mut entity) = self.get_entity(entity) else {
 			return;

--- a/src/plugins/interactions/src/components.rs
+++ b/src/plugins/interactions/src/components.rs
@@ -52,7 +52,7 @@ pub struct RayFilter {
 #[derive(Debug, PartialEq)]
 pub struct CannotParsePredicate;
 
-impl<'a> TryFrom<QueryFilter<'a>> for RayFilter {
+impl TryFrom<QueryFilter<'_>> for RayFilter {
 	type Error = CannotParsePredicate;
 
 	fn try_from(query_filter: QueryFilter) -> Result<Self, CannotParsePredicate> {
@@ -79,7 +79,7 @@ impl<'a> TryFrom<QueryFilter<'a>> for RayFilter {
 	}
 }
 
-impl<'a> From<RayFilter> for QueryFilter<'a> {
+impl From<RayFilter> for QueryFilter<'_> {
 	fn from(ray_filter: RayFilter) -> Self {
 		Self {
 			groups: ray_filter.groups,

--- a/src/plugins/loading/src/traits/is_fully_loaded.rs
+++ b/src/plugins/loading/src/traits/is_fully_loaded.rs
@@ -9,7 +9,7 @@ pub trait IsFullyLoaded {
 		TAsset: Asset;
 }
 
-impl<'w, T> IsFullyLoaded for Res<'w, T>
+impl<T> IsFullyLoaded for Res<'_, T>
 where
 	T: Resource + IsFullyLoaded,
 {

--- a/src/plugins/menu/src/traits/get_bundle/key_select_dropdown_append_skill_command.rs
+++ b/src/plugins/menu/src/traits/get_bundle/key_select_dropdown_append_skill_command.rs
@@ -200,6 +200,7 @@ mod tests {
 		)
 	}
 
+	#[allow(static_mut_refs)]
 	#[test]
 	fn retrieve_entry_with_correct_key_path() {
 		struct _Combos;

--- a/src/plugins/prefabs/src/systems/instantiate.rs
+++ b/src/plugins/prefabs/src/systems/instantiate.rs
@@ -18,13 +18,13 @@ struct GetHandlesFns<'a> {
 	material: GetHandleFn<'a, SMat>,
 }
 
-impl<'a> GetOrCreateAsset<TypeId, Mesh> for GetHandlesFns<'a> {
+impl GetOrCreateAsset<TypeId, Mesh> for GetHandlesFns<'_> {
 	fn get_or_create(&mut self, key: TypeId, mut create: impl FnMut() -> Mesh) -> Handle<Mesh> {
 		(self.mesh)(key, &mut create)
 	}
 }
 
-impl<'a> GetOrCreateAsset<TypeId, SMat> for GetHandlesFns<'a> {
+impl GetOrCreateAsset<TypeId, SMat> for GetHandlesFns<'_> {
 	fn get_or_create(&mut self, key: TypeId, mut create: impl FnMut() -> SMat) -> Handle<SMat> {
 		(self.material)(key, &mut create)
 	}

--- a/src/plugins/shaders/src/components/effect_shader.rs
+++ b/src/plugins/shaders/src/components/effect_shader.rs
@@ -64,7 +64,7 @@ impl EffectShader {
 	}
 }
 
-impl<'a> InsertUnmovableEffectShader for EntityCommands<'a> {
+impl InsertUnmovableEffectShader for EntityCommands<'_> {
 	fn insert_unmovable_effect_shader(&mut self, effect_shader: &EffectShader) {
 		let insert_into = effect_shader.insert_into;
 		let handle = &effect_shader.handle;
@@ -72,7 +72,7 @@ impl<'a> InsertUnmovableEffectShader for EntityCommands<'a> {
 	}
 }
 
-impl<'a> RemoveUnmovableEffectShader for EntityCommands<'a> {
+impl RemoveUnmovableEffectShader for EntityCommands<'_> {
 	fn remove_unmovable_effect_shader(&mut self, effect_shader: &EffectShader) {
 		let remove_from = effect_shader.remove_from;
 		remove_from(self)

--- a/src/plugins/skills/src/components/combo_node.rs
+++ b/src/plugins/skills/src/components/combo_node.rs
@@ -190,6 +190,7 @@ fn combos(combo_node: &ComboNode, key_path: Vec<SlotKey>) -> impl Iterator<Item 
 		.flat_map(append_followup_combo_steps)
 }
 
+#[allow(clippy::type_complexity)]
 fn build_path<'a>(
 	key_path: Vec<SlotKey>,
 ) -> impl FnMut((&SlotKey, &'a (Skill, ComboNode))) -> (Vec<SlotKey>, &'a Skill, &'a ComboNode) {

--- a/src/plugins/skills/src/components/combo_node/node_entry_mut.rs
+++ b/src/plugins/skills/src/components/combo_node/node_entry_mut.rs
@@ -6,7 +6,7 @@ use crate::{
 use bevy::prelude::default;
 use common::tools::ordered_hash_map::{Entry, OrderedHashMap};
 
-impl<'a, TSkill> Insert<Option<TSkill>> for NodeEntryMut<'a, TSkill> {
+impl<TSkill> Insert<Option<TSkill>> for NodeEntryMut<'_, TSkill> {
 	fn insert(&mut self, value: Option<TSkill>) {
 		match value {
 			Some(value) => update_entry(self, value),
@@ -31,7 +31,7 @@ fn clear_entry<TSkill>(entry: &mut NodeEntryMut<TSkill>) {
 	entry.tree.remove(&entry.key);
 }
 
-impl<'a, TSkill> ReKey<SlotKey> for NodeEntryMut<'a, TSkill> {
+impl<TSkill> ReKey<SlotKey> for NodeEntryMut<'_, TSkill> {
 	fn re_key(&mut self, new_key: SlotKey) {
 		if self.key == new_key {
 			return;

--- a/src/plugins/skills/src/components/combos.rs
+++ b/src/plugins/skills/src/components/combos.rs
@@ -286,13 +286,13 @@ mod tests {
 		mock: Mock_Entry,
 	}
 
-	impl<'a> Insert<Option<Skill>> for &'a mut _Entry {
+	impl Insert<Option<Skill>> for &mut _Entry {
 		fn insert(&mut self, value: Option<Skill>) {
 			self.mock.insert(value)
 		}
 	}
 
-	impl<'a> ReKey<SlotKey> for &'a mut _Entry {
+	impl ReKey<SlotKey> for &mut _Entry {
 		fn re_key(&mut self, key: SlotKey) {
 			self.mock.re_key(key)
 		}

--- a/src/plugins/skills/src/components/queue.rs
+++ b/src/plugins/skills/src/components/queue.rs
@@ -552,7 +552,7 @@ impl GetActiveSkill<SkillState> for Queue {
 	}
 }
 
-impl<'a> StateDuration<SkillState> for ActiveSkill<'a> {
+impl StateDuration<SkillState> for ActiveSkill<'_> {
 	fn get_state_duration(&self, key: SkillState) -> Duration {
 		match (key, &self.mode) {
 			(SkillState::Aim, Activation::Primed | Activation::Waiting) => Duration::MAX,
@@ -569,13 +569,13 @@ impl<'a> StateDuration<SkillState> for ActiveSkill<'a> {
 	}
 }
 
-impl<'a> GetSkillBehavior for ActiveSkill<'a> {
+impl GetSkillBehavior for ActiveSkill<'_> {
 	fn behavior(&self) -> (SlotKey, RunSkillBehavior) {
 		(*self.slot_key, self.skill.behavior.clone())
 	}
 }
 
-impl<'a> GetAnimation for ActiveSkill<'a> {
+impl GetAnimation for ActiveSkill<'_> {
 	fn animate(&self) -> Animate<Animation> {
 		match (&self.skill.animate, self.slot_key) {
 			(Animate::None, ..) => Animate::None,

--- a/src/plugins/skills/src/skills.rs
+++ b/src/plugins/skills/src/skills.rs
@@ -167,7 +167,7 @@ impl Default for RunSkillBehavior {
 	}
 }
 
-impl<'w, 's> SpawnSkillBehavior<Commands<'w, 's>> for RunSkillBehavior {
+impl SpawnSkillBehavior<Commands<'_, '_>> for RunSkillBehavior {
 	fn spawn_on(&self) -> SpawnOn {
 		match self {
 			RunSkillBehavior::OnActive(skill) => skill.spawn_on,

--- a/src/plugins/skills/src/systems/enqueue.rs
+++ b/src/plugins/skills/src/systems/enqueue.rs
@@ -185,6 +185,7 @@ mod tests {
 		app
 	}
 
+	#[allow(static_mut_refs)]
 	#[test]
 	fn enqueue_skill_from_skills() {
 		#[derive(Component, NestedMocks)]

--- a/src/plugins/skills/src/systems/equip.rs
+++ b/src/plugins/skills/src/systems/equip.rs
@@ -111,8 +111,8 @@ mod tests {
 		errors: HashMap<SlotKey, SwapError>,
 	}
 
-	impl<'a> SwapCommands<SlotKey, Handle<SkillItem>>
-		for SwapController<'a, (), SlotKey, _Container, _Swaps>
+	impl SwapCommands<SlotKey, Handle<SkillItem>>
+		for SwapController<'_, (), SlotKey, _Container, _Swaps>
 	{
 		fn try_swap(
 			&mut self,

--- a/src/plugins/skills/src/systems/execute.rs
+++ b/src/plugins/skills/src/systems/execute.rs
@@ -116,7 +116,7 @@ mod tests {
 		}
 	}
 
-	impl<'w, 's> Execute<Commands<'w, 's>, _Lifetime> for _Executor {
+	impl Execute<Commands<'_, '_>, _Lifetime> for _Executor {
 		type TError = _Error;
 
 		fn execute(

--- a/src/plugins/skills/src/traits/swap_commands.rs
+++ b/src/plugins/skills/src/traits/swap_commands.rs
@@ -45,8 +45,8 @@ impl<'a, TInnerKey, TOuterKey, TContainer, TSwaps>
 
 struct RetryFailed<T>(T);
 
-impl<'a, TContainer, TSwap, TContainerKey> SwapCommands<SlotKey, Handle<SkillItem>>
-	for SwapController<'a, TContainerKey, SlotKey, TContainer, Collection<TSwap>>
+impl<TContainer, TSwap, TContainerKey> SwapCommands<SlotKey, Handle<SkillItem>>
+	for SwapController<'_, TContainerKey, SlotKey, TContainer, Collection<TSwap>>
 where
 	TContainer: GetMut<TContainerKey, Option<Handle<SkillItem>>>,
 	TSwap: Keys<TContainerKey, SlotKey> + Clone,


### PR DESCRIPTION
After upgrading to rust 1.83. Was needed because pipeline rust version is not fixed (for the moment desired).