### PR TITLE
Tooltip requires interaction

### DIFF
--- a/src/plugins/menu/src/components.rs
+++ b/src/plugins/menu/src/components.rs
@@ -59,5 +59,5 @@ pub(crate) struct DeleteSkill {
 #[derive(Component, Debug, PartialEq)]
 pub(crate) struct ImageColorCommand(pub(crate) Color);
 
-#[derive(Component, Debug, PartialEq)]
+#[derive(Component, Debug, PartialEq, Default)]
 pub(crate) struct GlobalZIndexTop;

--- a/src/plugins/menu/src/systems/tooltip.rs
+++ b/src/plugins/menu/src/systems/tooltip.rs
@@ -1,5 +1,5 @@
 use crate::{
-	components::tooltip::{Tooltip, TooltipUiConfig},
+	components::tooltip::Tooltip,
 	traits::{
 		insert_ui_content::InsertUiContent,
 		tooltip_ui_control::{
@@ -11,7 +11,11 @@ use crate::{
 	},
 };
 use bevy::prelude::*;
-use common::traits::{handles_localization::LocalizeToken, mouse_position::MousePosition};
+use common::traits::{
+	handles_localization::LocalizeToken,
+	mouse_position::MousePosition,
+	thread_safe::ThreadSafe,
+};
 
 pub(crate) fn tooltip<T, TLocalization, TUI, TUIControl, TWindow>(
 	mut commands: Commands,
@@ -22,7 +26,7 @@ pub(crate) fn tooltip<T, TLocalization, TUI, TUIControl, TWindow>(
 	mut tooltip_uis: Query<(Entity, &TUI, &mut Node)>,
 	removed_tooltips: RemovedComponents<Tooltip<T>>,
 ) where
-	T: TooltipUiConfig + Sync + Send + 'static,
+	T: ThreadSafe,
 	TLocalization: LocalizeToken + Resource,
 	Tooltip<T>: InsertUiContent,
 	TUI: Component,
@@ -55,9 +59,7 @@ pub(crate) fn tooltip<T, TLocalization, TUI, TUIControl, TWindow>(
 	}
 }
 
-fn is_hovering<T: TooltipUiConfig + Sync + Send + 'static>(
-	(.., interaction): &(Entity, &Tooltip<T>, &Interaction),
-) -> bool {
+fn is_hovering<T>((.., interaction): &(Entity, &Tooltip<T>, &Interaction)) -> bool {
 	interaction == &&Interaction::Hovered
 }
 

--- a/src/plugins/menu/src/systems/tooltip_visibility.rs
+++ b/src/plugins/menu/src/systems/tooltip_visibility.rs
@@ -1,14 +1,15 @@
-use crate::components::tooltip::TooltipUI;
+use crate::components::tooltip::{TooltipContent, TooltipUiConfig};
 use bevy::{ecs::system::Res, prelude::Query, render::view::Visibility, time::Time};
+use common::traits::thread_safe::ThreadSafe;
 use std::time::Duration;
 
-pub(crate) fn tooltip_visibility<
-	TTime: Send + Sync + 'static + Default,
-	T: Send + Sync + 'static,
->(
-	mut uis: Query<(&mut TooltipUI<T>, &mut Visibility)>,
+pub(crate) fn tooltip_visibility<TTime, T>(
+	mut uis: Query<(&mut TooltipContent<T>, &mut Visibility)>,
 	time: Res<Time<TTime>>,
-) {
+) where
+	TTime: ThreadSafe + Default,
+	T: TooltipUiConfig + ThreadSafe,
+{
 	let delta = time.delta();
 
 	for (mut ui, mut visibility) in &mut uis {
@@ -47,7 +48,7 @@ mod tests {
 		let tooltip_ui = app
 			.world_mut()
 			.spawn((
-				TooltipUI::<()>::new(Entity::from_raw(42), Duration::from_millis(100)),
+				TooltipContent::<()>::new(Entity::from_raw(42), Duration::from_millis(100)),
 				Visibility::Hidden,
 			))
 			.id();
@@ -66,7 +67,7 @@ mod tests {
 		let tooltip_ui = app
 			.world_mut()
 			.spawn((
-				TooltipUI::<()>::new(Entity::from_raw(42), Duration::from_millis(10)),
+				TooltipContent::<()>::new(Entity::from_raw(42), Duration::from_millis(10)),
 				Visibility::Hidden,
 			))
 			.id();
@@ -85,7 +86,7 @@ mod tests {
 		let tooltip_ui = app
 			.world_mut()
 			.spawn((
-				TooltipUI::<()>::new(Entity::from_raw(42), Duration::from_millis(1000)),
+				TooltipContent::<()>::new(Entity::from_raw(42), Duration::from_millis(1000)),
 				Visibility::Hidden,
 			))
 			.id();
@@ -107,7 +108,7 @@ mod tests {
 		let tooltip_ui = app
 			.world_mut()
 			.spawn((
-				TooltipUI::<()>::new(Entity::from_raw(42), Duration::from_millis(10)),
+				TooltipContent::<()>::new(Entity::from_raw(42), Duration::from_millis(10)),
 				Visibility::Hidden,
 			))
 			.id();
@@ -118,8 +119,11 @@ mod tests {
 		let tooltip_ui = app.world().entity(tooltip_ui);
 
 		assert_eq!(
-			Some(&TooltipUI::<()>::new(Entity::from_raw(42), Duration::ZERO)),
-			tooltip_ui.get::<TooltipUI<()>>()
+			Some(&TooltipContent::<()>::new(
+				Entity::from_raw(42),
+				Duration::ZERO
+			)),
+			tooltip_ui.get::<TooltipContent<()>>()
 		);
 	}
 }

--- a/src/plugins/menu/src/traits/add_tooltip.rs
+++ b/src/plugins/menu/src/traits/add_tooltip.rs
@@ -1,3 +1,4 @@
+use super::insert_ui_content::InsertUiContent;
 use crate::{
 	Tooltip,
 	TooltipUIControl,
@@ -5,14 +6,12 @@ use crate::{
 	systems::{tooltip::tooltip, tooltip_visibility::tooltip_visibility},
 };
 use bevy::prelude::*;
-use common::traits::handles_localization::LocalizeToken;
-
-use super::insert_ui_content::InsertUiContent;
+use common::traits::{handles_localization::LocalizeToken, thread_safe::ThreadSafe};
 
 pub(crate) trait AddTooltip {
 	fn add_tooltip<TLocalization, T>(&mut self) -> &mut Self
 	where
-		T: TooltipUiConfig + Clone + Sync + Send + 'static,
+		T: TooltipUiConfig + ThreadSafe,
 		Tooltip<T>: InsertUiContent,
 		TLocalization: LocalizeToken + Resource;
 }
@@ -20,7 +19,7 @@ pub(crate) trait AddTooltip {
 impl AddTooltip for App {
 	fn add_tooltip<TLocalization, T>(&mut self) -> &mut Self
 	where
-		T: TooltipUiConfig + Clone + Sync + Send + 'static,
+		T: TooltipUiConfig + ThreadSafe,
 		Tooltip<T>: InsertUiContent,
 		TLocalization: LocalizeToken + Resource,
 	{

--- a/src/plugins/menu/src/traits/add_tooltip.rs
+++ b/src/plugins/menu/src/traits/add_tooltip.rs
@@ -1,7 +1,7 @@
 use crate::{
 	Tooltip,
 	TooltipUIControl,
-	components::tooltip::{TooltipUI, TooltipUiConfig},
+	components::tooltip::{TooltipContent, TooltipUiConfig},
 	systems::{tooltip::tooltip, tooltip_visibility::tooltip_visibility},
 };
 use bevy::prelude::*;
@@ -27,7 +27,7 @@ impl AddTooltip for App {
 		self.add_systems(
 			Update,
 			(
-				tooltip::<T, TLocalization, TooltipUI<T>, TooltipUIControl, Window>,
+				tooltip::<T, TLocalization, TooltipContent<T>, TooltipUIControl, Window>,
 				tooltip_visibility::<Real, T>,
 			),
 		)

--- a/src/plugins/menu/src/traits/tooltip_ui_control.rs
+++ b/src/plugins/menu/src/traits/tooltip_ui_control.rs
@@ -1,5 +1,5 @@
 use super::insert_ui_content::InsertUiContent;
-use crate::components::tooltip::{Tooltip, TooltipUiConfig};
+use crate::components::tooltip::Tooltip;
 use bevy::prelude::*;
 use common::traits::{handles_localization::LocalizeToken, thread_safe::ThreadSafe};
 
@@ -11,7 +11,7 @@ pub(crate) trait DespawnAllTooltips<TUI> {
 
 pub(crate) trait DespawnOutdatedTooltips<TUI, T>
 where
-	T: TooltipUiConfig + Send + Sync + 'static,
+	T: ThreadSafe,
 {
 	fn despawn_outdated(
 		&self,
@@ -30,7 +30,6 @@ pub(crate) trait UpdateTooltipPosition<TUI> {
 
 pub(crate) trait SpawnTooltips<T, TLocalization>
 where
-	T: TooltipUiConfig,
 	TLocalization: LocalizeToken + ThreadSafe,
 {
 	fn spawn(

--- a/src/plugins/menu/src/traits/tooltip_ui_control.rs
+++ b/src/plugins/menu/src/traits/tooltip_ui_control.rs
@@ -4,8 +4,11 @@ use bevy::prelude::*;
 use common::traits::{handles_localization::LocalizeToken, thread_safe::ThreadSafe};
 
 pub(crate) trait DespawnAllTooltips<TUI> {
-	fn despawn_all(&self, uis: &Query<(Entity, &TUI, &mut Node)>, commands: &mut Commands)
-	where
+	fn despawn_all(
+		&self,
+		uis: &Query<(Entity, &TUI, &mut Node, &ComputedNode)>,
+		commands: &mut Commands,
+	) where
 		TUI: Component + Sized;
 }
 
@@ -15,7 +18,7 @@ where
 {
 	fn despawn_outdated(
 		&self,
-		uis: &Query<(Entity, &TUI, &mut Node)>,
+		uis: &Query<(Entity, &TUI, &mut Node, &ComputedNode)>,
 		commands: &mut Commands,
 		outdated_tooltips: RemovedComponents<Tooltip<T>>,
 	) where
@@ -23,10 +26,16 @@ where
 }
 
 pub(crate) trait UpdateTooltipPosition<TUI> {
-	fn update_position(&self, uis: &mut Query<(Entity, &TUI, &mut Node)>, position: Vec2)
-	where
+	fn update_position(
+		&self,
+		uis: &mut Query<(Entity, &TUI, &mut Node, &ComputedNode)>,
+		position: MouseVec2,
+	) where
 		TUI: Component + Sized;
 }
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub(crate) struct MouseVec2(pub(crate) Vec2);
 
 pub(crate) trait SpawnTooltips<T, TLocalization>
 where
@@ -38,7 +47,6 @@ where
 		localize: &mut TLocalization,
 		tooltip_entity: Entity,
 		tooltip: &Tooltip<T>,
-		position: Vec2,
 	) where
 		Tooltip<T>: InsertUiContent;
 }


### PR DESCRIPTION
`Tooltip`s now require `Interaction`. Other requirements have been moved to `TooltipContent`. We also no longer copy the tooltip onto the node where the tooltip content is being rendered. This would cause the original tooltip not being hovered any longer (because the child with the content is hovered now), thus immediately despawning the content of the now "untriggered" tooltip.