### PR TITLE
After load map navigation bug

### DIFF
--- a/src/plugins/map_generation/src/components/map.rs
+++ b/src/plugins/map_generation/src/components/map.rs
@@ -6,6 +6,8 @@ pub(crate) mod grid_graph;
 pub(crate) mod image;
 
 use bevy::prelude::*;
+use common::components::persistent_entity::PersistentEntity;
 
 #[derive(Component, Debug, PartialEq, Clone, Default)]
+#[require(PersistentEntity)]
 pub(crate) struct Map;

--- a/src/plugins/map_generation/src/components/map/cells.rs
+++ b/src/plugins/map_generation/src/components/map/cells.rs
@@ -4,7 +4,10 @@ pub(crate) mod half_offset_cell;
 pub(crate) mod parsed_color;
 
 use crate::{
-	components::map::cells::{half_offset_cell::HalfOffsetCell, parsed_color::ParsedColor},
+	components::map::{
+		Map,
+		cells::{half_offset_cell::HalfOffsetCell, parsed_color::ParsedColor},
+	},
 	traits::{
 		parse_map_image::ParseMapImage,
 		pixels::{Layer, PixelBytesIterator},
@@ -21,6 +24,7 @@ pub(crate) type CellGrid<TCell> = HashMap<(usize, usize), TCell>;
 
 #[derive(Component, Debug, PartialEq)]
 #[component(immutable)]
+#[require(Map)]
 pub(crate) struct MapCells<TCell> {
 	pub(crate) size: Size,
 	pub(crate) cells: CellGrid<TCell>,

--- a/src/plugins/map_generation/src/components/map_agents.rs
+++ b/src/plugins/map_generation/src/components/map_agents.rs
@@ -9,7 +9,7 @@ pub struct GridAgents(EntityHashSet);
 
 #[derive(Component, Debug, PartialEq)]
 #[relationship(relationship_target = GridAgents)]
-pub struct GridAgentOf(Entity);
+pub struct GridAgentOf(pub(crate) Entity);
 
 impl Getter<Entity> for GridAgentOf {
 	fn get(&self) -> Entity {
@@ -18,4 +18,5 @@ impl Getter<Entity> for GridAgentOf {
 }
 
 #[derive(Component, SavableComponent, Debug, PartialEq, Serialize, Deserialize, Clone)]
+#[component(immutable)]
 pub struct AgentOfPersistentMap(pub(crate) PersistentEntity);

--- a/src/plugins/map_generation/src/components/map_agents.rs
+++ b/src/plugins/map_generation/src/components/map_agents.rs
@@ -1,16 +1,21 @@
 use bevy::{ecs::entity::EntityHashSet, prelude::*};
-use common::traits::accessors::get::Getter;
+use common::{components::persistent_entity::PersistentEntity, traits::accessors::get::Getter};
+use macros::SavableComponent;
+use serde::{Deserialize, Serialize};
 
 #[derive(Component, Debug, PartialEq)]
-#[relationship_target(relationship = MapAgentOf)]
-pub struct MapAgents(EntityHashSet);
+#[relationship_target(relationship = GridAgentOf)]
+pub struct GridAgents(EntityHashSet);
 
 #[derive(Component, Debug, PartialEq)]
-#[relationship(relationship_target = MapAgents)]
-pub struct MapAgentOf(pub(crate) Entity);
+#[relationship(relationship_target = GridAgents)]
+pub struct GridAgentOf(Entity);
 
-impl Getter<Entity> for MapAgentOf {
+impl Getter<Entity> for GridAgentOf {
 	fn get(&self) -> Entity {
 		self.0
 	}
 }
+
+#[derive(Component, SavableComponent, Debug, PartialEq, Serialize, Deserialize, Clone)]
+pub struct AgentOfPersistentMap(pub(crate) PersistentEntity);

--- a/src/plugins/map_generation/src/lib.rs
+++ b/src/plugins/map_generation/src/lib.rs
@@ -15,7 +15,7 @@ use crate::{
 			cells::corridor::Corridor,
 			demo_map::DemoMap,
 		},
-		map_agents::GridAgentOf,
+		map_agents::{AgentOfPersistentMap, GridAgentOf},
 	},
 	resources::agents::color_lookup::{AgentsColorLookup, AgentsColorLookupImages},
 };
@@ -80,6 +80,7 @@ where
 		register_agents_lookup_load_tracking.in_app(app, resource_exists::<AgentsColorLookup>);
 
 		TSavegame::register_savable_component::<AgentsLoaded>(app);
+		TSavegame::register_savable_component::<AgentOfPersistentMap>(app);
 		TSavegame::register_savable_component::<DemoMap>(app);
 
 		app.register_required_components::<Map, TSavegame::TSaveEntityMarker>()
@@ -104,6 +105,7 @@ where
 					WallBack::apply_extra_components::<TLights>,
 					WallLight::apply_extra_components::<TLights>,
 					FloorLight::apply_extra_components::<TLights>,
+					AgentOfPersistentMap::link_to_grid.run_if(in_state(GameState::Play)),
 				)
 					.in_set(Self::SYSTEMS),
 			)

--- a/src/plugins/map_generation/src/lib.rs
+++ b/src/plugins/map_generation/src/lib.rs
@@ -15,7 +15,7 @@ use crate::{
 			cells::corridor::Corridor,
 			demo_map::DemoMap,
 		},
-		map_agents::MapAgentOf,
+		map_agents::GridAgentOf,
 	},
 	resources::agents::color_lookup::{AgentsColorLookup, AgentsColorLookupImages},
 };
@@ -121,5 +121,5 @@ impl<TDependencies> HandlesMapGeneration for MapGenerationPlugin<TDependencies> 
 
 	const SYSTEMS: Self::TSystemSet = MapSystems;
 
-	type TMapRef = MapAgentOf;
+	type TMapRef = GridAgentOf;
 }

--- a/src/plugins/map_generation/src/systems.rs
+++ b/src/plugins/map_generation/src/systems.rs
@@ -3,6 +3,7 @@ pub(crate) mod apply_extra_components;
 pub(crate) mod insert_agents_folder;
 pub(crate) mod insert_map_cells;
 pub(crate) mod insert_map_grid_graph;
+pub(crate) mod link_agent_to_grid;
 pub(crate) mod map_assets_loaded;
 pub(crate) mod map_color_lookup;
 pub(crate) mod spawn_map_agents;

--- a/src/plugins/map_generation/src/systems/link_agent_to_grid.rs
+++ b/src/plugins/map_generation/src/systems/link_agent_to_grid.rs
@@ -1,0 +1,101 @@
+use crate::components::{
+	grid::Grid,
+	map_agents::{AgentOfPersistentMap, GridAgentOf},
+	nav_grid::NavGrid,
+};
+use bevy::prelude::*;
+use common::{
+	resources::persistent_entities::PersistentEntities,
+	traits::try_insert_on::TryInsertOn,
+};
+
+impl AgentOfPersistentMap {
+	pub(crate) fn link_to_grid(
+		mut persistent_entities: ResMut<PersistentEntities>,
+		mut commands: Commands,
+		maps: Query<&NavGrid<Grid>>,
+		agents: Query<(Entity, &Self), Changed<Self>>,
+	) {
+		for (entity, AgentOfPersistentMap(map)) in &agents {
+			let Some(map) = persistent_entities.get_entity(map) else {
+				continue;
+			};
+			let Ok(nav_grid) = maps.get(map) else {
+				continue;
+			};
+			commands.try_insert_on(entity, GridAgentOf(nav_grid.entity));
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::components::map_agents::GridAgentOf;
+	use common::{
+		components::persistent_entity::PersistentEntity,
+		traits::register_persistent_entities::RegisterPersistentEntities,
+	};
+	use testing::SingleThreadedApp;
+
+	fn setup() -> App {
+		let mut app = App::new().single_threaded(Update);
+
+		app.register_persistent_entities();
+		app.add_systems(Update, AgentOfPersistentMap::link_to_grid);
+
+		app
+	}
+
+	#[test]
+	fn add_link() {
+		let mut app = setup();
+		let grid = app.world_mut().spawn_empty().id();
+		let map = PersistentEntity::default();
+		app.world_mut().spawn((map, NavGrid::<Grid>::from(grid)));
+		let entity = app.world_mut().spawn(AgentOfPersistentMap(map)).id();
+
+		app.update();
+
+		assert_eq!(
+			Some(&GridAgentOf(grid)),
+			app.world().entity(entity).get::<GridAgentOf>(),
+		);
+	}
+
+	#[test]
+	fn act_only_once() {
+		let mut app = setup();
+		let grid = app.world_mut().spawn_empty().id();
+		let map = PersistentEntity::default();
+		app.world_mut().spawn((map, NavGrid::<Grid>::from(grid)));
+		let entity = app.world_mut().spawn(AgentOfPersistentMap(map)).id();
+
+		app.update();
+		app.world_mut().entity_mut(entity).remove::<GridAgentOf>();
+		app.update();
+
+		assert_eq!(None, app.world().entity(entity).get::<GridAgentOf>());
+	}
+
+	#[test]
+	fn act_again_when_new_map_reference_inserted() {
+		let mut app = setup();
+		let grid = app.world_mut().spawn_empty().id();
+		let map = PersistentEntity::default();
+		app.world_mut().spawn((map, NavGrid::<Grid>::from(grid)));
+		let entity = app.world_mut().spawn(AgentOfPersistentMap(map)).id();
+
+		app.update();
+		app.world_mut()
+			.entity_mut(entity)
+			.remove::<GridAgentOf>()
+			.insert(AgentOfPersistentMap(map));
+		app.update();
+
+		assert_eq!(
+			Some(&GridAgentOf(grid)),
+			app.world().entity(entity).get::<GridAgentOf>(),
+		);
+	}
+}

--- a/src/plugins/map_generation/src/traits/register_map_cell.rs
+++ b/src/plugins/map_generation/src/traits/register_map_cell.rs
@@ -111,7 +111,7 @@ impl RegisterMapCell for App {
 					MapImage::<TCell>::insert_map_cells.pipe(OnError::log),
 					MapImage::<Agent<TCell>>::insert_map_cells.pipe(OnError::log),
 					MapCells::<TCell>::insert_map_grid_graph.pipe(OnError::log),
-					MapCells::<Agent<TCell>>::spawn_map_agents::<Grid>.pipe(OnError::log),
+					MapCells::<Agent<TCell>>::spawn_map_agents.pipe(OnError::log),
 				)
 					.chain(),
 			)


### PR DESCRIPTION
Save data did not contain any reference to the map. So the agents didn't know which map they belonged to after loading.

Fixed by storing a reference to the map's persistent entity and linking agents with grids when this reference is inserted during regular gameplay.