### PR TITLE
spawn `VoidBeam` with separate `Lifetime` component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2349,6 +2349,7 @@ dependencies = [
  "common",
  "macros",
  "serde",
+ "testing",
 ]
 
 [[package]]

--- a/src/plugins/common/src/traits/handles_interactions.rs
+++ b/src/plugins/common/src/traits/handles_interactions.rs
@@ -1,6 +1,5 @@
 use crate::{blocker::Blocker, components::persistent_entity::PersistentEntity, tools::Units};
 use bevy::prelude::*;
-use std::time::Duration;
 
 pub trait HandlesInteractions {
 	type TSystems: SystemSet;
@@ -24,5 +23,4 @@ pub trait BeamParameters {
 	fn source(&self) -> PersistentEntity;
 	fn target(&self) -> PersistentEntity;
 	fn range(&self) -> Units;
-	fn lifetime(&self) -> Duration;
 }

--- a/src/plugins/enemy/Cargo.toml
+++ b/src/plugins/enemy/Cargo.toml
@@ -12,3 +12,7 @@ serde.workspace = true
 # internal
 common.workspace = true
 macros.workspace = true
+
+[dev-dependencies]
+# internal
+testing.workspace = true


### PR DESCRIPTION
The lifetime is not stored in `VoidBeam` any more but instead is stored in the `Lifetime` component. This allows the updated lifetime (after beam lived for some time) to be saved/loaded.