### PR TITLE
Camera show key binds

### DIFF
--- a/assets/locale/en-us.ftl
+++ b/assets/locale/en-us.ftl
@@ -36,6 +36,8 @@ movement-key-backward = Move backward
 movement-key-left = Move left
 movement-key-right = Move right
 
+camera-key-rotate = Camera Rotation
+
 menu-inventory = Inventory
 menu-combos = Combos
 menu-settings = Settings

--- a/assets/locale/en-us.ftl
+++ b/assets/locale/en-us.ftl
@@ -25,6 +25,7 @@ key-bindings = Key Bindings
 key-bindings-slots = Slots
 key-bindings-movement = Movement
 key-bindings-menus = Menus
+key-bindings-camera = Camera
 
 slot-key-top-hand-left = Top Hand Left
 slot-key-top-hand-right = Top Hand Right
@@ -79,3 +80,7 @@ key-code-key-x = X
 key-code-key-y = Y
 key-code-key-z = Z
 key-code-escape = Escape
+
+mouse-button-left = Left Mouse Button
+mouse-button-right = Right Mouse Button
+mouse-button-middle = Middle Mouse Button

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,7 +98,8 @@ fn prepare_game(app: &mut App) {
 		&enemy_plugin,
 		&graphics_plugin,
 	);
-	let camera_control_plugin = CameraControlPlugin::depends_on(&player_plugin, &graphics_plugin);
+	let camera_control_plugin =
+		CameraControlPlugin::depends_on(&settings_plugin, &player_plugin, &graphics_plugin);
 
 	app.add_plugins(DefaultPlugins)
 		.add_plugins(RapierPhysicsPlugin::<NoUserData>::default())

--- a/src/plugins/camera_control/src/lib.rs
+++ b/src/plugins/camera_control/src/lib.rs
@@ -5,6 +5,7 @@ mod traits;
 use bevy::prelude::*;
 use common::{
 	states::game_state::GameState,
+	tools::keys::camera_key::CameraKey,
 	traits::{
 		handles_graphics::{FirstPassCamera, WorldCameras},
 		handles_player::{HandlesPlayer, PlayerMainCamera},
@@ -49,7 +50,7 @@ where
 		.add_systems(
 			Update,
 			(
-				move_on_orbit::<OrbitPlayer>,
+				move_on_orbit::<OrbitPlayer, TSettings::TKeyMap<CameraKey>>,
 				move_with_target::<OrbitPlayer>,
 			)
 				.run_if(in_state(GameState::Play)),

--- a/src/plugins/camera_control/src/lib.rs
+++ b/src/plugins/camera_control/src/lib.rs
@@ -8,6 +8,7 @@ use common::{
 	traits::{
 		handles_graphics::{FirstPassCamera, WorldCameras},
 		handles_player::{HandlesPlayer, PlayerMainCamera},
+		handles_settings::HandlesSettings,
 		thread_safe::ThreadSafe,
 	},
 };
@@ -21,18 +22,21 @@ use systems::{
 
 pub struct CameraControlPlugin<TDependencies>(PhantomData<TDependencies>);
 
-impl<TPlayers, TGraphics> CameraControlPlugin<(TPlayers, TGraphics)>
+impl<TSettings, TPlayers, TGraphics> CameraControlPlugin<(TSettings, TPlayers, TGraphics)>
 where
+	TSettings: ThreadSafe + HandlesSettings,
 	TPlayers: ThreadSafe + HandlesPlayer + PlayerMainCamera,
 	TGraphics: ThreadSafe + WorldCameras + FirstPassCamera,
 {
-	pub fn depends_on(_: &TPlayers, _: &TGraphics) -> Self {
+	pub fn depends_on(_: &TSettings, _: &TPlayers, _: &TGraphics) -> Self {
 		Self(PhantomData)
 	}
 }
 
-impl<TPlayers, TGraphics> Plugin for CameraControlPlugin<(TPlayers, TGraphics)>
+impl<TSettings, TPlayers, TGraphics> Plugin
+	for CameraControlPlugin<(TSettings, TPlayers, TGraphics)>
 where
+	TSettings: ThreadSafe + HandlesSettings,
 	TPlayers: ThreadSafe + HandlesPlayer + PlayerMainCamera,
 	TGraphics: ThreadSafe + WorldCameras + FirstPassCamera,
 {

--- a/src/plugins/camera_control/src/systems/move_on_orbit.rs
+++ b/src/plugins/camera_control/src/systems/move_on_orbit.rs
@@ -1,15 +1,20 @@
 use crate::traits::orbit::Orbit;
 use bevy::{input::mouse::MouseMotion, prelude::*};
-use common::tools::keys::user_input::UserInput;
+use common::{
+	tools::keys::{camera_key::CameraKey, user_input::UserInput},
+	traits::key_mappings::Pressed,
+};
 
-pub(crate) fn move_on_orbit<TOrbit>(
-	mouse: Res<ButtonInput<UserInput>>,
+pub(crate) fn move_on_orbit<TOrbit, TMap>(
+	input: Res<ButtonInput<UserInput>>,
+	map: Res<TMap>,
 	mut mouse_motion: EventReader<MouseMotion>,
 	mut query: Query<(&TOrbit, &mut Transform)>,
 ) where
 	TOrbit: Orbit + Component,
+	TMap: Pressed<CameraKey> + Resource,
 {
-	if !mouse.pressed(UserInput::from(MouseButton::Right)) {
+	if !map.pressed(&input).any(|key| key == CameraKey::Rotate) {
 		return;
 	}
 
@@ -41,11 +46,24 @@ mod tests {
 		}
 	}
 
-	fn setup_app() -> App {
+	#[derive(Resource, NestedMocks)]
+	struct _Map {
+		mock: Mock_Map,
+	}
+
+	#[automock]
+	impl Pressed<CameraKey> for _Map {
+		fn pressed(&self, input: &ButtonInput<UserInput>) -> impl Iterator<Item = CameraKey> {
+			self.mock.pressed(input)
+		}
+	}
+
+	fn setup_app(map: _Map) -> App {
 		let mut app = App::new().single_threaded(Update);
 		let input = ButtonInput::<UserInput>::default();
 
-		app.add_systems(Update, move_on_orbit::<_Orbit>);
+		app.insert_resource(map);
+		app.add_systems(Update, move_on_orbit::<_Orbit, _Map>);
 		app.add_event::<MouseMotion>();
 		app.insert_resource(input);
 
@@ -54,7 +72,10 @@ mod tests {
 
 	#[test]
 	fn move_camera_on_move_event() {
-		let mut app = setup_app();
+		let mut app = setup_app(_Map::new().with_mock(|mock| {
+			mock.expect_pressed()
+				.returning(|_| Box::new(std::iter::once(CameraKey::Rotate)));
+		}));
 		app.world_mut().spawn((
 			_Orbit::new().with_mock(|mock| {
 				mock.expect_orbit()
@@ -72,16 +93,16 @@ mod tests {
 			.send(MouseMotion {
 				delta: Vec2::new(3., 4.),
 			});
-		app.world_mut()
-			.resource_mut::<ButtonInput<UserInput>>()
-			.press(UserInput::from(MouseButton::Right));
 
 		app.update();
 	}
 
 	#[test]
 	fn do_not_move_camera_when_not_right_mouse_button_pressed() {
-		let mut app = setup_app();
+		let mut app = setup_app(_Map::new().with_mock(|mock| {
+			mock.expect_pressed()
+				.returning(|_| Box::new(std::iter::empty()));
+		}));
 		app.world_mut().spawn((
 			_Orbit::new().with_mock(|mock| {
 				mock.expect_orbit()
@@ -105,7 +126,10 @@ mod tests {
 
 	#[test]
 	fn move_multiple_cameras_on_move_event() {
-		let mut app = setup_app();
+		let mut app = setup_app(_Map::new().with_mock(|mock| {
+			mock.expect_pressed()
+				.returning(|_| Box::new(std::iter::once(CameraKey::Rotate)));
+		}));
 		app.world_mut().spawn((
 			_Orbit::new().with_mock(|mock| {
 				mock.expect_orbit()
@@ -135,9 +159,41 @@ mod tests {
 			.send(MouseMotion {
 				delta: Vec2::new(3., 4.),
 			});
+
+		app.update();
+	}
+
+	#[test]
+	fn call_map_with_correct_input() {
+		let mut input = ButtonInput::default();
+		input.press(UserInput::MouseButton(MouseButton::Right));
+		let mut app = setup_app(_Map::new().with_mock(|mock| {
+			mock.expect_pressed().returning(|input| {
+				assert_eq!(
+					vec![&UserInput::MouseButton(MouseButton::Right)],
+					input.get_pressed().collect::<Vec<_>>()
+				);
+				Box::new(std::iter::once(CameraKey::Rotate))
+			});
+		}));
+		app.insert_resource(input);
+		app.world_mut().spawn((
+			_Orbit::new().with_mock(|mock| {
+				mock.expect_orbit()
+					.with(
+						eq(Transform::from_translation(Vec3::ZERO)),
+						eq(Vec2::new(3., 4.)),
+					)
+					.times(1)
+					.return_const(());
+			}),
+			Transform::from_translation(Vec3::ZERO),
+		));
 		app.world_mut()
-			.resource_mut::<ButtonInput<UserInput>>()
-			.press(UserInput::from(MouseButton::Right));
+			.resource_mut::<Events<MouseMotion>>()
+			.send(MouseMotion {
+				delta: Vec2::new(3., 4.),
+			});
 
 		app.update();
 	}

--- a/src/plugins/common/src/tools/keys.rs
+++ b/src/plugins/common/src/tools/keys.rs
@@ -1,3 +1,4 @@
+pub mod camera_key;
 pub mod movement;
 pub mod slot;
 pub mod user_input;
@@ -10,6 +11,7 @@ use crate::{
 	},
 };
 use bevy::{reflect::TypePath, utils::default};
+use camera_key::CameraKey;
 use movement::MovementKey;
 use serde::{Deserialize, Serialize};
 use slot::SlotKey;
@@ -21,6 +23,7 @@ pub enum Key {
 	Movement(MovementKey),
 	Slot(SlotKey),
 	Menu(MenuState),
+	Camera(CameraKey),
 }
 
 impl Default for Key {
@@ -38,7 +41,8 @@ impl IterFinite for Key {
 		match current.0? {
 			Key::Movement(key) => try_next(Key::Movement, key).or(try_fst(Key::Slot)),
 			Key::Slot(key) => try_next(Key::Slot, key).or(try_fst(Key::Menu)),
-			Key::Menu(key) => try_next(Key::Menu, key),
+			Key::Menu(key) => try_next(Key::Menu, key).or(try_fst(Key::Camera)),
+			Key::Camera(key) => try_next(Key::Camera, key),
 		}
 	}
 }
@@ -49,6 +53,7 @@ impl From<Key> for UserInput {
 			Key::Movement(key) => Self::from(key),
 			Key::Slot(key) => Self::from(key),
 			Key::Menu(key) => Self::from(key),
+			Key::Camera(key) => Self::from(key),
 		}
 	}
 }
@@ -59,6 +64,7 @@ impl From<Key> for Token {
 			Key::Movement(key) => Self::from(key),
 			Key::Slot(key) => Self::from(key),
 			Key::Menu(key) => Self::from(key),
+			Key::Camera(key) => Self::from(key),
 		}
 	}
 }
@@ -99,6 +105,7 @@ mod tests {
 				.map(Key::Movement)
 				.chain(SlotKey::iterator().map(Key::Slot))
 				.chain(MenuState::iterator().map(Key::Menu))
+				.chain(CameraKey::iterator().map(Key::Camera))
 				.collect::<Vec<_>>(),
 			Key::iterator().take(100).collect::<Vec<_>>()
 		);
@@ -111,6 +118,7 @@ mod tests {
 				.map(UserInput::from)
 				.chain(SlotKey::iterator().map(UserInput::from))
 				.chain(MenuState::iterator().map(UserInput::from))
+				.chain(CameraKey::iterator().map(UserInput::from))
 				.collect::<HashSet<_>>(),
 			Key::iterator().map(UserInput::from).collect::<HashSet<_>>(),
 		);

--- a/src/plugins/common/src/tools/keys/camera_key.rs
+++ b/src/plugins/common/src/tools/keys/camera_key.rs
@@ -1,0 +1,70 @@
+use super::{IsNot, Key, user_input::UserInput};
+use crate::traits::{
+	handles_localization::Token,
+	iteration::{Iter, IterFinite},
+};
+use bevy::input::mouse::MouseButton;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Eq, Hash, PartialEq, Debug, Serialize, Deserialize)]
+pub enum CameraKey {
+	Rotate,
+}
+
+impl From<CameraKey> for Token {
+	fn from(camera_key: CameraKey) -> Self {
+		match camera_key {
+			CameraKey::Rotate => Self::from("camera-key-rotate"),
+		}
+	}
+}
+
+impl From<CameraKey> for Key {
+	fn from(camera_key: CameraKey) -> Self {
+		Self::Camera(camera_key)
+	}
+}
+
+impl From<CameraKey> for UserInput {
+	fn from(value: CameraKey) -> Self {
+		match value {
+			CameraKey::Rotate => UserInput::MouseButton(MouseButton::Right),
+		}
+	}
+}
+
+impl TryFrom<Key> for CameraKey {
+	type Error = IsNot<CameraKey>;
+
+	fn try_from(value: Key) -> Result<Self, Self::Error> {
+		match value {
+			Key::Camera(camera_key) => Ok(camera_key),
+			_ => Err(IsNot::key()),
+		}
+	}
+}
+
+impl IterFinite for CameraKey {
+	fn iterator() -> Iter<Self> {
+		Iter(Some(Self::Rotate))
+	}
+
+	fn next(current: &Iter<Self>) -> Option<Self> {
+		match &current.0? {
+			CameraKey::Rotate => None,
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn iterate() {
+		assert_eq!(
+			vec![CameraKey::Rotate],
+			CameraKey::iterator().take(100).collect::<Vec<_>>()
+		);
+	}
+}

--- a/src/plugins/menu/src/components/settings_screen.rs
+++ b/src/plugins/menu/src/components/settings_screen.rs
@@ -12,7 +12,13 @@ use crate::{
 use bevy::prelude::*;
 use common::{
 	states::menu_state::MenuState,
-	tools::keys::{Key, movement::MovementKey, slot::SlotKey, user_input::UserInput},
+	tools::keys::{
+		Key,
+		camera_key::CameraKey,
+		movement::MovementKey,
+		slot::SlotKey,
+		user_input::UserInput,
+	},
 	traits::{
 		handles_localization::{LocalizeToken, Token},
 		iterate::Iterate,
@@ -150,6 +156,7 @@ impl InsertUiContent for SettingsScreen {
 				self.add_section::<SlotKey>(parent, localize, "key-bindings-slots");
 				self.add_section::<MovementKey>(parent, localize, "key-bindings-movement");
 				self.add_section::<MenuState>(parent, localize, "key-bindings-menus");
+				self.add_section::<CameraKey>(parent, localize, "key-bindings-camera");
 			});
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for camera-related key bindings, including a new "Camera" category and a "Camera Rotation" action.
  - Camera controls can now be mapped to mouse buttons, with clear labels for left, right, and middle mouse buttons.
  - Camera key bindings are now displayed in the settings screen alongside other input categories.

- **Bug Fixes**
  - Improved consistency and flexibility in handling key mappings for camera controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->