### PR TITLE
Agent type targeting

### DIFF
--- a/src/plugins/behaviors/src/components/movement.rs
+++ b/src/plugins/behaviors/src/components/movement.rs
@@ -208,7 +208,7 @@ mod tests {
 		let mut app = setup(Movement::<_T>::set_faces);
 		let entity = app
 			.world_mut()
-			.spawn((Movement::<_T>::default(), SetFace(Face::Cursor)))
+			.spawn((Movement::<_T>::default(), SetFace(Face::Target)))
 			.id();
 
 		app.update();
@@ -223,7 +223,7 @@ mod tests {
 		let mut app = setup(Movement::<_T>::set_faces);
 		let entity = app
 			.world_mut()
-			.spawn((Movement::<_T>::default(), SetFace(Face::Cursor)))
+			.spawn((Movement::<_T>::default(), SetFace(Face::Target)))
 			.id();
 
 		app.update();

--- a/src/plugins/behaviors/src/lib.rs
+++ b/src/plugins/behaviors/src/lib.rs
@@ -66,7 +66,7 @@ use systems::{
 	attack::AttackSystem,
 	base_behavior::SelectBehavior,
 	chase::ChaseSystem,
-	face::{execute_face::execute_face, get_faces::get_faces},
+	face::{execute_face::execute_face, get_faces::GetFaces},
 	movement::{
 		animate_movement::AnimateMovement,
 		execute_move_update::ExecuteMovement,
@@ -244,7 +244,8 @@ where
 					// Apply facing
 					(
 						Movement::<VelocityBased>::set_faces,
-						get_faces.pipe(execute_face::<TPlayers::TMouseHover, TPlayers::TCamRay>),
+						TPlayers::TPlayer::get_faces
+							.pipe(execute_face::<TPlayers::TMouseHover, TPlayers::TCamRay>),
 					)
 						.chain(),
 				)

--- a/src/plugins/behaviors/src/lib.rs
+++ b/src/plugins/behaviors/src/lib.rs
@@ -9,7 +9,7 @@ use crate::{
 		fix_points::{Anchor, FixPoints, fix_point::FixPoint},
 		on_cool_down::OnCoolDown,
 	},
-	systems::movement::compute_path::MovementPath,
+	systems::{face::execute_enemy_face::execute_enemy_face, movement::compute_path::MovementPath},
 };
 use bevy::prelude::*;
 use bevy_rapier3d::prelude::Velocity;
@@ -66,7 +66,7 @@ use systems::{
 	attack::AttackSystem,
 	base_behavior::SelectBehavior,
 	chase::ChaseSystem,
-	face::{execute_face::execute_face, get_faces::GetFaces},
+	face::{execute_player_face::execute_player_face, get_faces::GetFaces},
 	movement::{
 		animate_movement::AnimateMovement,
 		execute_move_update::ExecuteMovement,
@@ -245,7 +245,8 @@ where
 					(
 						Movement::<VelocityBased>::set_faces,
 						TPlayers::TPlayer::get_faces
-							.pipe(execute_face::<TPlayers::TMouseHover, TPlayers::TCamRay>),
+							.pipe(execute_player_face::<TPlayers::TMouseHover, TPlayers::TCamRay>),
+						TEnemies::TEnemyBehavior::get_faces.pipe(execute_enemy_face),
 					)
 						.chain(),
 				)

--- a/src/plugins/behaviors/src/systems/face.rs
+++ b/src/plugins/behaviors/src/systems/face.rs
@@ -1,2 +1,3 @@
-pub(crate) mod execute_face;
+pub(crate) mod execute_enemy_face;
+pub(crate) mod execute_player_face;
 pub(crate) mod get_faces;

--- a/src/plugins/behaviors/src/systems/face/execute_enemy_face.rs
+++ b/src/plugins/behaviors/src/systems/face/execute_enemy_face.rs
@@ -1,0 +1,230 @@
+use crate::components::Attack;
+use bevy::prelude::*;
+use common::{
+	components::persistent_entity::PersistentEntity,
+	traits::{accessors::get::GetMut, handles_orientation::Face},
+	zyheeda_commands::ZyheedaCommands,
+};
+
+pub(crate) fn execute_enemy_face(
+	In(faces): In<Vec<(Entity, Face)>>,
+	mut commands: ZyheedaCommands,
+	mut transforms: Query<&mut Transform>,
+	attacks: Query<&Attack>,
+) {
+	for (entity, face) in faces {
+		let (mut transform, target) = match face {
+			Face::Target => {
+				let Ok(Attack(target)) = attacks.get(entity) else {
+					continue;
+				};
+				let Some(target) = get_translation(&mut commands, &transforms, target) else {
+					continue;
+				};
+				let Ok(transform) = transforms.get_mut(entity) else {
+					continue;
+				};
+				(transform, target)
+			}
+			Face::Entity(target) => {
+				let Some(target) = get_translation(&mut commands, &transforms, &target) else {
+					continue;
+				};
+				let Ok(transform) = transforms.get_mut(entity) else {
+					continue;
+				};
+				(transform, target)
+			}
+			Face::Translation(target) => {
+				let Ok(transform) = transforms.get_mut(entity) else {
+					continue;
+				};
+				(transform, target)
+			}
+		};
+
+		if transform.translation == target {
+			continue;
+		}
+
+		transform.look_at(target, Vec3::Y);
+	}
+}
+
+fn get_translation(
+	commands: &mut ZyheedaCommands,
+	transforms: &Query<&mut Transform>,
+	target: &PersistentEntity,
+) -> Option<Vec3> {
+	commands
+		.get_mut(target)
+		.and_then(|target| transforms.get(target.id()).ok())
+		.map(|target| target.translation)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use bevy::ecs::system::{RunSystemError, RunSystemOnce};
+	use common::{
+		components::persistent_entity::PersistentEntity,
+		traits::register_persistent_entities::RegisterPersistentEntities,
+	};
+	use std::sync::LazyLock;
+	use testing::SingleThreadedApp;
+
+	static TARGET: LazyLock<PersistentEntity> = LazyLock::new(PersistentEntity::default);
+
+	#[derive(Component)]
+	#[require(PersistentEntity = *TARGET)]
+	struct _Target;
+
+	fn setup() -> App {
+		let mut app = App::new().single_threaded(Update);
+
+		app.register_persistent_entities();
+
+		app
+	}
+
+	mod target {
+		use super::*;
+
+		#[test]
+		fn face() -> Result<(), RunSystemError> {
+			let mut app = setup();
+			app.world_mut()
+				.spawn((Transform::from_xyz(1., 2., 3.), _Target));
+			let agent = app
+				.world_mut()
+				.spawn((Transform::from_xyz(5., 4., 11.), Attack(*TARGET)))
+				.id();
+
+			app.world_mut()
+				.run_system_once_with(execute_enemy_face, vec![(agent, Face::Target)])?;
+
+			assert_eq!(
+				Some(&Transform::from_xyz(5., 4., 11.).looking_at(Vec3::new(1., 2., 3.), Vec3::Y)),
+				app.world().entity(agent).get::<Transform>()
+			);
+			Ok(())
+		}
+
+		#[test]
+		fn no_default_rotation_when_looking_at_self() -> Result<(), RunSystemError> {
+			let mut app = setup();
+			let persistent_agent = PersistentEntity::default();
+			let agent = app
+				.world_mut()
+				.spawn((
+					persistent_agent,
+					Transform::from_xyz(5., 4., 11.).looking_to(Vec3::X, Vec3::Y),
+					Attack(persistent_agent),
+				))
+				.id();
+
+			app.world_mut()
+				.run_system_once_with(execute_enemy_face, vec![(agent, Face::Target)])?;
+
+			assert_eq!(
+				Some(&Transform::from_xyz(5., 4., 11.).looking_to(Vec3::X, Vec3::Y)),
+				app.world().entity(agent).get::<Transform>()
+			);
+			Ok(())
+		}
+	}
+
+	mod translation {
+		use super::*;
+
+		#[test]
+		fn face() -> Result<(), RunSystemError> {
+			let mut app = setup();
+			let agent = app.world_mut().spawn(Transform::from_xyz(4., 5., 6.)).id();
+
+			app.world_mut().run_system_once_with(
+				execute_enemy_face,
+				vec![(agent, Face::Translation(Vec3::new(10., 11., 12.)))],
+			)?;
+
+			assert_eq!(
+				Some(
+					&Transform::from_xyz(4., 5., 6.).looking_at(Vec3::new(10., 11., 12.), Vec3::Y)
+				),
+				app.world().entity(agent).get::<Transform>()
+			);
+			Ok(())
+		}
+
+		#[test]
+		fn no_default_rotation_when_looking_at_self() -> Result<(), RunSystemError> {
+			let mut app = setup();
+			let persistent_agent = PersistentEntity::default();
+			let agent = app
+				.world_mut()
+				.spawn((
+					persistent_agent,
+					Transform::from_xyz(4., 5., 6.).looking_to(Vec3::X, Vec3::Y),
+					Attack(persistent_agent),
+				))
+				.id();
+
+			app.world_mut().run_system_once_with(
+				execute_enemy_face,
+				vec![(agent, Face::Translation(Vec3::new(4., 5., 6.)))],
+			)?;
+
+			assert_eq!(
+				Some(&Transform::from_xyz(4., 5., 6.).looking_to(Vec3::X, Vec3::Y)),
+				app.world().entity(agent).get::<Transform>()
+			);
+			Ok(())
+		}
+	}
+
+	mod entity {
+		use super::*;
+
+		#[test]
+		fn face() -> Result<(), RunSystemError> {
+			let mut app = setup();
+			app.world_mut()
+				.spawn((Transform::from_xyz(15., 2., 3.), _Target));
+			let agent = app.world_mut().spawn(Transform::from_xyz(1., 4., 11.)).id();
+
+			app.world_mut()
+				.run_system_once_with(execute_enemy_face, vec![(agent, Face::Entity(*TARGET))])?;
+
+			assert_eq!(
+				Some(&Transform::from_xyz(1., 4., 11.).looking_at(Vec3::new(15., 2., 3.), Vec3::Y)),
+				app.world().entity(agent).get::<Transform>()
+			);
+			Ok(())
+		}
+
+		#[test]
+		fn no_default_rotation_when_looking_at_self() -> Result<(), RunSystemError> {
+			let mut app = setup();
+			let persistent_agent = PersistentEntity::default();
+			let agent = app
+				.world_mut()
+				.spawn((
+					persistent_agent,
+					Transform::from_xyz(1., 4., 11.).looking_to(Vec3::X, Vec3::Y),
+					Attack(persistent_agent),
+				))
+				.id();
+
+			app.world_mut().run_system_once_with(
+				execute_enemy_face,
+				vec![(agent, Face::Entity(persistent_agent))],
+			)?;
+
+			assert_eq!(
+				Some(&Transform::from_xyz(1., 4., 11.).looking_to(Vec3::X, Vec3::Y)),
+				app.world().entity(agent).get::<Transform>()
+			);
+			Ok(())
+		}
+	}
+}

--- a/src/plugins/behaviors/src/systems/face/execute_face.rs
+++ b/src/plugins/behaviors/src/systems/face/execute_face.rs
@@ -63,7 +63,7 @@ fn get_face_targets(
 		.filter_map(|(id, face)| {
 			let target = match *face {
 				Face::Translation(translation) => Some(translation),
-				Face::Cursor => Some(target),
+				Face::Target => Some(target),
 				Face::Entity(entity) => {
 					let target = get_target(entity, &colliders, &mut commands)?;
 					get_translation(target, transforms)
@@ -180,7 +180,7 @@ mod tests {
 		}));
 		let agent = app
 			.world_mut()
-			.spawn((Transform::from_xyz(4., 5., 6.), _Face(Face::Cursor)))
+			.spawn((Transform::from_xyz(4., 5., 6.), _Face(Face::Target)))
 			.id();
 
 		app.update();
@@ -232,7 +232,7 @@ mod tests {
 		}));
 		let agent = app
 			.world_mut()
-			.spawn((Transform::from_xyz(4., 5., 6.), _Face(Face::Cursor)))
+			.spawn((Transform::from_xyz(4., 5., 6.), _Face(Face::Target)))
 			.id();
 		let root = app
 			.world_mut()
@@ -267,7 +267,7 @@ mod tests {
 			.world_mut()
 			.spawn((
 				Transform::from_xyz(4., 5., 6.).looking_to(Vec3::new(1., 0., 1.), Vec3::Y),
-				_Face(Face::Cursor),
+				_Face(Face::Target),
 			))
 			.id();
 		let collider = app
@@ -297,7 +297,7 @@ mod tests {
 		}));
 		let agent = app
 			.world_mut()
-			.spawn((Transform::from_xyz(4., 5., 6.), _Face(Face::Cursor)))
+			.spawn((Transform::from_xyz(4., 5., 6.), _Face(Face::Target)))
 			.id();
 		let collider = app
 			.world_mut()
@@ -328,7 +328,7 @@ mod tests {
 			.world_mut()
 			.spawn((
 				Transform::from_xyz(4., 5., 6.).looking_to(Vec3::new(1., 0., 1.), Vec3::Y),
-				_Face(Face::Cursor),
+				_Face(Face::Target),
 			))
 			.id();
 		app.insert_resource(_MouseHover(Some(ColliderInfo {
@@ -438,7 +438,7 @@ mod tests {
 			.world_mut()
 			.spawn((
 				Transform::from_xyz(4., 5., 6.),
-				_Face(Face::Cursor),
+				_Face(Face::Target),
 				Immobilized,
 			))
 			.id();
@@ -461,7 +461,7 @@ mod tests {
 		}));
 		let agent = app
 			.world_mut()
-			.spawn((Transform::from_xyz(4., 5., 6.), _Face(Face::Cursor)))
+			.spawn((Transform::from_xyz(4., 5., 6.), _Face(Face::Target)))
 			.id();
 		let collider = app
 			.world_mut()

--- a/src/plugins/behaviors/src/systems/face/execute_player_face.rs
+++ b/src/plugins/behaviors/src/systems/face/execute_player_face.rs
@@ -16,7 +16,7 @@ use common::{
 	zyheeda_commands::ZyheedaCommands,
 };
 
-pub(crate) fn execute_face<TMouseHover, TCursor>(
+pub(crate) fn execute_player_face<TMouseHover, TCursor>(
 	In(faces): In<Vec<(Entity, Face)>>,
 	mut transforms: Query<(Entity, &mut Transform, Option<&Immobilized>)>,
 	commands: ZyheedaCommands,
@@ -164,7 +164,7 @@ mod tests {
 		app.register_persistent_entities();
 		app.add_systems(
 			Update,
-			read_faces.pipe(execute_face::<_MouseHover, _Cursor>),
+			read_faces.pipe(execute_player_face::<_MouseHover, _Cursor>),
 		);
 		app.insert_resource(cursor);
 		app.init_resource::<_MouseHover>();

--- a/src/plugins/behaviors/src/systems/face/get_faces.rs
+++ b/src/plugins/behaviors/src/systems/face/get_faces.rs
@@ -80,7 +80,7 @@ mod tests {
 		let face = Face::Translation(Vec3::new(1., 2., 3.));
 		let agent = app
 			.world_mut()
-			.spawn((SetFace(Face::Cursor), OverrideFace(face)))
+			.spawn((SetFace(Face::Target), OverrideFace(face)))
 			.id();
 
 		app.update();

--- a/src/plugins/common/src/traits/handles_orientation.rs
+++ b/src/plugins/common/src/traits/handles_orientation.rs
@@ -11,7 +11,8 @@ pub trait HandlesOrientation {
 #[derive(Default, Debug, PartialEq, Clone, Copy, Serialize, Deserialize)]
 pub enum Face {
 	#[default]
-	Cursor,
+	/// This is dependent on the type of agent, for a player it likely means the cursor.
+	Target,
 	Entity(PersistentEntity),
 	Translation(Vec3),
 }

--- a/src/plugins/skills/src/systems/advance_active_skill.rs
+++ b/src/plugins/skills/src/systems/advance_active_skill.rs
@@ -113,7 +113,7 @@ where
 	agent.remove::<SkillSideEffectsCleared>();
 
 	if states.contains(&StateMeta::Entering(SkillState::Aim)) {
-		agent.try_insert(TOrientation::temporarily(Face::Cursor));
+		agent.try_insert(TOrientation::temporarily(Face::Target));
 		if let Err(error) = animate::<TPlayerAnimations>(skill, agent) {
 			errors.push(error);
 		}
@@ -966,7 +966,7 @@ mod tests {
 
 		let agent = app.world().entity(agent);
 
-		assert_eq!(Some(&_TempFace(Face::Cursor)), agent.get::<_TempFace>());
+		assert_eq!(Some(&_TempFace(Face::Target)), agent.get::<_TempFace>());
 	}
 
 	#[test]
@@ -1022,7 +1022,7 @@ mod tests {
 		app.update();
 
 		let agent = app.world().entity(agent);
-		assert_eq!(Some(&_TempFace(Face::Cursor)), agent.get::<_TempFace>());
+		assert_eq!(Some(&_TempFace(Face::Target)), agent.get::<_TempFace>());
 	}
 
 	#[test]
@@ -1031,7 +1031,7 @@ mod tests {
 		app.world_mut().entity_mut(agent).insert((
 			_Dequeue { active: None },
 			Transform::from_xyz(-1., -2., -3.),
-			_TempFace(Face::Cursor),
+			_TempFace(Face::Target),
 		));
 
 		app.update();


### PR DESCRIPTION
Previous cursor facing has been replaced with target facing. `Target` is now context specific depending on agent.
- player: faces cursor
- enemy; faces attack target