### PR TITLE
rename `SetupScreen` to `SettingsScreen`

### DIFF
--- a/src/plugins/menu/src/components.rs
+++ b/src/plugins/menu/src/components.rs
@@ -10,7 +10,7 @@ pub(crate) mod key_select_dropdown_command;
 pub(crate) mod loading_screen;
 pub(crate) mod menu_background;
 pub(crate) mod quickbar_panel;
-pub(crate) mod setup_screen;
+pub(crate) mod settings_screen;
 pub(crate) mod start_game;
 pub(crate) mod start_menu;
 pub(crate) mod start_menu_button;

--- a/src/plugins/menu/src/components/settings_screen.rs
+++ b/src/plugins/menu/src/components/settings_screen.rs
@@ -5,15 +5,15 @@ use common::traits::{handles_localization::LocalizeToken, thread_safe::ThreadSaf
 
 #[derive(Component, Debug, PartialEq)]
 #[require(MenuBackground)]
-pub(crate) struct SetupScreen;
+pub(crate) struct SettingsScreen;
 
-impl LoadUi<AssetServer> for SetupScreen {
+impl LoadUi<AssetServer> for SettingsScreen {
 	fn load_ui(_: &mut AssetServer) -> Self {
 		Self
 	}
 }
 
-impl InsertUiContent for SetupScreen {
+impl InsertUiContent for SettingsScreen {
 	fn insert_ui_content<TLocalization>(&self, _: &mut TLocalization, _: &mut ChildBuilder)
 	where
 		TLocalization: LocalizeToken + ThreadSafe,

--- a/src/plugins/menu/src/lib.rs
+++ b/src/plugins/menu/src/lib.rs
@@ -66,7 +66,7 @@ use components::{
 	loading_screen::LoadingScreen,
 	menu_background::MenuBackground,
 	quickbar_panel::QuickbarPanel,
-	setup_screen::SetupScreen,
+	settings_screen::SettingsScreen,
 	start_game::StartGame,
 	start_menu::StartMenu,
 	start_menu_button::StartMenuButton,
@@ -289,10 +289,12 @@ where
 		);
 	}
 
-	fn setup_screen(&self, app: &mut App) {
+	fn settings_screen(&self, app: &mut App) {
 		let setup = GameState::IngameMenu(MenuState::Setup);
 
-		app.add_ui::<SetupScreen, TLocalization::TLocalizationServer, TGraphics::TUiCamera>(setup);
+		app.add_ui::<SettingsScreen, TLocalization::TLocalizationServer, TGraphics::TUiCamera>(
+			setup,
+		);
 	}
 
 	fn general_systems(&self, app: &mut App) {
@@ -329,7 +331,7 @@ where
 		self.ui_overlay(app);
 		self.combo_overview(app);
 		self.inventory_screen(app);
-		self.setup_screen(app);
+		self.settings_screen(app);
 		self.general_systems(app);
 
 		#[cfg(debug_assertions)]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Renamed "SetupScreen" to "SettingsScreen" throughout the menu interface for improved consistency in naming.
  - Updated related UI and method names to reflect the new terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->