### PR TITLE
Quick bar skill execution fix

### DIFF
--- a/src/plugins/behaviors/src/lib.rs
+++ b/src/plugins/behaviors/src/lib.rs
@@ -83,12 +83,12 @@ where
 			.add_systems(
 				Update,
 				(
-					trigger_move_input_event::<CamRay>,
+					trigger_move_input_event::<CamRay>
+						.run_if(in_state(MouseContext::<KeyCode>::Default)),
 					get_faces.pipe(execute_face::<CamRay>),
 				)
 					.chain()
-					.run_if(in_state(GameState::Play))
-					.run_if(in_state(MouseContext::<KeyCode>::Default)),
+					.run_if(in_state(GameState::Play)),
 			)
 			.add_systems(
 				Update,


### PR DESCRIPTION
Now only movement is constraint by `MouseContext::<KeyCode>::Default`. Thus, we do not move when pressing the quickbar ui with the mouse (sets MouseContext::<KeyCode> to something other than `Default`) . However, orientating the player during the aim phase of the skill execution from the quickbar occurs normally.