### PR TITLE
set navigation grid cell size to 1.

### DIFF
--- a/src/plugins/map_generation/src/lib.rs
+++ b/src/plugins/map_generation/src/lib.rs
@@ -58,7 +58,7 @@ where
 					LoadLevel::<LightCell>::graph.pipe(spawn_procedural),
 				),
 			)
-			.add_systems(Update, Level::<2>::insert)
+			.add_systems(Update, Level::<1>::insert)
 			.add_systems(
 				Update,
 				(
@@ -72,6 +72,6 @@ where
 }
 
 impl<TDependencies> HandlesMapGeneration for MapGenerationPlugin<TDependencies> {
-	type TMap = Level<2>;
+	type TMap = Level<1>;
 	type TGraph = GridGraph;
 }


### PR DESCRIPTION
Done by subdividing the original grid with cell size 2 one time instead of 2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Adjusted the map generation process to use an updated level configuration for smoother system updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->