### PR TITLE
`MenuState::Setup` -> `MenuState::Settings`

### DIFF
--- a/src/plugins/common/src/states/game_state.rs
+++ b/src/plugins/common/src/states/game_state.rs
@@ -48,7 +48,7 @@ impl TryFrom<GameState> for KeyCode {
 			GameState::Saving => Ok(KeyCode::F5),
 			GameState::IngameMenu(MenuState::Inventory) => Ok(KeyCode::KeyI),
 			GameState::IngameMenu(MenuState::ComboOverview) => Ok(KeyCode::KeyK),
-			GameState::IngameMenu(MenuState::Setup) => Ok(KeyCode::Escape),
+			GameState::IngameMenu(MenuState::Settings) => Ok(KeyCode::Escape),
 			_ => Err(NoKeySet),
 		}
 	}
@@ -72,9 +72,9 @@ impl IterFinite for GameState {
 				Some(GameState::IngameMenu(MenuState::ComboOverview))
 			}
 			GameState::IngameMenu(MenuState::ComboOverview) => {
-				Some(GameState::IngameMenu(MenuState::Setup))
+				Some(GameState::IngameMenu(MenuState::Settings))
 			}
-			GameState::IngameMenu(MenuState::Setup) => None,
+			GameState::IngameMenu(MenuState::Settings) => None,
 		}
 	}
 }
@@ -102,7 +102,7 @@ mod tests {
 				GameState::Saving,
 				GameState::IngameMenu(MenuState::Inventory),
 				GameState::IngameMenu(MenuState::ComboOverview),
-				GameState::IngameMenu(MenuState::Setup),
+				GameState::IngameMenu(MenuState::Settings),
 			],
 			GameState::iterator().take(100).collect::<Vec<_>>(),
 		)

--- a/src/plugins/common/src/states/menu_state.rs
+++ b/src/plugins/common/src/states/menu_state.rs
@@ -3,5 +3,5 @@ pub enum MenuState {
 	#[default]
 	Inventory,
 	ComboOverview,
-	Setup,
+	Settings,
 }

--- a/src/plugins/menu/src/lib.rs
+++ b/src/plugins/menu/src/lib.rs
@@ -290,10 +290,10 @@ where
 	}
 
 	fn settings_screen(&self, app: &mut App) {
-		let setup = GameState::IngameMenu(MenuState::Setup);
+		let settings = GameState::IngameMenu(MenuState::Settings);
 
 		app.add_ui::<SettingsScreen, TLocalization::TLocalizationServer, TGraphics::TUiCamera>(
-			setup,
+			settings,
 		);
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Renamed the "Setup" menu state to "Settings" across all relevant screens and menus for improved clarity and consistency.
- **Bug Fixes**
  - Updated state transitions and UI references to ensure the correct display and navigation to the Settings menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->