### PR TITLE
fix lingering veloxity on loading save

### DIFF
--- a/src/plugins/behaviors/src/components/movement/dto.rs
+++ b/src/plugins/behaviors/src/components/movement/dto.rs
@@ -1,0 +1,44 @@
+use crate::components::movement::Movement;
+use bevy::prelude::*;
+use common::{
+	errors::Unreachable,
+	traits::{handles_custom_assets::TryLoadFrom, thread_safe::ThreadSafe},
+};
+use serde::{Deserialize, Serialize};
+use std::marker::PhantomData;
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+pub struct MovementDto<TMovement>
+where
+	TMovement: ThreadSafe + Default,
+{
+	target: Vec3,
+	#[serde(skip)]
+	_p: PhantomData<TMovement>,
+}
+
+impl<TMovement> From<Movement<TMovement>> for MovementDto<TMovement>
+where
+	TMovement: ThreadSafe + Default,
+{
+	fn from(Movement { target, .. }: Movement<TMovement>) -> Self {
+		Self {
+			target,
+			_p: PhantomData,
+		}
+	}
+}
+
+impl<TMovement> TryLoadFrom<MovementDto<TMovement>> for Movement<TMovement>
+where
+	TMovement: ThreadSafe + Default,
+{
+	type TInstantiationError = Unreachable;
+
+	fn try_load_from<TLoadAsset>(
+		MovementDto { target, .. }: MovementDto<TMovement>,
+		_: &mut TLoadAsset,
+	) -> Result<Self, Self::TInstantiationError> {
+		Ok(Self::to(target))
+	}
+}

--- a/src/plugins/behaviors/src/components/movement/path_or_wasd.rs
+++ b/src/plugins/behaviors/src/components/movement/path_or_wasd.rs
@@ -33,7 +33,10 @@ impl<TMoveMethod> PathOrWasd<TMoveMethod> {
 	}
 }
 
-impl<TMoveMethod> Default for PathOrWasd<TMoveMethod> {
+impl<TMoveMethod> Default for PathOrWasd<TMoveMethod>
+where
+	TMoveMethod: ThreadSafe,
+{
 	fn default() -> Self {
 		Self {
 			mode: Mode::Path(VecDeque::default()),
@@ -42,7 +45,10 @@ impl<TMoveMethod> Default for PathOrWasd<TMoveMethod> {
 	}
 }
 
-impl<TMoveMethod> From<PointerInput> for Movement<PathOrWasd<TMoveMethod>> {
+impl<TMoveMethod> From<PointerInput> for Movement<PathOrWasd<TMoveMethod>>
+where
+	TMoveMethod: ThreadSafe,
+{
 	fn from(PointerInput(target): PointerInput) -> Self {
 		Self {
 			target,
@@ -51,7 +57,10 @@ impl<TMoveMethod> From<PointerInput> for Movement<PathOrWasd<TMoveMethod>> {
 	}
 }
 
-impl<TMoveMethod> From<WasdInput<TMoveMethod>> for Movement<PathOrWasd<TMoveMethod>> {
+impl<TMoveMethod> From<WasdInput<TMoveMethod>> for Movement<PathOrWasd<TMoveMethod>>
+where
+	TMoveMethod: ThreadSafe,
+{
 	fn from(WasdInput { target, .. }: WasdInput<TMoveMethod>) -> Self {
 		Self {
 			target,
@@ -62,7 +71,7 @@ impl<TMoveMethod> From<WasdInput<TMoveMethod>> for Movement<PathOrWasd<TMoveMeth
 
 impl<TMoveMethod> PathOrWasd<TMoveMethod>
 where
-	TMoveMethod: ThreadSafe,
+	TMoveMethod: ThreadSafe + Default,
 {
 	pub(crate) fn cleanup(
 		mut commands: Commands,
@@ -99,7 +108,10 @@ where
 	}
 }
 
-fn next_waypoint<TMoveMethod>(path_or_wasd: &mut PathOrWasd<TMoveMethod>) -> Option<Vec3> {
+fn next_waypoint<TMoveMethod>(path_or_wasd: &mut PathOrWasd<TMoveMethod>) -> Option<Vec3>
+where
+	TMoveMethod: ThreadSafe,
+{
 	match &mut path_or_wasd.mode {
 		Mode::Wasd(target) => target.take(),
 		Mode::Path(path) => path.pop_front(),

--- a/src/plugins/behaviors/src/input/wasd_input.rs
+++ b/src/plugins/behaviors/src/input/wasd_input.rs
@@ -8,7 +8,7 @@ use crate::{
 	traits::change_per_frame::MinDistance,
 };
 use bevy::prelude::*;
-use common::tools::speed::Speed;
+use common::{tools::speed::Speed, traits::thread_safe::ThreadSafe};
 use std::{marker::PhantomData, time::Duration};
 
 #[derive(Debug, PartialEq, Clone, Copy)]
@@ -37,7 +37,7 @@ where
 
 impl<TMethod> InputProcessComponent for WasdInput<TMethod>
 where
-	TMethod: 'static,
+	TMethod: ThreadSafe,
 {
 	type TComponent = Movement<PathOrWasd<TMethod>>;
 }

--- a/src/plugins/behaviors/src/lib.rs
+++ b/src/plugins/behaviors/src/lib.rs
@@ -171,6 +171,7 @@ where
 		TSaveGame::register_savable_component::<SkillContact>(app);
 		TSaveGame::register_savable_component::<SkillProjection>(app);
 		TSaveGame::register_savable_component::<OnCoolDown>(app);
+		TSaveGame::register_savable_component::<Movement<PathOrWasd<VelocityBased>>>(app);
 
 		let point_input = PointerInput::parse::<TPlayers::TCamRay, TSettings::TKeyMap<MovementKey>>;
 		let wasd_input = WasdInput::<VelocityBased>::parse::<

--- a/src/plugins/behaviors/src/systems/movement/compute_path.rs
+++ b/src/plugins/behaviors/src/systems/movement/compute_path.rs
@@ -31,7 +31,7 @@ pub(crate) trait MovementPath: Component + Getter<ColliderRadius> + Sized {
 		>,
 		computers: Query<&TComputer>,
 	) where
-		TMoveMethod: ThreadSafe,
+		TMoveMethod: ThreadSafe + Default,
 		TComputer: Component + ComputePath,
 	{
 		if movements.is_empty() {
@@ -59,6 +59,7 @@ fn new_movement<TAgent, TMoveMethod, TComputer>(
 where
 	TAgent: Getter<ColliderRadius>,
 	TComputer: ComputePath,
+	TMoveMethod: ThreadSafe,
 {
 	let mut new_movement = movement.new_movement();
 
@@ -83,6 +84,7 @@ fn compute_path<TAgent, TMoveMethod, TComputer>(
 where
 	TAgent: Getter<ColliderRadius>,
 	TComputer: ComputePath,
+	TMoveMethod: ThreadSafe,
 {
 	let start = transform.translation();
 	let end = movement.target;
@@ -110,7 +112,7 @@ mod test_new_path {
 	use mockall::{automock, predicate::eq};
 	use std::{collections::VecDeque, marker::PhantomData};
 
-	#[derive(Debug, PartialEq)]
+	#[derive(Debug, PartialEq, Default)]
 	struct _MoveMethod;
 
 	#[derive(Component, NestedMocks)]


### PR DESCRIPTION
Path path computation target is added to save game data.

On loading from save, path to target is recomputed and movement is executed accordingly.