### PR TITLE
Fix holding skills after save load

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,6 +194,7 @@ dependencies = [
  "common",
  "macros",
  "mockall",
+ "serde",
  "test-case",
  "tracing",
  "uuid",

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,12 +46,12 @@ fn prepare_game(app: &mut App) -> Result<(), ZyheedaAppError> {
 	};
 	let game_dir = home.join("Games").join("Project Zyheeda");
 
-	let animations = AnimationsPlugin;
 	let loading = LoadingPlugin;
 	let settings = SettingsPlugin::from_plugin(&loading);
 	let localization = LocalizationPlugin::from_plugin(&loading);
 	let game_state = GameStatePlugin::from_plugin(&loading);
 	let savegame = SavegamePlugin::from_plugin(&settings).with_game_directory(game_dir);
+	let animations = AnimationsPlugin::from_plugin(&savegame);
 	let light = LightPlugin::from_plugin(&savegame);
 	let life_cycles = LifeCyclesPlugin::from_plugin(&savegame);
 	let children_assets_dispatch = ChildrenAssetsDispatchPlugin::from_plugin(&loading);

--- a/src/plugins/animations/Cargo.toml
+++ b/src/plugins/animations/Cargo.toml
@@ -9,6 +9,7 @@ bevy.workspace = true
 bevy_rapier3d.workspace = true
 tracing.workspace = true
 uuid.workspace = true
+serde.workspace = true
 
 # itnernal
 common.workspace = true

--- a/src/plugins/animations/src/components/animation_dispatch.rs
+++ b/src/plugins/animations/src/components/animation_dispatch.rs
@@ -1,12 +1,18 @@
-use crate::traits::{
-	AnimationPlayers,
-	AnimationPlayersWithoutGraph,
-	GetActiveAnimations,
-	GetAllActiveAnimations,
+mod dto;
+
+use crate::{
+	components::animation_dispatch::dto::AnimationDispatchDto,
+	traits::{
+		AnimationPlayers,
+		AnimationPlayersWithoutGraph,
+		GetActiveAnimations,
+		GetAllActiveAnimations,
+	},
 };
 use bevy::prelude::*;
 use common::traits::{
 	animation::{Animation, AnimationPriority, StartAnimation, StopAnimation},
+	handles_saving::SavableComponent,
 	track::{IsTracking, Track, Untrack},
 };
 use std::{
@@ -18,7 +24,7 @@ use std::{
 	hash::Hash,
 };
 
-#[derive(Component, Debug, PartialEq)]
+#[derive(Component, Debug, PartialEq, Clone)]
 pub struct AnimationDispatch<TAnimation = Animation>
 where
 	TAnimation: Eq + Hash,
@@ -89,6 +95,10 @@ where
 			stack: default(),
 		}
 	}
+}
+
+impl SavableComponent for AnimationDispatch {
+	type TDto = AnimationDispatchDto;
 }
 
 impl Track<AnimationPlayer> for AnimationDispatch {

--- a/src/plugins/animations/src/components/animation_dispatch/dto.rs
+++ b/src/plugins/animations/src/components/animation_dispatch/dto.rs
@@ -1,0 +1,30 @@
+use crate::components::animation_dispatch::AnimationDispatch;
+use bevy::prelude::*;
+use common::{
+	errors::Unreachable,
+	traits::{animation::Animation, handles_custom_assets::TryLoadFrom},
+};
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct AnimationDispatchDto {
+	stack: (HashSet<Animation>, HashSet<Animation>, HashSet<Animation>),
+}
+
+impl From<AnimationDispatch> for AnimationDispatchDto {
+	fn from(AnimationDispatch { stack, .. }: AnimationDispatch) -> Self {
+		Self { stack }
+	}
+}
+
+impl TryLoadFrom<AnimationDispatchDto> for AnimationDispatch {
+	type TInstantiationError = Unreachable;
+
+	fn try_load_from<TLoadAsset>(
+		AnimationDispatchDto { stack }: AnimationDispatchDto,
+		_: &mut TLoadAsset,
+	) -> Result<Self, Self::TInstantiationError> {
+		Ok(Self { stack, ..default() })
+	}
+}

--- a/src/plugins/behaviors/src/components.rs
+++ b/src/plugins/behaviors/src/components.rs
@@ -13,6 +13,8 @@ use common::{
 	tools::UnitsPerSecond,
 	traits::{animation::Animation, handles_orientation::Face},
 };
+use macros::SavableComponent;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub(crate) struct Always;
@@ -20,7 +22,7 @@ pub(crate) struct Always;
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub(crate) struct Once;
 
-#[derive(Component, Debug, PartialEq)]
+#[derive(Component, SavableComponent, Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct OverrideFace(pub Face);
 
 #[derive(Component, Debug, PartialEq)]

--- a/src/plugins/behaviors/src/lib.rs
+++ b/src/plugins/behaviors/src/lib.rs
@@ -172,6 +172,7 @@ where
 		TSaveGame::register_savable_component::<SkillProjection>(app);
 		TSaveGame::register_savable_component::<OnCoolDown>(app);
 		TSaveGame::register_savable_component::<Movement<PathOrWasd<VelocityBased>>>(app);
+		TSaveGame::register_savable_component::<OverrideFace>(app);
 
 		let point_input = PointerInput::parse::<TPlayers::TCamRay, TSettings::TKeyMap<MovementKey>>;
 		let wasd_input = WasdInput::<VelocityBased>::parse::<

--- a/src/plugins/common/src/traits/animation.rs
+++ b/src/plugins/common/src/traits/animation.rs
@@ -1,5 +1,6 @@
 use super::{iteration::IterFinite, load_asset::Path};
 use bevy::{ecs::component::Mutable, prelude::*};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
@@ -42,7 +43,7 @@ pub enum AnimationMaskDefinition {
 	},
 }
 
-#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 pub enum AnimationAsset {
 	Path(Path),
 	Directional(Directional),
@@ -54,7 +55,7 @@ impl From<&'static str> for AnimationAsset {
 	}
 }
 
-#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 pub struct Directional {
 	pub forward: Path,
 	pub backward: Path,
@@ -89,13 +90,13 @@ pub trait RegisterAnimations: HasAnimationsDispatch {
 		TMovementDirection: Component + GetMovementDirection;
 }
 
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, Serialize, Deserialize)]
 pub enum PlayMode {
 	Replay,
 	Repeat,
 }
 
-#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 pub struct Animation {
 	pub asset: AnimationAsset,
 	pub play_mode: PlayMode,

--- a/src/plugins/common/src/traits/handles_orientation.rs
+++ b/src/plugins/common/src/traits/handles_orientation.rs
@@ -1,4 +1,6 @@
+use crate::components::persistent_entity::PersistentEntity;
 use bevy::prelude::*;
+use serde::{Deserialize, Serialize};
 
 pub trait HandlesOrientation {
 	type TFaceTemporarily: Component;
@@ -6,10 +8,10 @@ pub trait HandlesOrientation {
 	fn temporarily(face: Face) -> Self::TFaceTemporarily;
 }
 
-#[derive(Default, Debug, PartialEq, Clone, Copy)]
+#[derive(Default, Debug, PartialEq, Clone, Copy, Serialize, Deserialize)]
 pub enum Face {
 	#[default]
 	Cursor,
-	Entity(Entity),
+	Entity(PersistentEntity),
 	Translation(Vec3),
 }

--- a/src/plugins/skills/src/skills.rs
+++ b/src/plugins/skills/src/skills.rs
@@ -9,7 +9,7 @@ use crate::{
 		spawn_on::SpawnOn,
 	},
 	components::SkillTarget,
-	traits::{Matches, Prime, spawn_skill_behavior::SpawnSkillBehavior},
+	traits::{Prime, spawn_skill_behavior::SpawnSkillBehavior},
 };
 use bevy::prelude::*;
 use common::{
@@ -150,23 +150,13 @@ impl InspectAble<SkillIcon> for QueuedSkill {
 
 impl Prime for QueuedSkill {
 	fn prime(&mut self) {
-		if self.mode != Activation::Waiting {
-			return;
-		}
 		self.mode = Activation::Primed;
-	}
-}
-
-impl Matches<SlotKey> for QueuedSkill {
-	fn matches(&self, slot_key: &SlotKey) -> bool {
-		&self.slot_key == slot_key
 	}
 }
 
 #[cfg(test)]
 mod test_queued {
 	use super::*;
-	use bevy::utils::default;
 
 	#[test]
 	fn prime_skill() {
@@ -178,21 +168,6 @@ mod test_queued {
 		queued.prime();
 
 		assert_eq!(Activation::Primed, queued.mode);
-	}
-
-	#[test]
-	fn do_not_prime_active() {
-		let mut queued = QueuedSkill {
-			skill: Skill::default(),
-			mode: Activation::ActiveAfter(Duration::from_millis(123)),
-			..default()
-		};
-		queued.prime();
-
-		assert_eq!(
-			Activation::ActiveAfter(Duration::from_millis(123)),
-			queued.mode
-		);
 	}
 }
 

--- a/src/plugins/skills/src/systems/get_inputs.rs
+++ b/src/plugins/skills/src/systems/get_inputs.rs
@@ -9,7 +9,6 @@ use common::{
 pub(crate) struct Input {
 	pub just_pressed: Vec<SlotKey>,
 	pub pressed: Vec<SlotKey>,
-	pub just_released: Vec<SlotKey>,
 }
 
 pub(crate) fn get_inputs<
@@ -22,7 +21,6 @@ pub(crate) fn get_inputs<
 	Input {
 		just_pressed: input.just_pressed_slots(&key_map),
 		pressed: input.pressed_slots(&key_map),
-		just_released: input.just_released_slots(&key_map),
 	}
 }
 
@@ -62,9 +60,6 @@ mod tests {
 		fn pressed_slots(&self, map: &_Map) -> Vec<SlotKey> {
 			self.mock.pressed_slots(map)
 		}
-		fn just_released_slots(&self, map: &_Map) -> Vec<SlotKey> {
-			self.mock.just_released_slots(map)
-		}
 	}
 
 	fn setup(input: _Input, map: _Map) -> App {
@@ -90,9 +85,6 @@ mod tests {
 					.return_const(vec![SlotKey::BottomHand(Side::Right)]);
 				mock.expect_pressed_slots()
 					.times(1)
-					.return_const(vec![SlotKey::BottomHand(Side::Right)]);
-				mock.expect_just_released_slots()
-					.times(1)
 					.return_const(vec![SlotKey::BottomHand(Side::Left)]);
 			}),
 			_Map,
@@ -105,8 +97,7 @@ mod tests {
 		assert_eq!(
 			&_Result(Input {
 				just_pressed: vec![SlotKey::BottomHand(Side::Right)],
-				pressed: vec![SlotKey::BottomHand(Side::Right)],
-				just_released: vec![SlotKey::BottomHand(Side::Left)],
+				pressed: vec![SlotKey::BottomHand(Side::Left)],
 			}),
 			result
 		);

--- a/src/plugins/skills/src/traits.rs
+++ b/src/plugins/skills/src/traits.rs
@@ -26,16 +26,12 @@ pub(crate) trait Enqueue<TItem> {
 	fn enqueue(&mut self, item: TItem);
 }
 
-pub(crate) trait Matches<T> {
-	fn matches(&self, value: &T) -> bool;
-}
-
 pub(crate) trait Flush {
 	fn flush(&mut self);
 }
 
-pub(crate) trait IterMut<TItem> {
-	fn iter_mut<'a>(&'a mut self) -> impl DoubleEndedIterator<Item = &'a mut TItem>
+pub(crate) trait IterWaitingMut<TItem> {
+	fn iter_waiting_mut<'a>(&'a mut self) -> impl Iterator<Item = &'a mut TItem>
 	where
 		TItem: 'a;
 }
@@ -103,7 +99,6 @@ where
 {
 	fn just_pressed_slots(&self, map: &TMap) -> Vec<SlotKey>;
 	fn pressed_slots(&self, map: &TMap) -> Vec<SlotKey>;
-	fn just_released_slots(&self, map: &TMap) -> Vec<SlotKey>;
 }
 
 pub trait Schedule<TBehavior> {

--- a/src/plugins/skills/src/traits/user_input.rs
+++ b/src/plugins/skills/src/traits/user_input.rs
@@ -20,12 +20,6 @@ where
 			.filter_map(|k| map.try_get_action(*k))
 			.collect()
 	}
-
-	fn just_released_slots(&self, map: &TMap) -> Vec<SlotKey> {
-		self.get_just_released()
-			.filter_map(|k| map.try_get_action(*k))
-			.collect()
-	}
 }
 
 #[cfg(test)]
@@ -80,27 +74,6 @@ mod tests {
 				SlotKey::BottomHand(Side::Left),
 			]),
 			HashSet::from_iter(input.pressed_slots(&_Map)),
-		)
-	}
-
-	#[test]
-	fn get_just_released() {
-		let mut input = ButtonInput::<UserInput>::default();
-		input.press(UserInput::from(KeyCode::KeyA));
-		input.press(UserInput::from(KeyCode::KeyB));
-		input.press(UserInput::from(KeyCode::KeyC));
-		input.press(UserInput::from(KeyCode::KeyD));
-		input.release(UserInput::from(KeyCode::KeyA));
-		input.release(UserInput::from(KeyCode::KeyB));
-		input.release(UserInput::from(KeyCode::KeyC));
-		input.clear_just_pressed(UserInput::from(KeyCode::KeyA));
-		input.clear_just_pressed(UserInput::from(KeyCode::KeyB));
-		input.clear_just_pressed(UserInput::from(KeyCode::KeyC));
-		input.clear_just_pressed(UserInput::from(KeyCode::KeyD));
-
-		assert_eq!(
-			HashSet::from([SlotKey::BottomHand(Side::Right),]),
-			HashSet::from_iter(input.just_released_slots(&_Map)),
 		)
 	}
 }


### PR DESCRIPTION
Fixes:
- waiting skills are properly primed when not pressing corresponding key when loading a save game
- saving `OverrideFace` to properly apply facing when loading a save game
- saving `AnimationDispatch` to properly apply running animations on time of saving (they start playing from the beginning, but that should be fine)