### PR TITLE
use `.with_child()` instead of `children![]` on inserts

### DIFF
--- a/src/plugins/behaviors/src/components/skill_behavior.rs
+++ b/src/plugins/behaviors/src/components/skill_behavior.rs
@@ -69,21 +69,20 @@ impl SimplePrefab for Shape {
 			),
 		};
 
-		entity.try_insert((
-			Transform::from_translation(offset),
-			Visibility::default(),
-			InteractionTarget,
-			children![
-				(model, model_transform),
-				(
-					collider,
-					collider_transform,
-					ActiveEvents::COLLISION_EVENTS,
-					ActiveCollisionTypes::default(),
-					Sensor,
-				),
-			],
-		));
+		entity
+			.try_insert((
+				Transform::from_translation(offset),
+				Visibility::default(),
+				InteractionTarget,
+			))
+			.with_child((model, model_transform))
+			.with_child((
+				collider,
+				collider_transform,
+				ActiveEvents::COLLISION_EVENTS,
+				ActiveCollisionTypes::default(),
+				Sensor,
+			));
 
 		Ok(())
 	}

--- a/src/plugins/enemy/src/components/void_beam.rs
+++ b/src/plugins/enemy/src/components/void_beam.rs
@@ -55,15 +55,16 @@ where
 	TInteractions: HandlesInteractions + HandlesEffect<DealDamage>,
 {
 	fn insert_prefab_components(&self, entity: &mut EntityCommands) -> Result<(), Error> {
-		entity.try_insert((
-			TInteractions::beam_from(self),
-			TInteractions::is_ray_interrupted_by(&[Blocker::Physical, Blocker::Force]),
-			TInteractions::effect(DealDamage::once_per_second(self.attack.damage)),
-			children![VoidBeamModel {
+		entity
+			.try_insert((
+				TInteractions::beam_from(self),
+				TInteractions::is_ray_interrupted_by(&[Blocker::Physical, Blocker::Force]),
+				TInteractions::effect(DealDamage::once_per_second(self.attack.damage)),
+			))
+			.with_child(VoidBeamModel {
 				color: self.attack.color,
 				emissive: self.attack.emissive,
-			}],
-		));
+			});
 
 		Ok(())
 	}

--- a/src/plugins/enemy/src/components/void_sphere.rs
+++ b/src/plugins/enemy/src/components/void_sphere.rs
@@ -114,24 +114,23 @@ where
 		let mut transform_2nd_ring = transform;
 		transform_2nd_ring.rotate_axis(Dir3::Z, PI / 2.);
 
-		entity.try_insert((
-			Health::new(5.).bundle_via::<TInteractions>(),
-			Affected::by::<Gravity>().bundle_via::<TInteractions>(),
-			children![
-				(VoidSpherePart::Core, VoidSphereCore, transform),
-				(
-					VoidSpherePart::RingA(UnitsPerSecond::new(PI / 50.)),
-					VoidSphereRing,
-					transform,
-				),
-				(
-					VoidSpherePart::RingB(UnitsPerSecond::new(PI / 75.)),
-					VoidSphereRing,
-					transform_2nd_ring,
-				),
-				(Collider::ball(VOID_SPHERE_OUTER_RADIUS), transform),
-			],
-		));
+		entity
+			.try_insert((
+				Health::new(5.).bundle_via::<TInteractions>(),
+				Affected::by::<Gravity>().bundle_via::<TInteractions>(),
+			))
+			.with_child((VoidSpherePart::Core, VoidSphereCore, transform))
+			.with_child((
+				VoidSpherePart::RingA(UnitsPerSecond::new(PI / 50.)),
+				VoidSphereRing,
+				transform,
+			))
+			.with_child((
+				VoidSpherePart::RingB(UnitsPerSecond::new(PI / 75.)),
+				VoidSphereRing,
+				transform_2nd_ring,
+			))
+			.with_child((Collider::ball(VOID_SPHERE_OUTER_RADIUS), transform));
 
 		Ok(())
 	}

--- a/src/plugins/player/src/components/player.rs
+++ b/src/plugins/player/src/components/player.rs
@@ -284,17 +284,16 @@ where
 	TLights: HandlesLights,
 {
 	fn insert_prefab_components(&self, entity: &mut EntityCommands) -> Result<(), Error> {
-		entity.insert((
-			Health::new(100.).bundle_via::<TInteractions>(),
-			children![(
+		entity
+			.insert((Health::new(100.).bundle_via::<TInteractions>(),))
+			.with_child((
 				TLights::responsive_light_trigger(),
 				Collider::capsule(
 					Vec3::new(0.0, 0.2, -0.05),
 					Vec3::new(0.0, 1.4, -0.05),
 					**Self::collider_radius(),
 				),
-			)],
-		));
+			));
 
 		Ok(())
 	}


### PR DESCRIPTION
`children![]` should be used when spawning only, because when inserting it could unintentionally override already existing children on that entity, causing them to be unparented