### PR TITLE
Fix player movement on load

### DIFF
--- a/src/plugins/behaviors/src/lib.rs
+++ b/src/plugins/behaviors/src/lib.rs
@@ -274,12 +274,8 @@ where
 				)
 					.chain()
 					.in_set(BehaviorSystems)
-					/* FIXME: `.before()` should synch facing and animation weights, but for some reason it
-					 *         doesn't. Using `.after()` might cause a one frame delay here, but seems to
-					 *         ensure that animation weights are computed off of correct look direction after
-					 *         applying transform facing.
-					 */
 					.after(TAnimations::SYSTEMS)
+					.after(TPathFinding::SYSTEMS)
 					.run_if(in_state(GameState::Play)),
 			);
 	}

--- a/src/plugins/behaviors/src/systems/movement/compute_path.rs
+++ b/src/plugins/behaviors/src/systems/movement/compute_path.rs
@@ -14,21 +14,21 @@ use std::collections::VecDeque;
 
 impl<T> MovementPath for T where T: Component + Getter<ColliderRadius> + Sized {}
 
-type PathOrWasdMovement<TMoveMethod> = Movement<PathOrWasd<TMoveMethod>>;
 type Components<'a, TMoveMethod, TAgent, TGetComputer> = (
 	Entity,
 	&'a GlobalTransform,
-	&'a PathOrWasdMovement<TMoveMethod>,
+	&'a Movement<PathOrWasd<TMoveMethod>>,
 	&'a TAgent,
 	&'a TGetComputer,
 );
 
 pub(crate) trait MovementPath: Component + Getter<ColliderRadius> + Sized {
+	#[allow(clippy::type_complexity)]
 	fn compute_path<TMoveMethod, TComputer, TGetComputer>(
 		mut commands: Commands,
 		mut movements: Query<
 			Components<TMoveMethod, Self, TGetComputer>,
-			Changed<PathOrWasdMovement<TMoveMethod>>,
+			Changed<Movement<PathOrWasd<TMoveMethod>>>,
 		>,
 		computers: Query<&TComputer>,
 	) where

--- a/src/plugins/behaviors/src/systems/movement/compute_path.rs
+++ b/src/plugins/behaviors/src/systems/movement/compute_path.rs
@@ -17,19 +17,15 @@ impl<T> MovementPath for T where T: Component + Getter<ColliderRadius> + Sized {
 type Components<'a, TMoveMethod, TAgent, TGetComputer> = (
 	Entity,
 	&'a GlobalTransform,
-	&'a Movement<PathOrWasd<TMoveMethod>>,
 	&'a TAgent,
-	&'a TGetComputer,
+	Ref<'a, Movement<PathOrWasd<TMoveMethod>>>,
+	Ref<'a, TGetComputer>,
 );
 
 pub(crate) trait MovementPath: Component + Getter<ColliderRadius> + Sized {
-	#[allow(clippy::type_complexity)]
 	fn compute_path<TMoveMethod, TComputer, TGetComputer>(
 		mut commands: Commands,
-		mut movements: Query<
-			Components<TMoveMethod, Self, TGetComputer>,
-			Changed<Movement<PathOrWasd<TMoveMethod>>>,
-		>,
+		mut movements: Query<Components<TMoveMethod, Self, TGetComputer>>,
 		computers: Query<&TComputer>,
 	) where
 		TMoveMethod: ThreadSafe + Default,
@@ -40,14 +36,17 @@ pub(crate) trait MovementPath: Component + Getter<ColliderRadius> + Sized {
 			return;
 		}
 
-		for (entity, transform, movement, agent, get_computer) in &mut movements {
+		for (entity, transform, agent, movement, get_computer) in &mut movements {
+			if !movement.is_changed() && !get_computer.is_changed() {
+				continue;
+			}
 			let Computer::Entity(computer) = get_computer.get() else {
 				continue;
 			};
 			let Ok(computer) = computers.get(computer) else {
 				continue;
 			};
-			let move_component = new_movement(computer, transform, movement, agent);
+			let move_component = new_movement(computer, transform, movement.as_ref(), agent);
 			commands.try_insert_on(entity, move_component);
 			commands.try_remove_from::<Movement<TMoveMethod>>(entity);
 		}
@@ -442,6 +441,34 @@ mod test_new_path {
 			_GetComputer(Computer::None),
 		));
 
+		app.update();
+	}
+
+	#[test]
+	fn compute_again_if_computer_reference_changed() {
+		let mut app = setup();
+
+		let computer = app
+			.world_mut()
+			.spawn(_ComputePath::new().with_mock(|mock| {
+				mock.expect_compute_path().times(2).return_const(None);
+			}))
+			.id();
+		let entity = app
+			.world_mut()
+			.spawn((
+				_AgentMovement::default(),
+				Movement::new(Vec3::new(4., 5., 6.), PathOrWasd::<_MoveMethod>::new_path),
+				GlobalTransform::from_xyz(1., 2., 3.),
+				_GetComputer(Computer::Entity(computer)),
+			))
+			.id();
+
+		app.update();
+		app.world_mut()
+			.entity_mut(entity)
+			.get_mut::<_GetComputer>()
+			.as_deref_mut();
 		app.update();
 	}
 }

--- a/src/plugins/common/src/traits/handles_map_generation.rs
+++ b/src/plugins/common/src/traits/handles_map_generation.rs
@@ -3,15 +3,13 @@ use crate::{tools::Units, traits::accessors::get::Getter};
 use bevy::prelude::*;
 use std::hash::Hash;
 
-pub trait HandlesMapGeneration
-where
-	Self::TMap: Component,
-	Self::TMapAgent: Component + Getter<Map> + Default,
-	for<'a> Self::TGraph: Graph + From<&'a Self::TMap> + ThreadSafe,
-{
-	type TMap;
-	type TMapAgent;
-	type TGraph;
+pub trait HandlesMapGeneration {
+	type TMap: Component;
+	type TMapAgent: Component + Getter<Map> + Default;
+	type TGraph: Graph + for<'a> From<&'a Self::TMap> + ThreadSafe;
+	type TSystemSet: SystemSet;
+
+	const SYSTEMS: Self::TSystemSet;
 }
 
 pub trait Graph:

--- a/src/plugins/common/src/traits/handles_path_finding.rs
+++ b/src/plugins/common/src/traits/handles_path_finding.rs
@@ -10,6 +10,9 @@ use bevy::prelude::*;
 pub trait HandlesPathFinding {
 	type TComputePath: Component + ComputePath;
 	type TPathAgent: Component + Default + Getter<Computer>;
+	type TSystemSet: SystemSet;
+
+	const SYSTEMS: Self::TSystemSet;
 }
 
 pub trait ComputePath {

--- a/src/plugins/map_generation/src/lib.rs
+++ b/src/plugins/map_generation/src/lib.rs
@@ -54,25 +54,29 @@ where
 		app.register_map_cell::<TLoading, TSavegame, Corridor>()
 			.register_derived_component::<Grid, Collider>()
 			.add_systems(OnEnter(GameState::NewGame), DemoMap::spawn)
-			.add_systems(
-				PreUpdate,
-				GetGrid::update::<Changed<GlobalTransform>>.run_if(in_state(GameState::Play)),
-			)
 			.add_systems(Update, Grid::<1>::insert)
 			.add_systems(
 				Update,
 				(
+					GetGrid::update::<Changed<GlobalTransform>>.run_if(in_state(GameState::Play)),
 					WallBack::apply_extra_components::<TLights>,
 					WallLight::apply_extra_components::<TLights>,
 					FloorLight::apply_extra_components::<TLights>,
-				),
+				)
+					.in_set(Self::SYSTEMS),
 			)
 			.add_systems(Update, unlit_material);
 	}
 }
 
+#[derive(SystemSet, Debug, PartialEq, Eq, Hash, Clone)]
+pub struct MapSystems;
+
 impl<TDependencies> HandlesMapGeneration for MapGenerationPlugin<TDependencies> {
 	type TMap = Grid<1>;
 	type TMapAgent = GetGrid;
 	type TGraph = GridGraph;
+	type TSystemSet = MapSystems;
+
+	const SYSTEMS: Self::TSystemSet = MapSystems;
 }

--- a/src/plugins/path_finding/src/lib.rs
+++ b/src/plugins/path_finding/src/lib.rs
@@ -41,4 +41,7 @@ where
 {
 	type TComputePath = Navigation<ThetaStar, TMaps::TGraph>;
 	type TPathAgent = TMaps::TMapAgent;
+	type TSystemSet = TMaps::TSystemSet;
+
+	const SYSTEMS: Self::TSystemSet = TMaps::SYSTEMS;
 }


### PR DESCRIPTION
We now:
- have proper system execution order between map generation, path finding and behavior systems
- update path generation on changing pointer to map (recompute also when previous pointer was invalid)

The first point already fixes the bug, because movement was not computed on load (we had no valid pointer to map) , but the second makes path finding more robust, so it doesn't need to rely on a fixed system execution order.