### PR TITLE
`SavableComponent` behaves like typical rust derives

### DIFF
--- a/src/plugins/animations/Cargo.toml
+++ b/src/plugins/animations/Cargo.toml
@@ -11,8 +11,9 @@ tracing.workspace = true
 uuid.workspace = true
 serde.workspace = true
 
-# itnernal
+# internal
 common.workspace = true
+macros.workspace = true
 
 [dev-dependencies]
 # external

--- a/src/plugins/animations/src/components/animation_dispatch.rs
+++ b/src/plugins/animations/src/components/animation_dispatch.rs
@@ -19,10 +19,10 @@ use common::traits::{
 		StartAnimation,
 		StopAnimation,
 	},
-	handles_saving::SavableComponent,
 	register_derived_component::{DerivableComponentFrom, InsertDerivedComponent},
 	track::{IsTracking, Track, Untrack},
 };
+use macros::SavableComponent;
 use std::{
 	collections::{
 		HashSet,
@@ -32,7 +32,8 @@ use std::{
 	hash::Hash,
 };
 
-#[derive(Component, Debug, PartialEq, Clone)]
+#[derive(Component, SavableComponent, Debug, PartialEq, Clone)]
+#[savable_component(dto = AnimationDispatchDto)]
 pub struct AnimationDispatch<TAnimation = Animation>
 where
 	TAnimation: Eq + Hash,
@@ -111,10 +112,6 @@ where
 			stack: default(),
 		}
 	}
-}
-
-impl SavableComponent for AnimationDispatch {
-	type TDto = AnimationDispatchDto;
 }
 
 impl<TComponent> From<&TComponent> for AnimationDispatch

--- a/src/plugins/skills/src/components/combos.rs
+++ b/src/plugins/skills/src/components/combos.rs
@@ -22,15 +22,13 @@ use common::{
 		action_key::slot::{Combo, SlotKey},
 		item_type::ItemType,
 	},
-	traits::{
-		handles_combo_menu::GetCombosOrdered,
-		handles_saving::SavableComponent,
-		iterate::Iterate,
-	},
+	traits::{handles_combo_menu::GetCombosOrdered, iterate::Iterate},
 };
+use macros::SavableComponent;
 use std::collections::VecDeque;
 
-#[derive(Component, PartialEq, Debug, Clone)]
+#[derive(Component, SavableComponent, PartialEq, Debug, Clone)]
+#[savable_component(dto = CombosDto)]
 pub struct Combos<TComboNode = ComboNode> {
 	config: TComboNode,
 	current: Option<TComboNode>,
@@ -170,10 +168,6 @@ where
 	{
 		self.config.followup_keys(after)
 	}
-}
-
-impl SavableComponent for Combos {
-	type TDto = CombosDto;
 }
 
 #[cfg(test)]

--- a/src/plugins/skills/src/components/skill_executer.rs
+++ b/src/plugins/skills/src/components/skill_executer.rs
@@ -1,10 +1,9 @@
-pub(crate) mod dto;
+mod dto;
 
 use super::SkillTarget;
 use crate::{
-	SkillExecuterDto,
 	behaviors::{SkillCaster, build_skill_shape::OnSkillStop, spawn_on::SpawnOn},
-	skills::RunSkillBehavior,
+	skills::{RunSkillBehavior, dto::run_skill_behavior::RunSkillBehaviorDto},
 	traits::{Execute, Flush, Schedule, spawn_skill_behavior::SpawnSkillBehavior},
 };
 use bevy::prelude::*;
@@ -14,14 +13,15 @@ use common::{
 	traits::{
 		handles_effect::HandlesAllEffects,
 		handles_lifetime::HandlesLifetime,
-		handles_saving::SavableComponent,
 		handles_skill_behaviors::{HandlesSkillBehaviors, Spawner},
 		try_despawn::TryDespawnPersistent,
 	},
 };
+use macros::SavableComponent;
 use serde::{Deserialize, Serialize};
 
-#[derive(Component, Debug, PartialEq, Default, Clone, Serialize, Deserialize)]
+#[derive(Component, SavableComponent, Debug, PartialEq, Default, Clone, Serialize, Deserialize)]
+#[savable_component(dto = SkillExecuter<RunSkillBehaviorDto>)]
 pub(crate) enum SkillExecuter<TSkillBehavior = RunSkillBehavior> {
 	#[default]
 	Idle,
@@ -54,10 +54,6 @@ impl<TBehavior> Flush for SkillExecuter<TBehavior> {
 			_ => {}
 		}
 	}
-}
-
-impl SavableComponent for SkillExecuter {
-	type TDto = SkillExecuterDto;
 }
 
 impl<TCommands, TBehavior, TLifetimes, TEffects, TSkillBehavior>

--- a/src/plugins/skills/src/components/skill_executer/dto.rs
+++ b/src/plugins/skills/src/components/skill_executer/dto.rs
@@ -6,9 +6,8 @@ use common::{
 	errors::Unreachable,
 	traits::{handles_custom_assets::TryLoadFrom, load_asset::LoadAsset},
 };
-pub(crate) type SkillExecuterDto = SkillExecuter<RunSkillBehaviorDto>;
 
-impl From<SkillExecuter> for SkillExecuterDto {
+impl From<SkillExecuter> for SkillExecuter<RunSkillBehaviorDto> {
 	fn from(value: SkillExecuter) -> Self {
 		match value {
 			SkillExecuter::Idle => Self::Idle,
@@ -24,26 +23,26 @@ impl From<SkillExecuter> for SkillExecuterDto {
 	}
 }
 
-impl TryLoadFrom<SkillExecuterDto> for SkillExecuter {
+impl TryLoadFrom<SkillExecuter<RunSkillBehaviorDto>> for SkillExecuter {
 	type TInstantiationError = Unreachable;
 
 	fn try_load_from<TLoadAsset>(
-		value: SkillExecuterDto,
+		value: SkillExecuter<RunSkillBehaviorDto>,
 		_: &mut TLoadAsset,
 	) -> Result<Self, Self::TInstantiationError>
 	where
 		TLoadAsset: LoadAsset,
 	{
 		let executer = match value {
-			SkillExecuterDto::Idle => Self::Idle,
-			SkillExecuterDto::Start { slot_key, shape } => Self::Start {
+			SkillExecuter::Idle => Self::Idle,
+			SkillExecuter::Start { slot_key, shape } => Self::Start {
 				slot_key,
 				shape: RunSkillBehavior::from(shape),
 			},
-			SkillExecuterDto::StartedStoppable(persistent_entity) => {
+			SkillExecuter::StartedStoppable(persistent_entity) => {
 				Self::StartedStoppable(persistent_entity)
 			}
-			SkillExecuterDto::Stop(persistent_entity) => Self::Stop(persistent_entity),
+			SkillExecuter::Stop(persistent_entity) => Self::Stop(persistent_entity),
 		};
 
 		Ok(executer)
@@ -90,7 +89,7 @@ mod tests {
 	#[test_case(SkillExecuter::StartedStoppable(PersistentEntity::default()); "started stoppable")]
 	#[test_case(SkillExecuter::Stop(PersistentEntity::default()); "stop")]
 	fn roundtrip_survives(original: SkillExecuter) {
-		let dto = SkillExecuterDto::from(original.clone());
+		let dto = SkillExecuter::<RunSkillBehaviorDto>::from(original.clone());
 		let Ok(restored) = SkillExecuter::try_load_from(dto, &mut _LoadAsset);
 		assert_eq!(original, restored);
 	}

--- a/src/plugins/skills/src/lib.rs
+++ b/src/plugins/skills/src/lib.rs
@@ -12,7 +12,6 @@ use crate::components::{
 	combos_time_out::dto::CombosTimeOutDto,
 	loadout::Loadout,
 	queue::dto::QueueDto,
-	skill_executer::dto::SkillExecuterDto,
 };
 use bevy::prelude::*;
 use common::{


### PR DESCRIPTION
Now we can derive `SavableComponent` on types involving generics. If certain constraints are not satisfied, the compiler will complain on trait usage, not on derive declaration.