### PR TITLE
improve direction for assets/skills

### DIFF
--- a/assets/models/shield.glb
+++ b/assets/models/shield.glb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a5d6b972de7b0c51b61b1666335abe1383ce0f34d3aca64efdd7c778e4e370dc
-size 102068
+oid sha256:bead7a7590950a0b873f7259d50e04d96875347247c41f81b9b817b5ceb7434d
+size 99796

--- a/blueprints/blender/shield.blend
+++ b/blueprints/blender/shield.blend
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1793d43b3ea6c2ae3a3b0dbd61c0a1828d560e54fa2afb26e25eeb651bc6c886
-size 1197212
+oid sha256:af828548d39175222c7f102ceea150ac34e64c407b9688cf2d2da92e9def4804
+size 1293945

--- a/src/plugins/behaviors/src/components/skill_behavior.rs
+++ b/src/plugins/behaviors/src/components/skill_behavior.rs
@@ -156,7 +156,9 @@ impl SimplePrefab for Motion {
 			Motion::HeldBy { caster } => {
 				entity.try_insert_if_new((
 					RigidBody::Fixed,
-					Anchor::<Always>::to(caster).on_fix_point(SpawnerFixPoint(Spawner::Center)),
+					Anchor::<Always>::to_target(caster)
+						.on_fix_point(SpawnerFixPoint(Spawner::Center))
+						.with_target_rotation(),
 				));
 			}
 			Motion::Stationary {
@@ -191,11 +193,10 @@ impl SimplePrefab for Motion {
 				}
 
 				entity.try_insert_if_new((
-					Anchor::<Once>::to(caster).on_fix_point(SpawnerFixPoint(spawner)),
-					SetVelocityForward {
-						rotation: caster,
-						speed,
-					},
+					Anchor::<Once>::to_target(caster)
+						.on_fix_point(SpawnerFixPoint(spawner))
+						.with_target_rotation(),
+					SetVelocityForward(speed),
 				));
 			}
 		}
@@ -280,28 +281,33 @@ mod tests {
 			motion.prefab::<_Interactions>(entity, CreatedFrom::Contact)
 		}))?;
 
+		let entity = app.world().entity(entity);
 		assert_eq!(
 			(
 				Some(&RigidBody::Fixed),
 				None,
 				None,
 				None,
-				Some(&Anchor::<Always>::to(caster).on_fix_point(SpawnerFixPoint(Spawner::Center))),
+				Some(
+					&Anchor::<Always>::to_target(caster)
+						.on_fix_point(SpawnerFixPoint(Spawner::Center))
+						.with_target_rotation()
+				),
+				None,
 				None,
 				None,
 				None,
 			),
 			(
-				app.world().entity(entity).get::<RigidBody>(),
-				app.world().entity(entity).get::<GravityScale>(),
-				app.world().entity(entity).get::<Ccd>(),
-				app.world().entity(entity).get::<GroundTarget>(),
-				app.world().entity(entity).get::<Anchor<Always>>(),
-				app.world().entity(entity).get::<Anchor<Once>>(),
-				app.world().entity(entity).get::<SetVelocityForward>(),
-				app.world()
-					.entity(entity)
-					.get::<DestroyAfterDistanceTraveled<Velocity>>(),
+				entity.get::<RigidBody>(),
+				entity.get::<GravityScale>(),
+				entity.get::<Ccd>(),
+				entity.get::<GroundTarget>(),
+				entity.get::<Anchor<Always>>(),
+				entity.get::<Anchor<Once>>(),
+				entity.get::<SetVelocityForward>(),
+				entity.get::<DestroyAfterDistanceTraveled<Velocity>>(),
+				entity.get::<_Interaction>(),
 			)
 		);
 		Ok(())
@@ -373,6 +379,7 @@ mod tests {
 			motion.prefab::<_Interactions>(entity, CreatedFrom::Contact)
 		}))?;
 
+		let entity = app.world().entity(entity);
 		assert_eq!(
 			(
 				Some(&RigidBody::Dynamic),
@@ -381,13 +388,11 @@ mod tests {
 				None,
 				None,
 				Some(
-					&Anchor::<Once>::to(caster)
+					&Anchor::<Once>::to_target(caster)
 						.on_fix_point(SpawnerFixPoint(Spawner::Slot(SlotKey::TopHand(Side::Left))))
+						.with_target_rotation()
 				),
-				Some(&SetVelocityForward {
-					rotation: caster,
-					speed: UnitsPerSecond::new(11.),
-				}),
+				Some(&SetVelocityForward(UnitsPerSecond::new(11.))),
 				Some(
 					&WhenTraveled::via::<Velocity>()
 						.distance(Units::new(1111.))
@@ -395,16 +400,14 @@ mod tests {
 				),
 			),
 			(
-				app.world().entity(entity).get::<RigidBody>(),
-				app.world().entity(entity).get::<GravityScale>(),
-				app.world().entity(entity).get::<Ccd>(),
-				app.world().entity(entity).get::<GroundTarget>(),
-				app.world().entity(entity).get::<Anchor<Always>>(),
-				app.world().entity(entity).get::<Anchor<Once>>(),
-				app.world().entity(entity).get::<SetVelocityForward>(),
-				app.world()
-					.entity(entity)
-					.get::<DestroyAfterDistanceTraveled<Velocity>>(),
+				entity.get::<RigidBody>(),
+				entity.get::<GravityScale>(),
+				entity.get::<Ccd>(),
+				entity.get::<GroundTarget>(),
+				entity.get::<Anchor<Always>>(),
+				entity.get::<Anchor<Once>>(),
+				entity.get::<SetVelocityForward>(),
+				entity.get::<DestroyAfterDistanceTraveled<Velocity>>(),
 			)
 		);
 		Ok(())

--- a/src/plugins/behaviors/src/lib.rs
+++ b/src/plugins/behaviors/src/lib.rs
@@ -232,15 +232,13 @@ where
 					(
 						update_cool_downs::<Virtual>,
 						GroundTarget::set_position,
-						(
-							DestroyAfterDistanceTraveled::<Velocity>::system,
-							SkillContact::update_range,
-						)
-							.chain(),
-						SetVelocityForward::system,
-						Anchor::<Always>::system.pipe(OnError::log),
+						DestroyAfterDistanceTraveled::<Velocity>::system,
+						SkillContact::update_range,
 						Anchor::<Once>::system.pipe(OnError::log),
-					),
+						Anchor::<Always>::system.pipe(OnError::log),
+						SetVelocityForward::system,
+					)
+						.chain(),
 					// Apply facing
 					(
 						Movement::<VelocityBased>::set_faces,

--- a/src/plugins/common/src/components/asset_model.rs
+++ b/src/plugins/common/src/components/asset_model.rs
@@ -1,27 +1,52 @@
-use crate::components::flip::FlipHorizontally;
 use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
 
 #[derive(Component, Debug, PartialEq, Default, Clone, Serialize, Deserialize)]
 #[require(Transform, Visibility)]
-pub enum AssetModel {
+pub struct AssetModel {
+	pub(crate) flip_horizontally: Option<Name>,
+	pub(crate) model: Model,
+}
+
+#[derive(Debug, PartialEq, Default, Clone, Serialize, Deserialize)]
+pub(crate) enum Model {
 	#[default]
 	None,
 	Path(String),
 }
 
-impl From<&str> for AssetModel {
-	fn from(path: &str) -> Self {
-		Self::Path(path.to_owned())
+impl<T> From<T> for AssetModel
+where
+	T: Into<String>,
+{
+	fn from(path: T) -> Self {
+		Self::path(path)
 	}
 }
 
 impl AssetModel {
-	pub fn path(path: &str) -> AssetModel {
-		AssetModel::Path(path.to_owned())
+	pub fn path<T>(path: T) -> Self
+	where
+		T: Into<String>,
+	{
+		Self {
+			flip_horizontally: None,
+			model: Model::Path(path.into()),
+		}
 	}
 
-	pub fn flip_on(self, name: Name) -> (Self, FlipHorizontally) {
-		(self, FlipHorizontally::with(name))
+	pub fn none() -> Self {
+		Self {
+			flip_horizontally: None,
+			model: Model::None,
+		}
+	}
+
+	pub fn flipped_on<T>(mut self, name: T) -> Self
+	where
+		T: Into<Name>,
+	{
+		self.flip_horizontally = Some(name.into());
+		self
 	}
 }

--- a/src/plugins/common/src/components/flip.rs
+++ b/src/plugins/common/src/components/flip.rs
@@ -1,12 +1,15 @@
 use bevy::prelude::*;
 use std::f32::consts::PI;
 
-#[derive(Component)]
+#[derive(Component, Debug, PartialEq)]
 pub struct FlipHorizontally(Name);
 
 impl FlipHorizontally {
-	pub fn with(name: Name) -> Self {
-		Self(name)
+	pub fn on<TName>(name: TName) -> Self
+	where
+		TName: Into<Name>,
+	{
+		Self(name.into())
 	}
 
 	pub(crate) fn system(
@@ -51,7 +54,7 @@ mod tests {
 		let mut app = setup();
 		let parent = app
 			.world_mut()
-			.spawn(FlipHorizontally::with(Name::from("my name")))
+			.spawn(FlipHorizontally::on(Name::from("my name")))
 			.id();
 		let child = app
 			.world_mut()
@@ -80,7 +83,7 @@ mod tests {
 		let mut app = setup();
 		let parent = app
 			.world_mut()
-			.spawn(FlipHorizontally::with(Name::from("my name")))
+			.spawn(FlipHorizontally::on(Name::from("my name")))
 			.id();
 		let child = app
 			.world_mut()
@@ -108,7 +111,7 @@ mod tests {
 		let mut app = setup();
 		let parent = app
 			.world_mut()
-			.spawn(FlipHorizontally::with(Name::from("my name")))
+			.spawn(FlipHorizontally::on(Name::from("my name")))
 			.id();
 		let in_between = app.world_mut().spawn_empty().insert(ChildOf(parent)).id();
 		let child = app
@@ -138,7 +141,7 @@ mod tests {
 		let mut app = setup();
 		let parent = app
 			.world_mut()
-			.spawn(FlipHorizontally::with(Name::from("my name")))
+			.spawn(FlipHorizontally::on(Name::from("my name")))
 			.id();
 		let child = app
 			.world_mut()

--- a/src/plugins/map_generation/src/components/quadrants.rs
+++ b/src/plugins/map_generation/src/components/quadrants.rs
@@ -48,5 +48,5 @@ pub(crate) struct CorridorWallCornerInside;
 pub(crate) struct CorridorWall;
 
 fn corridor(suffix: &'static str) -> AssetModel {
-	AssetModel::Path(format!("{CORRIDOR_PATH_PREFIX}{suffix}.glb#Scene0"))
+	AssetModel::path(format!("{CORRIDOR_PATH_PREFIX}{suffix}.glb#Scene0"))
 }

--- a/src/plugins/player/src/components/player.rs
+++ b/src/plugins/player/src/components/player.rs
@@ -55,7 +55,7 @@ use std::collections::HashMap;
 	Visibility,
 	Name = "Player",
 	AssetModel = Self::MODEL_PATH,
-	FlipHorizontally = FlipHorizontally::with(Name::from("metarig")),
+	FlipHorizontally = FlipHorizontally::on("metarig"),
 	GroundOffset = Vec3::Y,
 	IsBlocker = [Blocker::Character],
 	RigidBody = RigidBody::Dynamic,

--- a/src/plugins/skills/src/behaviors/build_skill_shape/spawn_shield.rs
+++ b/src/plugins/skills/src/behaviors/build_skill_shape/spawn_shield.rs
@@ -42,13 +42,13 @@ impl SpawnShape for SpawnShield {
 	{
 		let SkillCaster(caster) = *caster;
 		let radius = 1.;
-		let offset = Vec3::new(0., 0., radius);
+		let offset = Vec3::new(0., 0., -radius);
 
 		TSkillBehaviors::spawn_skill(
 			commands,
 			Contact {
 				shape: Shape::Custom {
-					model: AssetModel::path("models/shield.glb"),
+					model: AssetModel::path("models/shield.glb").flipped_on("Shield"),
 					collider: Collider::cuboid(0.5, 0.5, 0.05),
 					scale: Vec3::splat(1.),
 				},

--- a/src/plugins/skills/src/components/slots.rs
+++ b/src/plugins/skills/src/components/slots.rs
@@ -105,8 +105,8 @@ impl ChildAssetComponent<HandItemSlots> for Item {
 			Some(Item {
 				model: ModelRender::Hand(path),
 				..
-			}) => AssetModel::Path(path.clone()),
-			_ => AssetModel::None,
+			}) => AssetModel::path(path),
+			_ => AssetModel::none(),
 		}
 	}
 }
@@ -138,8 +138,8 @@ impl ChildAssetComponent<ForearmItemSlots> for Item {
 			Some(Item {
 				model: ModelRender::Forearm(path),
 				..
-			}) => AssetModel::Path(path.clone()),
-			_ => AssetModel::None,
+			}) => AssetModel::path(path),
+			_ => AssetModel::none(),
 		}
 	}
 }


### PR DESCRIPTION
skill assets had been handled inconsistently. Models made in bevy need to be flipped horizontally on insertion.

Is now fixed by including flip info into `AssetModel` and mounting skills more consistently onto the caster's skill slots.