### PR TITLE
Loadout definition for player and enemies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4328,6 +4328,7 @@ dependencies = [
  "serde",
  "test-case",
  "testing",
+ "zyheeda_core",
 ]
 
 [[package]]

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,6 +74,7 @@ fn prepare_game(app: &mut App) -> Result<(), ZyheedaAppError> {
 		&settings,
 		&behaviors,
 		&players,
+		&enemies,
 		&menus,
 	);
 	let bars = BarsPlugin::from_plugins(&players, &enemies, &graphics);

--- a/src/plugins/common/src/tools/action_key/slot.rs
+++ b/src/plugins/common/src/tools/action_key/slot.rs
@@ -123,7 +123,7 @@ impl TryFrom<SlotKey> for PlayerSlot {
 
 #[derive(Debug, PartialEq)]
 pub struct NoValidSlotKey {
-	slot_key: SlotKey,
+	pub slot_key: SlotKey,
 }
 
 impl From<NoValidSlotKey> for Error {

--- a/src/plugins/common/src/tools/item_type.rs
+++ b/src/plugins/common/src/tools/item_type.rs
@@ -1,6 +1,5 @@
-use std::collections::HashSet;
-
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 
 #[derive(Debug, Default, Hash, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
 pub enum ItemType {

--- a/src/plugins/common/src/traits.rs
+++ b/src/plugins/common/src/traits.rs
@@ -40,6 +40,7 @@ pub mod iteration;
 pub mod key_mappings;
 pub mod load_asset;
 pub mod load_folder_assets;
+pub mod loadout;
 pub mod mapper;
 pub mod mouse_position;
 pub mod or_ok;

--- a/src/plugins/common/src/traits/handles_enemies.rs
+++ b/src/plugins/common/src/traits/handles_enemies.rs
@@ -4,9 +4,15 @@ use crate::{
 	tools::{
 		aggro_range::AggroRange,
 		attack_range::AttackRange,
+		bone::Bone,
 		collider_radius::ColliderRadius,
 		movement_animation::MovementAnimation,
 		speed::Speed,
+	},
+	traits::{
+		loadout::LoadoutConfig,
+		mapper::Mapper,
+		visible_slots::{EssenceSlot, ForearmSlot, HandSlot, VisibleSlots},
 	},
 };
 use bevy::prelude::*;
@@ -19,13 +25,18 @@ pub trait HandlesEnemies {
 
 pub trait HandlesEnemyBehaviors {
 	type TEnemyBehavior: Component
+		+ LoadoutConfig
+		+ VisibleSlots
 		+ EnemyAttack
 		+ for<'a> RefInto<'a, Speed>
 		+ for<'a> RefInto<'a, Option<&'a MovementAnimation>>
 		+ for<'a> RefInto<'a, EnemyTarget>
 		+ for<'a> RefInto<'a, AggroRange>
 		+ for<'a> RefInto<'a, AttackRange>
-		+ for<'a> RefInto<'a, ColliderRadius>;
+		+ for<'a> RefInto<'a, ColliderRadius>
+		+ for<'a> Mapper<Bone<'a>, Option<EssenceSlot>>
+		+ for<'a> Mapper<Bone<'a>, Option<HandSlot>>
+		+ for<'a> Mapper<Bone<'a>, Option<ForearmSlot>>;
 }
 
 pub trait EnemyAttack {

--- a/src/plugins/common/src/traits/handles_player.rs
+++ b/src/plugins/common/src/traits/handles_player.rs
@@ -11,6 +11,7 @@ use crate::{
 	},
 	traits::{
 		handles_skill_behaviors::SkillSpawner,
+		loadout::LoadoutConfig,
 		mapper::Mapper,
 		visible_slots::{EssenceSlot, ForearmSlot, HandSlot, VisibleSlots},
 	},
@@ -24,6 +25,7 @@ pub trait HandlesPlayer {
 	type TPlayer: Component
 		+ Default
 		+ VisibleSlots
+		+ LoadoutConfig
 		+ for<'a> Mapper<Bone<'a>, Option<SkillSpawner>>
 		+ for<'a> Mapper<Bone<'a>, Option<EssenceSlot>>
 		+ for<'a> Mapper<Bone<'a>, Option<HandSlot>>

--- a/src/plugins/common/src/traits/loadout.rs
+++ b/src/plugins/common/src/traits/loadout.rs
@@ -1,0 +1,7 @@
+use crate::tools::action_key::slot::SlotKey;
+use bevy::{asset::AssetPath, ecs::component::Component};
+
+pub trait LoadoutConfig: Component {
+	fn inventory(&self) -> impl IntoIterator<Item = Option<AssetPath<'static>>>;
+	fn slots(&self) -> impl IntoIterator<Item = (SlotKey, Option<AssetPath<'static>>)>;
+}

--- a/src/plugins/common/src/traits/loadout.rs
+++ b/src/plugins/common/src/traits/loadout.rs
@@ -1,7 +1,7 @@
 use crate::tools::action_key::slot::SlotKey;
-use bevy::{asset::AssetPath, ecs::component::Component};
+use bevy::asset::AssetPath;
 
-pub trait LoadoutConfig: Component {
-	fn inventory(&self) -> impl IntoIterator<Item = Option<AssetPath<'static>>>;
-	fn slots(&self) -> impl IntoIterator<Item = (SlotKey, Option<AssetPath<'static>>)>;
+pub trait LoadoutConfig {
+	fn inventory(&self) -> impl Iterator<Item = Option<AssetPath<'static>>>;
+	fn slots(&self) -> impl Iterator<Item = (SlotKey, Option<AssetPath<'static>>)>;
 }

--- a/src/plugins/enemy/src/components/enemy_behavior.rs
+++ b/src/plugins/enemy/src/components/enemy_behavior.rs
@@ -83,12 +83,12 @@ impl From<&EnemyBehavior> for ColliderRadius {
 }
 
 impl LoadoutConfig for EnemyBehavior {
-	fn inventory(&self) -> impl IntoIterator<Item = Option<AssetPath<'static>>> {
-		[]
+	fn inventory(&self) -> impl Iterator<Item = Option<AssetPath<'static>>> {
+		std::iter::empty()
 	}
 
-	fn slots(&self) -> impl IntoIterator<Item = (SlotKey, Option<AssetPath<'static>>)> {
-		[(SlotKey::from(VoidSphereSlot), None)]
+	fn slots(&self) -> impl Iterator<Item = (SlotKey, Option<AssetPath<'static>>)> {
+		std::iter::once((SlotKey::from(VoidSphereSlot), None))
 	}
 }
 

--- a/src/plugins/enemy/src/components/enemy_behavior.rs
+++ b/src/plugins/enemy/src/components/enemy_behavior.rs
@@ -1,5 +1,8 @@
-use crate::traits::insert_attack::InsertAttack;
-use bevy::prelude::*;
+use crate::{
+	components::void_sphere::{VoidSphere, VoidSphereSlot},
+	traits::insert_attack::InsertAttack,
+};
+use bevy::{asset::AssetPath, prelude::*};
 use common::{
 	components::{
 		collider_relationship::InteractionTarget,
@@ -7,13 +10,20 @@ use common::{
 		persistent_entity::PersistentEntity,
 	},
 	tools::{
+		action_key::slot::SlotKey,
 		aggro_range::AggroRange,
 		attack_range::AttackRange,
+		bone::Bone,
 		collider_radius::ColliderRadius,
 		movement_animation::MovementAnimation,
 		speed::Speed,
 	},
-	traits::handles_enemies::{Attacker, EnemyAttack, EnemyTarget, Target},
+	traits::{
+		handles_enemies::{Attacker, EnemyAttack, EnemyTarget, Target},
+		loadout::LoadoutConfig,
+		mapper::Mapper,
+		visible_slots::{EssenceSlot, ForearmSlot, HandSlot, VisibleSlots},
+	},
 };
 use std::{sync::Arc, time::Duration};
 
@@ -69,6 +79,52 @@ impl From<&EnemyBehavior> for EnemyTarget {
 impl From<&EnemyBehavior> for ColliderRadius {
 	fn from(enemy: &EnemyBehavior) -> Self {
 		enemy.collider_radius
+	}
+}
+
+impl LoadoutConfig for EnemyBehavior {
+	fn inventory(&self) -> impl IntoIterator<Item = Option<AssetPath<'static>>> {
+		[]
+	}
+
+	fn slots(&self) -> impl IntoIterator<Item = (SlotKey, Option<AssetPath<'static>>)> {
+		[(SlotKey::from(VoidSphereSlot), None)]
+	}
+}
+
+impl VisibleSlots for EnemyBehavior {
+	fn visible_slots(&self) -> impl Iterator<Item = SlotKey> {
+		[SlotKey::from(VoidSphereSlot)].into_iter()
+	}
+}
+
+impl Mapper<Bone<'_>, Option<EssenceSlot>> for EnemyBehavior {
+	fn map(&self, Bone(bone): Bone<'_>) -> Option<EssenceSlot> {
+		if bone != VoidSphere::SLOT_NAME {
+			return None;
+		}
+
+		Some(EssenceSlot(SlotKey::from(VoidSphereSlot)))
+	}
+}
+
+impl Mapper<Bone<'_>, Option<HandSlot>> for EnemyBehavior {
+	fn map(&self, Bone(bone): Bone<'_>) -> Option<HandSlot> {
+		if bone != VoidSphere::SLOT_NAME {
+			return None;
+		}
+
+		Some(HandSlot(SlotKey::from(VoidSphereSlot)))
+	}
+}
+
+impl Mapper<Bone<'_>, Option<ForearmSlot>> for EnemyBehavior {
+	fn map(&self, Bone(bone): Bone<'_>) -> Option<ForearmSlot> {
+		if bone != VoidSphere::SLOT_NAME {
+			return None;
+		}
+
+		Some(ForearmSlot(SlotKey::from(VoidSphereSlot)))
 	}
 }
 

--- a/src/plugins/player/Cargo.toml
+++ b/src/plugins/player/Cargo.toml
@@ -12,6 +12,7 @@ serde.workspace = true
 # internal
 common.workspace = true
 macros.workspace = true
+zyheeda_core.workspace = true
 
 [dev-dependencies]
 # external

--- a/src/plugins/player/src/components/player.rs
+++ b/src/plugins/player/src/components/player.rs
@@ -1,5 +1,5 @@
 use super::player_movement::{Config, MovementMode, PlayerMovement};
-use bevy::prelude::*;
+use bevy::{asset::AssetPath, prelude::*};
 use bevy_rapier3d::prelude::*;
 use common::{
 	attributes::{
@@ -44,12 +44,13 @@ use common::{
 		handles_skill_behaviors::SkillSpawner,
 		iteration::{Iter, IterFinite},
 		load_asset::{LoadAsset, Path},
+		loadout::LoadoutConfig,
 		mapper::Mapper,
 		prefab::{Prefab, PrefabEntityCommands},
 		visible_slots::{EssenceSlot, ForearmSlot, HandSlot, VisibleSlots},
 	},
 };
-use macros::SavableComponent;
+use macros::{SavableComponent, item_asset};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -336,6 +337,37 @@ where
 			));
 
 		Ok(())
+	}
+}
+
+impl LoadoutConfig for Player {
+	fn inventory(&self) -> impl IntoIterator<Item = Option<AssetPath<'static>>> {
+		[
+			Some(AssetPath::from(item_asset!("pistol"))),
+			Some(AssetPath::from(item_asset!("pistol"))),
+			Some(AssetPath::from(item_asset!("pistol"))),
+		]
+	}
+
+	fn slots(&self) -> impl IntoIterator<Item = (SlotKey, Option<AssetPath<'static>>)> {
+		[
+			(
+				SlotKey::from(PlayerSlot::Upper(Side::Left)),
+				Some(AssetPath::from(item_asset!("pistol"))),
+			),
+			(
+				SlotKey::from(PlayerSlot::Lower(Side::Left)),
+				Some(AssetPath::from(item_asset!("pistol"))),
+			),
+			(
+				SlotKey::from(PlayerSlot::Lower(Side::Right)),
+				Some(AssetPath::from(item_asset!("force_essence"))),
+			),
+			(
+				SlotKey::from(PlayerSlot::Upper(Side::Right)),
+				Some(AssetPath::from(item_asset!("force_essence"))),
+			),
+		]
 	}
 }
 

--- a/src/plugins/player/src/components/player.rs
+++ b/src/plugins/player/src/components/player.rs
@@ -53,6 +53,7 @@ use common::{
 use macros::{SavableComponent, item_asset};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use zyheeda_core::prelude::*;
 
 #[derive(Component, SavableComponent, Default, Debug, PartialEq, Clone, Serialize, Deserialize)]
 #[require(
@@ -341,16 +342,16 @@ where
 }
 
 impl LoadoutConfig for Player {
-	fn inventory(&self) -> impl IntoIterator<Item = Option<AssetPath<'static>>> {
-		[
+	fn inventory(&self) -> impl Iterator<Item = Option<AssetPath<'static>>> {
+		yield_eager!(
 			Some(AssetPath::from(item_asset!("pistol"))),
 			Some(AssetPath::from(item_asset!("pistol"))),
 			Some(AssetPath::from(item_asset!("pistol"))),
-		]
+		)
 	}
 
-	fn slots(&self) -> impl IntoIterator<Item = (SlotKey, Option<AssetPath<'static>>)> {
-		[
+	fn slots(&self) -> impl Iterator<Item = (SlotKey, Option<AssetPath<'static>>)> {
+		yield_eager!(
 			(
 				SlotKey::from(PlayerSlot::Upper(Side::Left)),
 				Some(AssetPath::from(item_asset!("pistol"))),
@@ -367,7 +368,7 @@ impl LoadoutConfig for Player {
 				SlotKey::from(PlayerSlot::Upper(Side::Right)),
 				Some(AssetPath::from(item_asset!("force_essence"))),
 			),
-		]
+		)
 	}
 }
 

--- a/src/plugins/skills/src/components/loadout.rs
+++ b/src/plugins/skills/src/components/loadout.rs
@@ -1,25 +1,15 @@
 use crate::components::{
 	combos::Combos,
 	combos_time_out::CombosTimeOut,
-	inventory::Inventory,
 	queue::Queue,
 	skill_executer::SkillExecuter,
-	slots::Slots,
 	swapper::Swapper,
 };
 use bevy::prelude::*;
-use common::{
-	traits::{
-		accessors::get::TryApplyOn,
-		load_asset::LoadAsset,
-		loadout::LoadoutConfig,
-		thread_safe::ThreadSafe,
-	},
-	zyheeda_commands::ZyheedaCommands,
-};
+use common::traits::{loadout::LoadoutConfig, thread_safe::ThreadSafe};
 use std::{marker::PhantomData, time::Duration};
 
-#[derive(Component, Debug)]
+#[derive(Component, Debug, PartialEq)]
 #[require(
 	Combos,
 	CombosTimeOut = CombosTimeOut::after(Duration::from_secs(2)),
@@ -30,41 +20,6 @@ use std::{marker::PhantomData, time::Duration};
 pub(crate) struct Loadout<T>(PhantomData<T>)
 where
 	T: LoadoutConfig + ThreadSafe;
-
-impl<T> Loadout<T>
-where
-	T: LoadoutConfig + ThreadSafe,
-{
-	pub(crate) fn insert(
-		trigger: Trigger<OnInsert, T>,
-		agents: Query<&T>,
-		mut commands: ZyheedaCommands,
-		mut assets: ResMut<AssetServer>,
-	) {
-		let entity = trigger.target();
-		let Ok(agent) = agents.get(entity) else {
-			return;
-		};
-
-		commands.try_apply_on(&entity, |mut e| {
-			e.try_insert_if_new((
-				Self::default(),
-				Inventory::from(
-					agent
-						.inventory()
-						.into_iter()
-						.map(|path| path.map(|path| assets.load_asset(path))),
-				),
-				Slots::from(
-					agent
-						.slots()
-						.into_iter()
-						.map(|(key, path)| (key, path.map(|path| assets.load_asset(path)))),
-				),
-			));
-		});
-	}
-}
 
 impl<T> Default for Loadout<T>
 where

--- a/src/plugins/skills/src/systems.rs
+++ b/src/plugins/skills/src/systems.rs
@@ -5,6 +5,7 @@ pub(crate) mod execute;
 pub(crate) mod flush;
 pub(crate) mod flush_skill_combos;
 pub(crate) mod get_inputs;
+pub(crate) mod insert_loadout;
 pub(crate) mod loadout_descriptor;
 pub(crate) mod quickbar_descriptor;
 pub(crate) mod slot;

--- a/src/plugins/skills/src/systems/insert_loadout.rs
+++ b/src/plugins/skills/src/systems/insert_loadout.rs
@@ -1,0 +1,286 @@
+use crate::components::{inventory::Inventory, loadout::Loadout, slots::Slots};
+use bevy::prelude::*;
+use common::{
+	traits::{
+		accessors::get::TryApplyOn,
+		load_asset::LoadAsset,
+		loadout::LoadoutConfig,
+		thread_safe::ThreadSafe,
+	},
+	zyheeda_commands::ZyheedaCommands,
+};
+
+impl<T> Loadout<T>
+where
+	T: LoadoutConfig + Component + ThreadSafe,
+{
+	pub(crate) fn insert(
+		trigger: Trigger<OnInsert, T>,
+		agents: Query<(&T, Option<&Inventory>, Option<&Slots>)>,
+		commands: ZyheedaCommands,
+		assets: ResMut<AssetServer>,
+	) {
+		insert_internal(trigger, agents, commands, assets);
+	}
+}
+
+fn insert_internal<T, TAssets>(
+	trigger: Trigger<OnInsert, T>,
+	agents: Query<(&T, Option<&Inventory>, Option<&Slots>)>,
+	mut commands: ZyheedaCommands,
+	mut assets: ResMut<TAssets>,
+) where
+	T: LoadoutConfig + Component + ThreadSafe,
+	TAssets: Resource + LoadAsset,
+{
+	let entity = trigger.target();
+	let Ok((agent, inventory, slots)) = agents.get(entity) else {
+		return;
+	};
+
+	commands.try_apply_on(&entity, |mut e| {
+		e.try_insert(Loadout::<T>::default());
+
+		if inventory.is_none() {
+			e.try_insert(Inventory::from(
+				agent
+					.inventory()
+					.map(|path| path.map(|path| assets.load_asset(path))),
+			));
+		}
+
+		if slots.is_none() {
+			e.try_insert(Slots::from(
+				agent
+					.slots()
+					.map(|(key, path)| (key, path.map(|path| assets.load_asset(path)))),
+			));
+		}
+	});
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::item::Item;
+	use bevy::asset::AssetPath;
+	use common::tools::action_key::slot::SlotKey;
+	use macros::NestedMocks;
+	use mockall::{automock, predicate::eq};
+	use testing::{NestedMocks, SingleThreadedApp, new_handle};
+
+	#[derive(Resource, NestedMocks)]
+	struct _Assets {
+		mock: Mock_Assets,
+	}
+
+	#[automock]
+	impl LoadAsset for _Assets {
+		fn load_asset<TAsset, TPath>(&mut self, path: TPath) -> Handle<TAsset>
+		where
+			TAsset: Asset,
+			TPath: Into<AssetPath<'static>> + 'static,
+		{
+			self.mock.load_asset(path)
+		}
+	}
+
+	#[derive(Component, Debug, PartialEq)]
+	struct _Agent {
+		inventory: Vec<Option<AssetPath<'static>>>,
+		slots: Vec<(SlotKey, Option<AssetPath<'static>>)>,
+	}
+
+	impl LoadoutConfig for _Agent {
+		fn inventory(&self) -> impl Iterator<Item = Option<AssetPath<'static>>> {
+			self.inventory.iter().cloned()
+		}
+
+		fn slots(&self) -> impl Iterator<Item = (SlotKey, Option<AssetPath<'static>>)> {
+			self.slots.iter().cloned()
+		}
+	}
+
+	fn setup(assets: _Assets) -> App {
+		let mut app = App::new().single_threaded(Update);
+
+		app.insert_resource(assets);
+		app.add_observer(insert_internal::<_Agent, _Assets>);
+
+		app
+	}
+
+	#[test]
+	fn insert_loadout_components() {
+		let inventory_item = new_handle();
+		let slot_item = new_handle();
+		let mut app = setup(_Assets::new().with_mock(|mock| {
+			mock.expect_load_asset::<Item, AssetPath<'static>>()
+				.with(eq(AssetPath::from("inventory item")))
+				.return_const(inventory_item.clone());
+			mock.expect_load_asset::<Item, AssetPath<'static>>()
+				.with(eq(AssetPath::from("slot item")))
+				.return_const(slot_item.clone());
+		}));
+
+		let entity = app.world_mut().spawn(_Agent {
+			inventory: vec![Some(AssetPath::from("inventory item"))],
+			slots: vec![(SlotKey(42), Some(AssetPath::from("slot item")))],
+		});
+
+		assert_eq!(
+			(
+				Some(&Loadout::<_Agent>::default()),
+				Some(&Inventory::from([Some(inventory_item)])),
+				Some(&Slots::from([(SlotKey(42), Some(slot_item))]))
+			),
+			(
+				entity.get::<Loadout<_Agent>>(),
+				entity.get::<Inventory>(),
+				entity.get::<Slots>(),
+			)
+		);
+	}
+
+	#[test]
+	fn no_inventory_mapping_if_inventory_already_present() {
+		let mut app = setup(_Assets::new().with_mock(|mock| {
+			mock.expect_load_asset::<Item, AssetPath<'static>>()
+				.with(eq(AssetPath::from("inventory item")))
+				.never();
+			mock.expect_load_asset::<Item, AssetPath<'static>>()
+				.with(eq(AssetPath::from("slot item")))
+				.return_const(new_handle());
+		}));
+
+		app.world_mut().spawn((
+			_Agent {
+				inventory: vec![Some(AssetPath::from("inventory item"))],
+				slots: vec![(SlotKey(42), Some(AssetPath::from("slot item")))],
+			},
+			Inventory::from([]),
+		));
+	}
+
+	#[test]
+	fn insert_loadout_if_inventory_already_present() {
+		let slot_item = new_handle();
+		let mut app = setup(_Assets::new().with_mock(|mock| {
+			mock.expect_load_asset::<Item, AssetPath<'static>>()
+				.with(eq(AssetPath::from("inventory item")))
+				.return_const(new_handle());
+			mock.expect_load_asset::<Item, AssetPath<'static>>()
+				.with(eq(AssetPath::from("slot item")))
+				.return_const(slot_item.clone());
+		}));
+
+		let entity = app.world_mut().spawn((
+			_Agent {
+				inventory: vec![Some(AssetPath::from("inventory item"))],
+				slots: vec![(SlotKey(42), Some(AssetPath::from("slot item")))],
+			},
+			Inventory::from([]),
+		));
+
+		assert_eq!(
+			(
+				Some(&Loadout::<_Agent>::default()),
+				Some(&Inventory::from([])),
+				Some(&Slots::from([(SlotKey(42), Some(slot_item))]))
+			),
+			(
+				entity.get::<Loadout<_Agent>>(),
+				entity.get::<Inventory>(),
+				entity.get::<Slots>(),
+			)
+		);
+	}
+
+	#[test]
+	fn no_slot_mapping_if_slots_already_present() {
+		let mut app = setup(_Assets::new().with_mock(|mock| {
+			mock.expect_load_asset::<Item, AssetPath<'static>>()
+				.with(eq(AssetPath::from("inventory item")))
+				.return_const(new_handle());
+			mock.expect_load_asset::<Item, AssetPath<'static>>()
+				.with(eq(AssetPath::from("slot item")))
+				.never();
+		}));
+
+		app.world_mut().spawn((
+			_Agent {
+				inventory: vec![Some(AssetPath::from("inventory item"))],
+				slots: vec![(SlotKey(42), Some(AssetPath::from("slot item")))],
+			},
+			Slots::from([]),
+		));
+	}
+
+	#[test]
+	fn insert_loadout_if_slots_already_present() {
+		let inventory_item = new_handle();
+		let mut app = setup(_Assets::new().with_mock(|mock| {
+			mock.expect_load_asset::<Item, AssetPath<'static>>()
+				.with(eq(AssetPath::from("inventory item")))
+				.return_const(inventory_item.clone());
+			mock.expect_load_asset::<Item, AssetPath<'static>>()
+				.with(eq(AssetPath::from("slot item")))
+				.return_const(new_handle());
+		}));
+
+		let entity = app.world_mut().spawn((
+			_Agent {
+				inventory: vec![Some(AssetPath::from("inventory item"))],
+				slots: vec![(SlotKey(42), Some(AssetPath::from("slot item")))],
+			},
+			Slots::from([]),
+		));
+
+		assert_eq!(
+			(
+				Some(&Loadout::<_Agent>::default()),
+				Some(&Inventory::from([Some(inventory_item)])),
+				Some(&Slots::from([]))
+			),
+			(
+				entity.get::<Loadout<_Agent>>(),
+				entity.get::<Inventory>(),
+				entity.get::<Slots>(),
+			)
+		);
+	}
+
+	#[test]
+	fn insert_loadout_if_slots_and_inventory_already_present() {
+		let mut app = setup(_Assets::new().with_mock(|mock| {
+			mock.expect_load_asset::<Item, AssetPath<'static>>()
+				.with(eq(AssetPath::from("inventory item")))
+				.return_const(new_handle());
+			mock.expect_load_asset::<Item, AssetPath<'static>>()
+				.with(eq(AssetPath::from("slot item")))
+				.return_const(new_handle());
+		}));
+
+		let entity = app.world_mut().spawn((
+			_Agent {
+				inventory: vec![Some(AssetPath::from("inventory item"))],
+				slots: vec![(SlotKey(42), Some(AssetPath::from("slot item")))],
+			},
+			Inventory::from([]),
+			Slots::from([]),
+		));
+
+		assert_eq!(
+			(
+				Some(&Loadout::<_Agent>::default()),
+				Some(&Inventory::from([])),
+				Some(&Slots::from([]))
+			),
+			(
+				entity.get::<Loadout<_Agent>>(),
+				entity.get::<Inventory>(),
+				entity.get::<Slots>(),
+			)
+		);
+	}
+}

--- a/src/zyheeda_core/src/lib.rs
+++ b/src/zyheeda_core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod errors;
 pub mod prelude;
+pub mod yields;
 
 #[cfg(test)]
 mod tests;

--- a/src/zyheeda_core/src/prelude.rs
+++ b/src/zyheeda_core/src/prelude.rs
@@ -1,1 +1,1 @@
-pub use crate::errors::*;
+pub use crate::{errors::*, yields::*};

--- a/src/zyheeda_core/src/yields.rs
+++ b/src/zyheeda_core/src/yields.rs
@@ -1,0 +1,8 @@
+#[macro_export]
+macro_rules! yield_eager {
+	($($items:expr),* $(,)?) => {
+		[$($items),*].into_iter()
+	};
+}
+
+pub use yield_eager;


### PR DESCRIPTION
Loadout definitions moved to player and enemy crate. Done in preparation of enemies using skills like the player.

The enemy definitions are currently hard coded for `VoidSphere`. Needs to be refined once more enemy types exist.