### PR TITLE
fix map backface see through bug

### DIFF
--- a/src/plugins/map_generation/src/components/wall_back.rs
+++ b/src/plugins/map_generation/src/components/wall_back.rs
@@ -19,7 +19,6 @@ impl ExtraComponentsDefinition for WallBack {
 			WallBack,
 			InsertAsset::shared::<WallBack>(|| StandardMaterial {
 				base_color: Color::from(BLACK),
-				depth_bias: f32::MAX,
 				..default()
 			}),
 		));


### PR DESCRIPTION
The wall back meshes had a `depth_bias` field set. No idea why I did that. But this caused the issue, because those faces were drawn over all other meshes.