### PR TITLE
Token light

### DIFF
--- a/src/plugins/common/src/traits/handles_localization.rs
+++ b/src/plugins/common/src/traits/handles_localization.rs
@@ -9,24 +9,40 @@ use std::{fmt::Display, ops::Deref, sync::Arc};
 use unic_langid::LanguageIdentifier;
 
 pub trait HandlesLocalization {
-	type TLocalizationServer: Resource + SetLocalization + LocalizeToken;
+	type TLocalizationServer: Resource + SetLocalization + Localize;
 }
 
 pub trait SetLocalization {
 	fn set_localization(&mut self, language: LanguageIdentifier);
 }
 
+pub trait Localize {
+	fn localize(&self, token: &Token) -> LocalizationResult;
+}
+
 pub trait LocalizeToken {
 	fn localize_token<TToken>(&self, token: TToken) -> LocalizationResult
 	where
-		TToken: Into<Token> + 'static;
+		TToken: Into<Token>;
+}
+
+impl<T> LocalizeToken for T
+where
+	T: Localize,
+{
+	fn localize_token<TToken>(&self, token: TToken) -> LocalizationResult
+	where
+		TToken: Into<Token>,
+	{
+		self.localize(&token.into())
+	}
 }
 
 #[derive(Debug, PartialEq, Default, Clone)]
 pub struct Token(Arc<str>);
 
 impl Token {
-	pub fn failed(self) -> FailedToken {
+	pub fn failed(&self) -> FailedToken {
 		FailedToken(self.0.clone())
 	}
 }

--- a/src/plugins/common/src/traits/handles_localization.rs
+++ b/src/plugins/common/src/traits/handles_localization.rs
@@ -23,7 +23,7 @@ pub trait LocalizeToken {
 }
 
 #[derive(Debug, PartialEq, Default, Clone)]
-pub struct Token(pub Arc<str>);
+pub struct Token(Arc<str>);
 
 impl Token {
 	pub fn failed(self) -> FailedToken {
@@ -58,7 +58,7 @@ impl Deref for Token {
 }
 
 #[derive(Debug, PartialEq, Clone)]
-pub struct FailedToken(pub Arc<str>);
+pub struct FailedToken(Arc<str>);
 
 impl Deref for FailedToken {
 	type Target = str;

--- a/src/plugins/common/src/traits/handles_localization/key_code.rs
+++ b/src/plugins/common/src/traits/handles_localization/key_code.rs
@@ -4,7 +4,7 @@ use bevy::prelude::*;
 impl From<KeyCode> for Token {
 	fn from(value: KeyCode) -> Self {
 		let key = format!("{value:?}");
-		Token(format!("key-code-{}", camel_case_to_kebab(key)))
+		Token::from(format!("key-code-{}", camel_case_to_kebab(key)))
 	}
 }
 

--- a/src/plugins/common/src/traits/handles_localization/key_code.rs
+++ b/src/plugins/common/src/traits/handles_localization/key_code.rs
@@ -4,12 +4,14 @@ use bevy::prelude::*;
 impl From<KeyCode> for Token {
 	fn from(value: KeyCode) -> Self {
 		let key = format!("{value:?}");
-		Token::from(format!("key-code-{}", camel_case_to_kebab(key)))
+		Token::from(format!("key-code-{}", camel_case_to_kebab(&key)))
 	}
 }
 
-fn camel_case_to_kebab(str: String) -> String {
-	let mut result = vec![];
+const MOST_EXPECTED_HYPHENS: usize = 2;
+
+fn camel_case_to_kebab(str: &str) -> String {
+	let mut result = String::with_capacity(str.len() + MOST_EXPECTED_HYPHENS);
 	let mut chars = str.chars();
 	let mut last_was_digit = false;
 
@@ -29,7 +31,7 @@ fn camel_case_to_kebab(str: String) -> String {
 		last_was_digit = is_digit;
 	}
 
-	result.into_iter().collect()
+	result
 }
 
 #[cfg(test)]

--- a/src/plugins/common/src/traits/handles_localization/localized.rs
+++ b/src/plugins/common/src/traits/handles_localization/localized.rs
@@ -1,43 +1,46 @@
 use bevy::prelude::*;
+use std::{ops::Deref, sync::Arc};
 
 #[derive(Debug, PartialEq, Default, Clone)]
-pub struct Localized(pub String);
+pub struct Localized(pub Arc<str>);
 
-impl Localized {
-	pub fn from_string<T>(value: T) -> Self
-	where
-		T: Into<String>,
-	{
-		Self(value.into())
+impl Deref for Localized {
+	type Target = str;
+
+	fn deref(&self) -> &Self::Target {
+		self.0.as_ref()
 	}
 }
 
-impl From<&str> for Localized {
-	fn from(value: &str) -> Self {
-		Self::from_string(value)
-	}
-}
-
-impl From<String> for Localized {
-	fn from(value: String) -> Self {
-		Self::from_string(value)
-	}
-}
-
-impl From<Localized> for String {
-	fn from(Localized(string): Localized) -> Self {
-		string
+impl<T> From<T> for Localized
+where
+	T: Into<String>,
+{
+	fn from(value: T) -> Self {
+		Self(Arc::from(value.into()))
 	}
 }
 
 impl From<Localized> for Text {
 	fn from(Localized(string): Localized) -> Self {
-		Text(string)
+		Text((*string).to_owned())
+	}
+}
+
+impl From<&Localized> for Text {
+	fn from(Localized(string): &Localized) -> Self {
+		Text((**string).to_owned())
 	}
 }
 
 impl From<Localized> for Name {
 	fn from(Localized(string): Localized) -> Self {
-		Name::from(string)
+		Name::from(&*string)
+	}
+}
+
+impl From<&Localized> for Name {
+	fn from(Localized(string): &Localized) -> Self {
+		Name::from(&**string)
 	}
 }

--- a/src/plugins/common/src/traits/handles_localization/localized.rs
+++ b/src/plugins/common/src/traits/handles_localization/localized.rs
@@ -2,7 +2,7 @@ use bevy::prelude::*;
 use std::{ops::Deref, sync::Arc};
 
 #[derive(Debug, PartialEq, Default, Clone)]
-pub struct Localized(pub Arc<str>);
+pub struct Localized(pub(super) Arc<str>);
 
 impl Deref for Localized {
 	type Target = str;

--- a/src/plugins/common/src/traits/handles_localization/mouse_button.rs
+++ b/src/plugins/common/src/traits/handles_localization/mouse_button.rs
@@ -9,7 +9,7 @@ impl From<MouseButton> for Token {
 			MouseButton::Middle => Self::from("mouse-button-middle"),
 			MouseButton::Back => Self::from("mouse-button-back"),
 			MouseButton::Forward => Self::from("mouse-button-forward"),
-			MouseButton::Other(index) => Self(format!("mouse-button-other-{index}")),
+			MouseButton::Other(index) => Self::from(format!("mouse-button-other-{index}")),
 		}
 	}
 }

--- a/src/plugins/localization/src/resources/ftl_server.rs
+++ b/src/plugins/localization/src/resources/ftl_server.rs
@@ -136,7 +136,7 @@ where
 		};
 
 		match locales.iter().find_map(localize) {
-			Some(localized) => LocalizationResult::Ok(Localized(localized)),
+			Some(localized) => LocalizationResult::Ok(Localized::from(localized)),
 			None => LocalizationResult::Error(Token(str).failed()),
 		}
 	}

--- a/src/plugins/localization/src/resources/ftl_server.rs
+++ b/src/plugins/localization/src/resources/ftl_server.rs
@@ -96,11 +96,11 @@ where
 			Some(current) => (current, vec![current, &self.fallback]),
 			None => (&self.fallback, vec![&self.fallback]),
 		};
-		let Token(str) = token.into();
+		let str = &*token.into();
 		let localize = |locale: &&Locale| {
 			if locale.ln != current.ln {
 				self.logger.log_warning(FtlError::FallbackAttempt {
-					token: current.ln_token(&str),
+					token: current.ln_token(str),
 					fallback: locale.ln.clone(),
 				});
 			}
@@ -110,15 +110,15 @@ where
 				return None;
 			};
 
-			let Some(msg) = bundle.get_message(&str) else {
+			let Some(msg) = bundle.get_message(str) else {
 				self.logger
-					.log_error(FtlError::NoMessageFor(locale.ln_token(&str)));
+					.log_error(FtlError::NoMessageFor(locale.ln_token(str)));
 				return None;
 			};
 
 			let Some(pattern) = msg.value() else {
 				self.logger
-					.log_error(FtlError::NoPatternFor(locale.ln_token(&str)));
+					.log_error(FtlError::NoPatternFor(locale.ln_token(str)));
 				return None;
 			};
 
@@ -127,7 +127,7 @@ where
 
 			if !fluent_errors.is_empty() {
 				self.logger.log_error(FtlError::FluentErrors {
-					token: locale.ln_token(&str),
+					token: locale.ln_token(str),
 					errors: fluent_errors,
 				});
 			}
@@ -137,7 +137,7 @@ where
 
 		match locales.iter().find_map(localize) {
 			Some(localized) => LocalizationResult::Ok(Localized::from(localized)),
-			None => LocalizationResult::Error(Token(str).failed()),
+			None => LocalizationResult::Error(Token::from(str).failed()),
 		}
 	}
 }

--- a/src/plugins/localization/src/resources/ftl_server.rs
+++ b/src/plugins/localization/src/resources/ftl_server.rs
@@ -8,7 +8,7 @@ use common::traits::{
 	handles_load_tracking::Loaded,
 	handles_localization::{
 		LocalizationResult,
-		LocalizeToken,
+		Localize,
 		SetLocalization,
 		Token,
 		localized::Localized,
@@ -84,19 +84,16 @@ impl SetLocalization for FtlServer {
 	}
 }
 
-impl<TLogger> LocalizeToken for FtlServer<TLogger>
+impl<TLogger> Localize for FtlServer<TLogger>
 where
 	TLogger: Log,
 {
-	fn localize_token<TToken>(&self, token: TToken) -> LocalizationResult
-	where
-		TToken: Into<Token>,
-	{
+	fn localize(&self, token: &Token) -> LocalizationResult {
 		let (current, locales) = match self.current.as_ref() {
 			Some(current) => (current, vec![current, &self.fallback]),
 			None => (&self.fallback, vec![&self.fallback]),
 		};
-		let str = &*token.into();
+		let str = &**token;
 		let localize = |locale: &&Locale| {
 			if locale.ln != current.ln {
 				self.logger.log_warning(FtlError::FallbackAttempt {
@@ -540,7 +537,7 @@ mod tests {
 
 		assert_eq!(
 			LocalizationResult::Ok(Localized::from("A!")),
-			server.localize_token("a")
+			server.localize(&Token::from("a"))
 		);
 	}
 
@@ -574,7 +571,7 @@ mod tests {
 
 		assert_eq!(
 			LocalizationResult::Ok(Localized::from("A!")),
-			server.localize_token("a")
+			server.localize(&Token::from("a"))
 		);
 	}
 
@@ -600,7 +597,7 @@ mod tests {
 
 		assert_eq!(
 			LocalizationResult::Error(Token::from("a").failed()),
-			server.localize_token("a")
+			server.localize(&Token::from("a"))
 		);
 	}
 
@@ -635,7 +632,7 @@ mod tests {
 
 		assert_eq!(
 			LocalizationResult::Error(Token::from("b").failed()),
-			server.localize_token("b")
+			server.localize(&Token::from("b"))
 		);
 	}
 
@@ -670,7 +667,7 @@ mod tests {
 
 		assert_eq!(
 			LocalizationResult::Error(Token::from("a").failed()),
-			server.localize_token("a"),
+			server.localize(&Token::from("a")),
 		);
 	}
 
@@ -712,7 +709,7 @@ mod tests {
 
 		assert_eq!(
 			LocalizationResult::Ok(Localized::from("{$a}")),
-			server.localize_token("a"),
+			server.localize(&Token::from("a")),
 		);
 	}
 
@@ -758,7 +755,7 @@ mod tests {
 
 		assert_eq!(
 			LocalizationResult::Ok(Localized::from("A!")),
-			server.localize_token("a"),
+			server.localize(&Token::from("a")),
 		);
 	}
 
@@ -813,7 +810,7 @@ mod tests {
 
 		assert_eq!(
 			LocalizationResult::Ok(Localized::from("A!")),
-			server.localize_token("a"),
+			server.localize(&Token::from("a")),
 		);
 	}
 
@@ -868,7 +865,7 @@ mod tests {
 
 		assert_eq!(
 			LocalizationResult::Ok(Localized::from("A!")),
-			server.localize_token("a"),
+			server.localize(&Token::from("a")),
 		);
 	}
 
@@ -921,7 +918,7 @@ mod tests {
 
 		assert_eq!(
 			LocalizationResult::Ok(Localized::from("{$a}")),
-			server.localize_token("a"),
+			server.localize(&Token::from("a")),
 		);
 	}
 }

--- a/src/plugins/menu/src/components/combo_overview.rs
+++ b/src/plugins/menu/src/components/combo_overview.rs
@@ -21,7 +21,7 @@ use bevy::{ecs::relationship::RelatedSpawnerCommands, prelude::*};
 use common::{
 	tools::{action_key::slot::PlayerSlot, skill_description::SkillToken, skill_icon::SkillIcon},
 	traits::{
-		handles_localization::{LocalizeToken, localized::Localized},
+		handles_localization::{Localize, LocalizeToken, localized::Localized},
 		inspect_able::{InspectAble, InspectField},
 		load_asset::{LoadAsset, Path},
 		thread_safe::ThreadSafe,
@@ -304,7 +304,7 @@ where
 		localize: &TLocalization,
 		parent: &mut RelatedSpawnerCommands<ChildOf>,
 	) where
-		TLocalization: LocalizeToken + 'static,
+		TLocalization: Localize + 'static,
 	{
 		let title = localize.localize_token("combo-skill-menu").or_token();
 
@@ -340,7 +340,7 @@ fn add_empty_combo<TLocalization>(
 	parent: &mut RelatedSpawnerCommands<ChildOf>,
 	icon: &Handle<Image>,
 ) where
-	TLocalization: LocalizeToken + 'static,
+	TLocalization: Localize + 'static,
 {
 	parent
 		.spawn(Node {
@@ -372,7 +372,7 @@ fn add_combo_list<TSkill, TLocalization>(
 	combo_overview: &ComboOverview<TSkill>,
 ) where
 	TSkill: InspectAble<SkillToken> + InspectAble<SkillIcon> + Clone + PartialEq + ThreadSafe,
-	TLocalization: LocalizeToken + 'static,
+	TLocalization: Localize + 'static,
 {
 	parent
 		.spawn(Node {
@@ -402,7 +402,7 @@ fn add_combo<TSkill, TLocalization>(
 	new_skill_icon: &Handle<Image>,
 ) where
 	TSkill: InspectAble<SkillToken> + InspectAble<SkillIcon> + Clone + PartialEq + ThreadSafe,
-	TLocalization: LocalizeToken + 'static,
+	TLocalization: Localize + 'static,
 {
 	parent
 		.spawn((
@@ -425,7 +425,7 @@ fn add_combo<TSkill, TLocalization>(
 
 enum AddPanel<'a, TSkill, TLocalization>
 where
-	TLocalization: LocalizeToken + 'static,
+	TLocalization: Localize + 'static,
 {
 	StartCombo {
 		panel_overlay: PanelOverlay<TLocalization>,
@@ -444,7 +444,7 @@ where
 
 impl<TLocalization> AddPanel<'_, (), TLocalization>
 where
-	TLocalization: LocalizeToken + 'static,
+	TLocalization: Localize + 'static,
 {
 	fn start_combo(
 		localize: &TLocalization,
@@ -495,7 +495,7 @@ where
 impl<TSkill, TLocalization> AddPanel<'_, TSkill, TLocalization>
 where
 	TSkill: InspectAble<SkillToken> + InspectAble<SkillIcon> + Clone + ThreadSafe,
-	TLocalization: LocalizeToken,
+	TLocalization: Localize,
 {
 	fn spawn_as_child(
 		self,
@@ -540,7 +540,7 @@ where
 		let token = SkillToken::inspect_field(skill).clone();
 		let skill_bundle = (
 			ComboSkillButton::<DropdownTrigger, TSkill>::new(skill.clone(), key_path.to_vec()),
-			Tooltip::new(localize.localize_token(token).or_token()),
+			Tooltip::new(localize.localize(&token).or_token()),
 			ComboOverview::skill_button(SkillIcon::inspect_field(skill).clone()),
 			SkillSelectDropdownInsertCommand::<PlayerSlot, Vertical>::new(key_path.to_vec()),
 		);
@@ -568,7 +568,7 @@ where
 impl<'a, TSkill, TLocalization> From<&'a ComboTreeElement<TSkill>>
 	for AddPanel<'a, TSkill, TLocalization>
 where
-	TLocalization: LocalizeToken + 'static,
+	TLocalization: Localize + 'static,
 {
 	fn from(element: &'a ComboTreeElement<TSkill>) -> Self {
 		match element {
@@ -639,7 +639,7 @@ fn add_key<TLocalization>(
 	parent: &mut RelatedSpawnerCommands<ChildOf>,
 	_: &TLocalization,
 ) where
-	TLocalization: LocalizeToken,
+	TLocalization: Localize,
 {
 	let Some(skill_key) = key_path.last() else {
 		return;
@@ -661,7 +661,7 @@ fn add_append_button<TLocalization>(
 	parent: &mut RelatedSpawnerCommands<ChildOf>,
 	localize: &TLocalization,
 ) where
-	TLocalization: LocalizeToken,
+	TLocalization: Localize,
 {
 	let label = localize.localize_token("combo-skill-add").or_token();
 
@@ -688,7 +688,7 @@ fn add_delete_button<TLocalization>(
 	parent: &mut RelatedSpawnerCommands<ChildOf>,
 	localize: &TLocalization,
 ) where
-	TLocalization: LocalizeToken,
+	TLocalization: Localize,
 {
 	let label = localize.localize_token("combo-skill-delete").or_token();
 

--- a/src/plugins/menu/src/components/combo_overview.rs
+++ b/src/plugins/menu/src/components/combo_overview.rs
@@ -325,7 +325,7 @@ fn add_title(parent: &mut RelatedSpawnerCommands<ChildOf>, title: Localized) {
 		})
 		.with_children(|parent| {
 			parent.spawn((
-				Text::new(title),
+				Text::from(title),
 				TextFont {
 					font_size: 40.,
 					..default()

--- a/src/plugins/menu/src/components/combo_skill_button.rs
+++ b/src/plugins/menu/src/components/combo_skill_button.rs
@@ -4,7 +4,7 @@ use bevy::{ecs::relationship::RelatedSpawnerCommands, prelude::*};
 use common::{
 	tools::{action_key::slot::PlayerSlot, skill_description::SkillToken, skill_icon::SkillIcon},
 	traits::{
-		handles_localization::LocalizeToken,
+		handles_localization::Localize,
 		inspect_able::{InspectAble, InspectField},
 		thread_safe::ThreadSafe,
 	},
@@ -51,10 +51,10 @@ where
 		localize: &TLocalization,
 		parent: &mut RelatedSpawnerCommands<ChildOf>,
 	) where
-		TLocalization: LocalizeToken,
+		TLocalization: Localize,
 	{
 		let token = SkillToken::inspect_field(&self.skill);
-		let name = localize.localize_token(token.clone()).or_token();
+		let name = localize.localize(token).or_token();
 
 		parent.spawn((
 			self.clone(),

--- a/src/plugins/menu/src/components/inventory_screen.rs
+++ b/src/plugins/menu/src/components/inventory_screen.rs
@@ -7,7 +7,7 @@ use bevy::{ecs::relationship::RelatedSpawnerCommands, prelude::*};
 use common::{
 	tools::{action_key::slot::PlayerSlot, inventory_key::InventoryKey},
 	traits::{
-		handles_localization::{LocalizeToken, localized::Localized},
+		handles_localization::{Localize, LocalizeToken, localized::Localized},
 		iteration::{IterFinite, IterInfinite},
 		thread_safe::ThreadSafe,
 	},
@@ -29,7 +29,7 @@ impl InsertUiContent for InventoryScreen {
 		localize: &TLocalization,
 		parent: &mut RelatedSpawnerCommands<ChildOf>,
 	) where
-		TLocalization: LocalizeToken,
+		TLocalization: Localize,
 	{
 		parent
 			.spawn(Node {
@@ -46,7 +46,7 @@ fn add_inventory<TLocalization>(
 	localize: &TLocalization,
 ) -> impl FnMut(&mut RelatedSpawnerCommands<ChildOf>)
 where
-	TLocalization: LocalizeToken,
+	TLocalization: Localize,
 {
 	move |parent| {
 		let mut keys = InventoryKey::iterator_infinite();
@@ -77,7 +77,7 @@ fn add_equipment<TLocalization>(
 	localize: &TLocalization,
 ) -> impl FnMut(&mut RelatedSpawnerCommands<ChildOf>)
 where
-	TLocalization: LocalizeToken,
+	TLocalization: Localize,
 {
 	move |parent| {
 		let equipment = localize.localize_token("equipment").or(|_| "Equipment");
@@ -133,7 +133,7 @@ fn add_grid<TKey, TLocalization>(
 	localize: &TLocalization,
 ) where
 	TKey: ThreadSafe,
-	TLocalization: LocalizeToken,
+	TLocalization: Localize,
 {
 	let label = &grid_label;
 	let empty = &localize.localize_token("inventory-item-empty").or_token();

--- a/src/plugins/menu/src/components/inventory_screen.rs
+++ b/src/plugins/menu/src/components/inventory_screen.rs
@@ -114,7 +114,7 @@ fn add_title(parent: &mut RelatedSpawnerCommands<ChildOf>, title: Localized) {
 		})
 		.with_children(|parent| {
 			parent.spawn((
-				Text::new(title),
+				Text::from(title),
 				TextFont {
 					font_size: 40.0,
 					..default()
@@ -147,7 +147,7 @@ fn add_grid<TKey, TLocalization>(
 			})
 			.with_children(|parent| {
 				parent.spawn((
-					Text::new(label.clone()),
+					Text::from(label),
 					TextFont {
 						font_size: 20.0,
 						..default()
@@ -171,7 +171,7 @@ fn add_grid<TKey, TLocalization>(
 						))
 						.with_children(|parent| {
 							parent.spawn((
-								Text::new(empty.clone()),
+								Text::from(empty),
 								TextFont {
 									font_size: 15.0,
 									..default()

--- a/src/plugins/menu/src/components/loading_screen.rs
+++ b/src/plugins/menu/src/components/loading_screen.rs
@@ -68,7 +68,7 @@ impl InsertUiContent for LoadingScreen<AssetsProgress> {
 		let label = localize.localize_token("loading-assets").or_token();
 
 		parent.spawn((
-			Text::new(label),
+			Text::from(label),
 			TextFont {
 				font_size: 32.,
 				..default()
@@ -88,7 +88,7 @@ impl InsertUiContent for LoadingScreen<DependenciesProgress> {
 		let label = localize.localize_token("resolving-dependencies").or_token();
 
 		parent.spawn((
-			Text::new(label),
+			Text::from(label),
 			TextFont {
 				font_size: 32.,
 				..default()

--- a/src/plugins/menu/src/components/loading_screen.rs
+++ b/src/plugins/menu/src/components/loading_screen.rs
@@ -2,7 +2,7 @@ use crate::traits::{LoadUi, insert_ui_content::InsertUiContent};
 use bevy::{ecs::relationship::RelatedSpawnerCommands, prelude::*};
 use common::traits::{
 	handles_load_tracking::{AssetsProgress, DependenciesProgress, Progress},
-	handles_localization::LocalizeToken,
+	handles_localization::{Localize, LocalizeToken},
 };
 use std::marker::PhantomData;
 
@@ -63,7 +63,7 @@ impl InsertUiContent for LoadingScreen<AssetsProgress> {
 		localize: &TLocalization,
 		parent: &mut RelatedSpawnerCommands<ChildOf>,
 	) where
-		TLocalization: LocalizeToken,
+		TLocalization: Localize,
 	{
 		let label = localize.localize_token("loading-assets").or_token();
 
@@ -83,7 +83,7 @@ impl InsertUiContent for LoadingScreen<DependenciesProgress> {
 		localize: &TLocalization,
 		parent: &mut RelatedSpawnerCommands<ChildOf>,
 	) where
-		TLocalization: LocalizeToken,
+		TLocalization: Localize,
 	{
 		let label = localize.localize_token("resolving-dependencies").or_token();
 

--- a/src/plugins/menu/src/components/settings_screen.rs
+++ b/src/plugins/menu/src/components/settings_screen.rs
@@ -21,7 +21,7 @@ use common::{
 		user_input::UserInput,
 	},
 	traits::{
-		handles_localization::{LocalizeToken, Token},
+		handles_localization::{Localize, LocalizeToken, Token},
 		iterate::Iterate,
 		iteration::IterFinite,
 		thread_safe::ThreadSafe,
@@ -39,8 +39,8 @@ pub(crate) struct SettingsScreen {
 impl SettingsScreen {
 	fn add_title(
 		parent: &mut RelatedSpawnerCommands<ChildOf>,
-		localize: &(impl LocalizeToken + ThreadSafe),
-		title: (impl Into<Token> + 'static),
+		localize: &(impl Localize + ThreadSafe),
+		title: impl Into<Token>,
 	) {
 		parent.spawn((
 			Text::from(localize.localize_token(title).or_token()),
@@ -53,8 +53,8 @@ impl SettingsScreen {
 
 	fn add_section_title(
 		parent: &mut RelatedSpawnerCommands<ChildOf>,
-		localize: &(impl LocalizeToken + ThreadSafe),
-		title: (impl Into<Token> + 'static),
+		localize: &(impl Localize + ThreadSafe),
+		title: impl Into<Token>,
 	) {
 		parent
 			.spawn(Node {
@@ -73,8 +73,8 @@ impl SettingsScreen {
 	fn add_section<T>(
 		&self,
 		parent: &mut RelatedSpawnerCommands<ChildOf>,
-		localize: &(impl LocalizeToken + ThreadSafe),
-		title: (impl Into<Token> + 'static),
+		localize: &(impl Localize + ThreadSafe),
+		title: impl Into<Token>,
 	) where
 		T: IterFinite,
 		ActionKey: From<T>,
@@ -146,7 +146,7 @@ impl InsertUiContent for SettingsScreen {
 		localize: &TLocalization,
 		parent: &mut RelatedSpawnerCommands<ChildOf>,
 	) where
-		TLocalization: LocalizeToken + ThreadSafe,
+		TLocalization: Localize + ThreadSafe,
 	{
 		parent
 			.spawn(Node {

--- a/src/plugins/menu/src/components/settings_screen.rs
+++ b/src/plugins/menu/src/components/settings_screen.rs
@@ -43,7 +43,7 @@ impl SettingsScreen {
 		title: (impl Into<Token> + 'static),
 	) {
 		parent.spawn((
-			Text::new(localize.localize_token(title).or_token()),
+			Text::from(localize.localize_token(title).or_token()),
 			TextFont {
 				font_size: 40.0,
 				..default()
@@ -62,7 +62,7 @@ impl SettingsScreen {
 				..default()
 			})
 			.with_child((
-				Text::new(localize.localize_token(title).or_token()),
+				Text::from(localize.localize_token(title).or_token()),
 				TextFont {
 					font_size: 20.0,
 					..default()

--- a/src/plugins/menu/src/components/settings_screen/key_bind.rs
+++ b/src/plugins/menu/src/components/settings_screen/key_bind.rs
@@ -9,7 +9,7 @@ use crate::traits::{
 };
 use bevy::{ecs::relationship::RelatedSpawnerCommands, prelude::*};
 use common::traits::{
-	handles_localization::{LocalizeToken, Token},
+	handles_localization::{Localize, LocalizeToken, Token},
 	thread_safe::ThreadSafe,
 };
 
@@ -45,7 +45,7 @@ where
 		localization: &TLocalization,
 		parent: &mut RelatedSpawnerCommands<ChildOf>,
 	) where
-		TLocalization: LocalizeToken + ThreadSafe,
+		TLocalization: Localize + ThreadSafe,
 	{
 		parent.spawn((
 			Text::from(localization.localize_token(self.0).or_token()),

--- a/src/plugins/menu/src/components/start_menu.rs
+++ b/src/plugins/menu/src/components/start_menu.rs
@@ -54,7 +54,7 @@ impl InsertUiContent for StartMenu {
 			})
 			.with_children(|parent| {
 				parent.spawn((
-					Text::new(title),
+					Text::from(title),
 					TextFont {
 						font_size: 64.0,
 						..default()

--- a/src/plugins/menu/src/components/start_menu.rs
+++ b/src/plugins/menu/src/components/start_menu.rs
@@ -3,7 +3,7 @@ use crate::traits::{LoadUi, colors::PanelColors, insert_ui_content::InsertUiCont
 use bevy::{ecs::relationship::RelatedSpawnerCommands, prelude::*};
 use common::{
 	states::{game_state::GameState, save_state::SaveState},
-	traits::handles_localization::LocalizeToken,
+	traits::handles_localization::{Localize, LocalizeToken},
 };
 
 #[derive(Component)]
@@ -35,7 +35,7 @@ impl InsertUiContent for StartMenu {
 		localization: &TLocalization,
 		parent: &mut RelatedSpawnerCommands<ChildOf>,
 	) where
-		TLocalization: LocalizeToken,
+		TLocalization: Localize,
 	{
 		let title = localization
 			.localize_token("project-zyheeda")

--- a/src/plugins/menu/src/components/start_menu_button.rs
+++ b/src/plugins/menu/src/components/start_menu_button.rs
@@ -61,7 +61,7 @@ impl Prefab<()> for StartMenuButton {
 		_: &mut impl LoadAsset,
 	) -> Result<(), Error> {
 		entity.with_child((
-			Text::new(self.label.clone()),
+			Text::from(&self.label),
 			TextFont {
 				font_size: 32.0,
 				..default()

--- a/src/plugins/menu/src/components/tooltip.rs
+++ b/src/plugins/menu/src/components/tooltip.rs
@@ -175,7 +175,7 @@ mod tests {
 		where
 			TToken: Into<Token> + 'static,
 		{
-			let Token(token) = token.into();
+			let token = &*token.into();
 			LocalizationResult::Ok(Localized::from(format!("Token: {token}")))
 		}
 	}

--- a/src/plugins/menu/src/components/tooltip.rs
+++ b/src/plugins/menu/src/components/tooltip.rs
@@ -176,7 +176,7 @@ mod tests {
 			TToken: Into<Token> + 'static,
 		{
 			let Token(token) = token.into();
-			LocalizationResult::Ok(Localized(format!("Token: {token}")))
+			LocalizationResult::Ok(Localized::from(format!("Token: {token}")))
 		}
 	}
 

--- a/src/plugins/menu/src/components/tooltip.rs
+++ b/src/plugins/menu/src/components/tooltip.rs
@@ -1,4 +1,4 @@
-pub(crate) mod string;
+pub(crate) mod token;
 
 use super::GlobalZIndexTop;
 use crate::traits::{
@@ -12,12 +12,15 @@ use crate::traits::{
 	},
 };
 use bevy::prelude::*;
-use common::traits::{handles_localization::LocalizeToken, thread_safe::ThreadSafe};
+use common::traits::{handles_localization::Localize, thread_safe::ThreadSafe};
 use std::{marker::PhantomData, time::Duration};
 
 #[derive(Component, Debug, PartialEq, Clone)]
 #[require(Node, Interaction)]
-pub(crate) struct Tooltip<T>(T);
+pub(crate) struct Tooltip<T>(T)
+where
+	T: TooltipUiConfig,
+	Self: InsertUiContent;
 
 pub(crate) trait TooltipUiConfig {
 	fn node() -> Node {
@@ -99,6 +102,7 @@ where
 impl<T> DespawnOutdatedTooltips<TooltipContent<T>, T> for TooltipUIControl
 where
 	T: TooltipUiConfig + ThreadSafe,
+	Tooltip<T>: InsertUiContent,
 {
 	fn despawn_outdated(
 		&self,
@@ -141,7 +145,7 @@ impl<T, TLocalization> SpawnTooltips<T, TLocalization> for TooltipUIControl
 where
 	T: TooltipUiConfig + ThreadSafe,
 	Tooltip<T>: InsertUiContent,
-	TLocalization: LocalizeToken + ThreadSafe,
+	TLocalization: Localize + ThreadSafe,
 {
 	fn spawn(
 		&self,
@@ -162,7 +166,12 @@ where
 mod tests {
 	use super::*;
 	use bevy::ecs::relationship::RelatedSpawnerCommands;
-	use common::traits::handles_localization::{LocalizationResult, Token, localized::Localized};
+	use common::traits::handles_localization::{
+		LocalizationResult,
+		LocalizeToken,
+		Token,
+		localized::Localized,
+	};
 	use testing::{SingleThreadedApp, assert_count, get_children};
 
 	impl TooltipUiConfig for () {}
@@ -170,12 +179,9 @@ mod tests {
 	#[derive(Resource, Default)]
 	struct _Localize;
 
-	impl LocalizeToken for _Localize {
-		fn localize_token<TToken>(&self, token: TToken) -> LocalizationResult
-		where
-			TToken: Into<Token> + 'static,
-		{
-			let token = &*token.into();
+	impl Localize for _Localize {
+		fn localize(&self, token: &Token) -> LocalizationResult {
+			let token = &**token;
 			LocalizationResult::Ok(Localized::from(format!("Token: {token}")))
 		}
 	}
@@ -212,6 +218,7 @@ mod tests {
 	fn setup_despawn_outdated<T>() -> App
 	where
 		T: TooltipUiConfig + Clone + ThreadSafe,
+		Tooltip<T>: InsertUiContent,
 	{
 		let mut app = new_app();
 		app.add_systems(
@@ -258,7 +265,7 @@ mod tests {
 			localize: &TLocalization,
 			parent: &mut RelatedSpawnerCommands<ChildOf>,
 		) where
-			TLocalization: LocalizeToken,
+			TLocalization: Localize,
 		{
 			let label = localize
 				.localize_token(self.0.content)
@@ -338,14 +345,14 @@ mod tests {
 
 	#[test]
 	fn despawn_outdated() {
-		let mut app = setup_despawn_outdated::<&'static str>();
+		let mut app = setup_despawn_outdated::<Token>();
 		let tooltips = [
-			app.world_mut().spawn(Tooltip("1")).id(),
-			app.world_mut().spawn(Tooltip("2")).id(),
+			app.world_mut().spawn(Tooltip(Token::from("1"))).id(),
+			app.world_mut().spawn(Tooltip(Token::from("2"))).id(),
 		];
 		for entity in tooltips {
 			app.world_mut().spawn((
-				TooltipContent::<&'static str>::new(entity, default()),
+				TooltipContent::<Token>::new(entity, default()),
 				Node::default(),
 			));
 		}
@@ -361,22 +368,22 @@ mod tests {
 		let tooltip_uis = app
 			.world()
 			.iter_entities()
-			.filter(|e| e.contains::<TooltipContent<&'static str>>());
+			.filter(|e| e.contains::<TooltipContent<Token>>());
 
 		assert_eq!(0, tooltip_uis.count());
 	}
 
 	#[test]
 	fn despawn_outdated_recursively() {
-		let mut app = setup_despawn_outdated::<&'static str>();
+		let mut app = setup_despawn_outdated::<Token>();
 		let tooltips = [
-			app.world_mut().spawn(Tooltip("1")).id(),
-			app.world_mut().spawn(Tooltip("2")).id(),
+			app.world_mut().spawn(Tooltip(Token::from("1"))).id(),
+			app.world_mut().spawn(Tooltip(Token::from("2"))).id(),
 		];
 		for entity in tooltips {
 			app.world_mut()
 				.spawn((
-					TooltipContent::<&'static str>::new(entity, default()),
+					TooltipContent::<Token>::new(entity, default()),
 					Node::default(),
 				))
 				.with_children(|parent| {
@@ -402,14 +409,14 @@ mod tests {
 
 	#[test]
 	fn do_not_despawn_when_not_outdated() {
-		let mut app = setup_despawn_outdated::<&'static str>();
+		let mut app = setup_despawn_outdated::<Token>();
 		let tooltips = [
-			app.world_mut().spawn(Tooltip("1")).id(),
-			app.world_mut().spawn(Tooltip("2")).id(),
+			app.world_mut().spawn(Tooltip(Token::from("1"))).id(),
+			app.world_mut().spawn(Tooltip(Token::from("2"))).id(),
 		];
 		for entity in tooltips {
 			app.world_mut().spawn((
-				TooltipContent::<&'static str>::new(entity, default()),
+				TooltipContent::<Token>::new(entity, default()),
 				Node::default(),
 			));
 		}
@@ -419,23 +426,23 @@ mod tests {
 		let tooltip_uis = app
 			.world()
 			.iter_entities()
-			.filter(|e| e.contains::<TooltipContent<&'static str>>());
+			.filter(|e| e.contains::<TooltipContent<Token>>());
 
 		assert_eq!(2, tooltip_uis.count());
 	}
 
 	#[test]
 	fn update_position() {
-		let mut app = setup_update_position::<&'static str>(MouseVec2(Vec2 { x: 42., y: 11. }));
+		let mut app = setup_update_position::<Token>(MouseVec2(Vec2 { x: 42., y: 11. }));
 		let uis = app
 			.world_mut()
 			.spawn_batch([
 				(
-					TooltipContent::<&'static str>::new(Entity::from_raw(100), default()),
+					TooltipContent::<Token>::new(Entity::from_raw(100), default()),
 					Node::default(),
 				),
 				(
-					TooltipContent::<&'static str>::new(Entity::from_raw(200), default()),
+					TooltipContent::<Token>::new(Entity::from_raw(200), default()),
 					Node::default(),
 				),
 			])

--- a/src/plugins/menu/src/components/tooltip/token.rs
+++ b/src/plugins/menu/src/components/tooltip/token.rs
@@ -1,9 +1,9 @@
 use super::{Tooltip, TooltipUiConfig};
 use crate::traits::{colors::PanelColors, insert_ui_content::InsertUiContent};
 use bevy::{ecs::relationship::RelatedSpawnerCommands, prelude::*};
-use common::traits::handles_localization::{LocalizeToken, localized::Localized};
+use common::traits::handles_localization::{Localize, Token, localized::Localized};
 
-impl TooltipUiConfig for &'static str {
+impl TooltipUiConfig for Token {
 	fn node() -> Node {
 		Node {
 			top: Val::Px(-25.0),
@@ -17,50 +17,15 @@ impl TooltipUiConfig for &'static str {
 	}
 }
 
-impl InsertUiContent for Tooltip<&'static str> {
+impl InsertUiContent for Tooltip<Token> {
 	fn insert_ui_content<TLocalization>(
 		&self,
 		localize: &TLocalization,
 		parent: &mut RelatedSpawnerCommands<ChildOf>,
 	) where
-		TLocalization: LocalizeToken,
+		TLocalization: Localize,
 	{
-		let localized = localize.localize_token(self.0).or_token();
-
-		parent.spawn((
-			Text::from(localized),
-			TextFont {
-				font_size: 20.0,
-				..default()
-			},
-			TextColor(PanelColors::DEFAULT.filled.background),
-		));
-	}
-}
-
-impl TooltipUiConfig for String {
-	fn node() -> Node {
-		Node {
-			top: Val::Px(-25.0),
-			padding: UiRect::all(Val::Px(5.0)),
-			..default()
-		}
-	}
-
-	fn background_color() -> BackgroundColor {
-		BackgroundColor(PanelColors::DEFAULT.filled.text)
-	}
-}
-
-impl InsertUiContent for Tooltip<String> {
-	fn insert_ui_content<TLocalization>(
-		&self,
-		localize: &TLocalization,
-		parent: &mut RelatedSpawnerCommands<ChildOf>,
-	) where
-		TLocalization: LocalizeToken,
-	{
-		let localized = localize.localize_token(self.0.clone()).or_token();
+		let localized = localize.localize(&self.0).or_token();
 
 		parent.spawn((
 			Text::from(localized),

--- a/src/plugins/menu/src/debug.rs
+++ b/src/plugins/menu/src/debug.rs
@@ -16,7 +16,7 @@ use common::{
 	tools::Index,
 	traits::{
 		handles_graphics::StaticRenderLayers,
-		handles_localization::LocalizeToken,
+		handles_localization::Localize,
 		iteration::IterFinite,
 		thread_safe::ThreadSafe,
 	},
@@ -93,7 +93,7 @@ fn update_state_time<TState>(
 
 pub fn setup_run_time_display<TLocalization, TGraphics>(app: &mut App)
 where
-	TLocalization: LocalizeToken + Resource,
+	TLocalization: Localize + Resource,
 	TGraphics: StaticRenderLayers + 'static,
 {
 	for state in GameState::iterator() {
@@ -326,7 +326,7 @@ fn get_button_options<TLayout: ThreadSafe, TExtra: ThreadSafe + Default>(
 
 pub fn setup_dropdown_test<TLocalization>(app: &mut App)
 where
-	TLocalization: LocalizeToken + Resource,
+	TLocalization: Localize + Resource,
 {
 	app.add_tooltip::<TLocalization, ButtonTooltip>()
 		.add_dropdown::<TLocalization, ButtonOption<SingleRow>>()

--- a/src/plugins/menu/src/lib.rs
+++ b/src/plugins/menu/src/lib.rs
@@ -55,7 +55,7 @@ use common::{
 			LoadGroup,
 		},
 		handles_loadout_menu::{ConfigureInventory, GetItem, HandlesLoadoutMenu, SwapValuesByKey},
-		handles_localization::{HandlesLocalization, LocalizeToken, localized::Localized},
+		handles_localization::{HandlesLocalization, Localize, Token, localized::Localized},
 		handles_saving::HandlesSaving,
 		handles_settings::HandlesSettings,
 		inspect_able::InspectAble,
@@ -278,8 +278,7 @@ where
 		>;
 
 		app.register_derived_component::<MenuBackground, Node>()
-			.add_tooltip::<TLocalization::TLocalizationServer, &'static str>()
-			.add_tooltip::<TLocalization::TLocalizationServer, String>()
+			.add_tooltip::<TLocalization::TLocalizationServer, Token>()
 			.add_tooltip::<TLocalization::TLocalizationServer, Localized>()
 			.add_systems(
 				Update,
@@ -381,7 +380,7 @@ struct InventoryConfiguration<TLocalization>(PhantomData<TLocalization>);
 impl<TSwap, TLocalization> ConfigureInventory<TSwap> for InventoryConfiguration<TLocalization>
 where
 	TSwap: Component<Mutability = Mutable> + SwapValuesByKey,
-	TLocalization: LocalizeToken + Resource,
+	TLocalization: Localize + Resource,
 {
 	fn configure<TInventory, TSlots, TSystemMarker1, TSystemMarker2>(
 		&self,

--- a/src/plugins/menu/src/systems/dropdown/spawn_focused.rs
+++ b/src/plugins/menu/src/systems/dropdown/spawn_focused.rs
@@ -123,7 +123,7 @@ mod tests {
 		where
 			TToken: Into<Token> + 'static,
 		{
-			let Token(token) = token.into();
+			let token = &*token.into();
 
 			LocalizationResult::Ok(Localized::from(format!("Token: {token}")))
 		}

--- a/src/plugins/menu/src/systems/dropdown/spawn_focused.rs
+++ b/src/plugins/menu/src/systems/dropdown/spawn_focused.rs
@@ -125,7 +125,7 @@ mod tests {
 		{
 			let Token(token) = token.into();
 
-			LocalizationResult::Ok(Localized(format!("Token: {token}")))
+			LocalizationResult::Ok(Localized::from(format!("Token: {token}")))
 		}
 	}
 

--- a/src/plugins/menu/src/systems/icon/insert_image.rs
+++ b/src/plugins/menu/src/systems/icon/insert_image.rs
@@ -41,7 +41,7 @@ mod tests {
 		let entity = app
 			.world_mut()
 			.spawn(Icon {
-				localized: Localized(String::default()),
+				localized: Localized::from(String::default()),
 				image: IconImage::Loaded(handle.clone()),
 			})
 			.id();
@@ -64,7 +64,7 @@ mod tests {
 		let entity = app
 			.world_mut()
 			.spawn(Icon {
-				localized: Localized(String::default()),
+				localized: Localized::from(String::default()),
 				image: IconImage::Loaded(handle),
 			})
 			.id();
@@ -89,7 +89,7 @@ mod tests {
 		let entity = app
 			.world_mut()
 			.spawn(Icon {
-				localized: Localized(String::default()),
+				localized: Localized::from(String::default()),
 				image: IconImage::Loaded(handle.clone()),
 			})
 			.id();

--- a/src/plugins/menu/src/systems/render_ui.rs
+++ b/src/plugins/menu/src/systems/render_ui.rs
@@ -80,9 +80,7 @@ mod tests {
 			mock.expect_localize_token::<&str>()
 				.times(1)
 				.with(eq("a"))
-				.return_const(LocalizationResult::Ok(Localized::from_string(
-					"a localized",
-				)));
+				.return_const(LocalizationResult::Ok(Localized::from("a localized")));
 		});
 		let mut app = setup(localize);
 		let entity = app.world_mut().spawn(_Component).id();
@@ -101,7 +99,7 @@ mod tests {
 		let localize = _Localize::new().with_mock(|mock| {
 			mock.expect_localize_token::<&str>()
 				.times(1)
-				.return_const(LocalizationResult::Ok(Localized::from_string("")));
+				.return_const(LocalizationResult::Ok(Localized::from("")));
 		});
 		let mut app = setup(localize);
 		app.world_mut().spawn(_Component);

--- a/src/plugins/menu/src/systems/update_panels/input_label_icon.rs
+++ b/src/plugins/menu/src/systems/update_panels/input_label_icon.rs
@@ -62,7 +62,7 @@ fn insert_icon<TMap, TLanguageServer, TKey>(
 	let key = key_map.get_input(label.key);
 	let token = key.into();
 	let localized = language_server.localize_token(token.clone()).or_token();
-	let Token(token) = token;
+	let token = &*token;
 	let path = root.join(format!("{token}.png"));
 
 	entity.try_insert(Icon {
@@ -147,7 +147,7 @@ mod tests {
 
 		app.update();
 
-		let Token(token) = Token::from(UserInput::from(KeyCode::ArrowUp));
+		let token = &*Token::from(UserInput::from(KeyCode::ArrowUp));
 		assert_eq!(
 			Some(&Icon {
 				localized: Localized::from("IIIIII"),

--- a/src/plugins/menu/src/systems/update_panels/input_label_icon.rs
+++ b/src/plugins/menu/src/systems/update_panels/input_label_icon.rs
@@ -6,7 +6,7 @@ use bevy::prelude::*;
 use common::{
 	traits::{
 		accessors::get::GetMut,
-		handles_localization::{LocalizeToken, Token},
+		handles_localization::{Localize, Token},
 		key_mappings::GetInput,
 		thread_safe::ThreadSafe,
 	},
@@ -30,7 +30,7 @@ where
 	where
 		TMap: Resource + GetInput<TKey>,
 		TMap::TInput: Into<Token>,
-		TLanguageServer: Resource + LocalizeToken,
+		TLanguageServer: Resource + Localize,
 	{
 		let root = icon_root_path.into();
 
@@ -56,12 +56,12 @@ fn insert_icon<TMap, TLanguageServer, TKey>(
 ) where
 	TMap: GetInput<TKey>,
 	TMap::TInput: Into<Token>,
-	TLanguageServer: LocalizeToken,
+	TLanguageServer: Localize,
 	TKey: Copy,
 {
 	let key = key_map.get_input(label.key);
 	let token = key.into();
-	let localized = language_server.localize_token(token.clone()).or_token();
+	let localized = language_server.localize(&token).or_token();
 	let token = &*token;
 	let path = root.join(format!("{token}.png"));
 
@@ -108,12 +108,9 @@ mod tests {
 	}
 
 	#[automock]
-	impl LocalizeToken for _LanguageServer {
-		fn localize_token<TToken>(&self, token: TToken) -> LocalizationResult
-		where
-			TToken: Into<Token> + 'static,
-		{
-			self.mock.localize_token(token)
+	impl Localize for _LanguageServer {
+		fn localize(&self, token: &Token) -> LocalizationResult {
+			self.mock.localize(token)
 		}
 	}
 
@@ -138,7 +135,7 @@ mod tests {
 					.return_const(UserInput::from(KeyCode::ArrowUp));
 			}),
 			_LanguageServer::new().with_mock(|mock| {
-				mock.expect_localize_token()
+				mock.expect_localize()
 					.with(eq(Token::from(UserInput::from(KeyCode::ArrowUp))))
 					.return_const(LocalizationResult::Ok(Localized::from("IIIIII")));
 			}),
@@ -167,7 +164,7 @@ mod tests {
 					.return_const(UserInput::from(KeyCode::ArrowUp));
 			}),
 			_LanguageServer::new().with_mock(|mock| {
-				mock.expect_localize_token()
+				mock.expect_localize()
 					.with(eq(Token::from(UserInput::from(KeyCode::ArrowUp))))
 					.return_const(LocalizationResult::Ok(Localized::from("IIIIII")));
 			}),

--- a/src/plugins/menu/src/systems/update_panels/set_container_panels.rs
+++ b/src/plugins/menu/src/systems/update_panels/set_container_panels.rs
@@ -31,9 +31,7 @@ pub trait SetContainerPanels: Component<Mutability = Mutable> + Sized {
 			let (state, label) = match items.get_item(*key) {
 				Some(item) => (
 					PanelState::Filled,
-					localize
-						.localize(&ItemToken::inspect_field(item).clone())
-						.or_token(),
+					localize.localize(ItemToken::inspect_field(item)).or_token(),
 				),
 				None => (
 					PanelState::Empty,

--- a/src/plugins/menu/src/systems/update_panels/set_container_panels.rs
+++ b/src/plugins/menu/src/systems/update_panels/set_container_panels.rs
@@ -5,7 +5,7 @@ use common::{
 	traits::{
 		accessors::set::Setter,
 		handles_loadout_menu::GetItem,
-		handles_localization::{LocalizeToken, localized::Localized},
+		handles_localization::{Localize, Token, localized::Localized},
 		inspect_able::{InspectAble, InspectField},
 		thread_safe::ThreadSafe,
 	},
@@ -22,7 +22,7 @@ pub trait SetContainerPanels: Component<Mutability = Mutable> + Sized {
 		mut panels: Query<(Entity, &KeyedPanel<TKey>, &mut Self)>,
 	) where
 		Self: Setter<PanelState>,
-		TLocalization: LocalizeToken + Resource,
+		TLocalization: Localize + Resource,
 		TKey: Eq + Hash + Copy + ThreadSafe,
 		TEquipment: Resource + GetItem<TKey>,
 		TEquipment::TItem: InspectAble<ItemToken>,
@@ -32,12 +32,14 @@ pub trait SetContainerPanels: Component<Mutability = Mutable> + Sized {
 				Some(item) => (
 					PanelState::Filled,
 					localize
-						.localize_token(ItemToken::inspect_field(item).clone())
+						.localize(&ItemToken::inspect_field(item).clone())
 						.or_token(),
 				),
 				None => (
 					PanelState::Empty,
-					localize.localize_token("inventory-item-empty").or_token(),
+					localize
+						.localize(&Token::from("inventory-item-empty"))
+						.or_token(),
 				),
 			};
 			panel.set(state);
@@ -109,12 +111,9 @@ mod tests {
 	}
 
 	#[automock]
-	impl LocalizeToken for _Localize {
-		fn localize_token<TToken>(&self, token: TToken) -> LocalizationResult
-		where
-			TToken: Into<Token> + 'static,
-		{
-			self.mock.localize_token(token)
+	impl Localize for _Localize {
+		fn localize(&self, token: &Token) -> LocalizationResult {
+			self.mock.localize(token)
 		}
 	}
 
@@ -133,11 +132,11 @@ mod tests {
 	#[test]
 	fn set_empty() {
 		let localize = _Localize::new().with_mock(|mock| {
-			mock.expect_localize_token::<Token>()
-				.return_const(LocalizationResult::Error(Token::from("??").failed()));
-			mock.expect_localize_token::<&str>()
-				.with(eq("inventory-item-empty"))
+			mock.expect_localize()
+				.with(eq(Token::from("inventory-item-empty")))
 				.return_const(LocalizationResult::Ok(Localized::from("EMPTY")));
+			mock.expect_localize()
+				.return_const(LocalizationResult::Error(Token::from("??").failed()));
 		});
 		let mut app = setup(HashMap::default(), localize);
 		let panel = app
@@ -172,12 +171,12 @@ mod tests {
 	#[test]
 	fn set_filled() {
 		let localize = _Localize::new().with_mock(|mock| {
-			mock.expect_localize_token::<Token>()
+			mock.expect_localize()
 				.with(eq(Token::from("my item")))
 				.return_const(LocalizationResult::Ok(Localized::from(
 					"Localized: my item",
 				)));
-			mock.expect_localize_token::<&str>()
+			mock.expect_localize()
 				.return_const(LocalizationResult::Error(Token::from("??").failed()));
 		});
 		let mut app = setup(
@@ -216,10 +215,10 @@ mod tests {
 	#[test]
 	fn still_set_state_when_no_children() {
 		let localize = _Localize::new().with_mock(|mock| {
-			mock.expect_localize_token::<Token>()
+			mock.expect_localize()
 				.with(eq(Token::from("my item")))
 				.return_const(LocalizationResult::Error(Token::from("??").failed()));
-			mock.expect_localize_token::<&str>()
+			mock.expect_localize()
 				.return_const(LocalizationResult::Error(Token::from("??").failed()));
 		});
 		let mut app = setup(HashMap::default(), localize);
@@ -236,12 +235,12 @@ mod tests {
 	#[test]
 	fn set_when_text_not_first_child() {
 		let localize = _Localize::new().with_mock(|mock| {
-			mock.expect_localize_token::<Token>()
+			mock.expect_localize()
 				.with(eq(Token::from("my item")))
 				.return_const(LocalizationResult::Ok(Localized::from(
 					"Localized: my item",
 				)));
-			mock.expect_localize_token::<&str>()
+			mock.expect_localize()
 				.return_const(LocalizationResult::Error(Token::from("??").failed()));
 		});
 		let mut app = setup(

--- a/src/plugins/menu/src/traits/add_dropdown.rs
+++ b/src/plugins/menu/src/traits/add_dropdown.rs
@@ -10,12 +10,12 @@ use crate::{
 	},
 };
 use bevy::prelude::*;
-use common::traits::handles_localization::LocalizeToken;
+use common::traits::handles_localization::Localize;
 
 pub(crate) trait AddDropdown {
 	fn add_dropdown<TLocalization, TItem>(&mut self) -> &mut Self
 	where
-		TLocalization: LocalizeToken + Resource,
+		TLocalization: Localize + Resource,
 		TItem: InsertUiContent + Sync + Send + 'static,
 		Dropdown<TItem>: GetRootNode + GetLayout;
 }
@@ -23,7 +23,7 @@ pub(crate) trait AddDropdown {
 impl AddDropdown for App {
 	fn add_dropdown<TLocalization, TItem>(&mut self) -> &mut Self
 	where
-		TLocalization: LocalizeToken + Resource,
+		TLocalization: Localize + Resource,
 		TItem: InsertUiContent + Sync + Send + 'static,
 		Dropdown<TItem>: GetRootNode + GetLayout,
 	{

--- a/src/plugins/menu/src/traits/add_tooltip.rs
+++ b/src/plugins/menu/src/traits/add_tooltip.rs
@@ -6,14 +6,14 @@ use crate::{
 	systems::{tooltip::tooltip, tooltip_visibility::tooltip_visibility},
 };
 use bevy::prelude::*;
-use common::traits::{handles_localization::LocalizeToken, thread_safe::ThreadSafe};
+use common::traits::{handles_localization::Localize, thread_safe::ThreadSafe};
 
 pub(crate) trait AddTooltip {
 	fn add_tooltip<TLocalization, T>(&mut self) -> &mut Self
 	where
 		T: TooltipUiConfig + ThreadSafe,
 		Tooltip<T>: InsertUiContent,
-		TLocalization: LocalizeToken + Resource;
+		TLocalization: Localize + Resource;
 }
 
 impl AddTooltip for App {
@@ -21,7 +21,7 @@ impl AddTooltip for App {
 	where
 		T: TooltipUiConfig + ThreadSafe,
 		Tooltip<T>: InsertUiContent,
-		TLocalization: LocalizeToken + Resource,
+		TLocalization: Localize + Resource,
 	{
 		self.add_systems(
 			Update,

--- a/src/plugins/menu/src/traits/add_ui.rs
+++ b/src/plugins/menu/src/traits/add_ui.rs
@@ -1,13 +1,13 @@
 use super::{LoadUi, insert_ui_content::InsertUiContent};
 use crate::systems::{despawn::despawn, spawn::spawn, update_children::update_children};
 use bevy::prelude::*;
-use common::traits::{handles_graphics::StaticRenderLayers, handles_localization::LocalizeToken};
+use common::traits::{handles_graphics::StaticRenderLayers, handles_localization::Localize};
 
 pub(crate) trait AddUI<TState> {
 	fn add_ui<TComponent, TLocalizationServer, TGraphics>(&mut self, on_state: TState) -> &mut Self
 	where
 		TComponent: Component + LoadUi<AssetServer> + InsertUiContent,
-		TLocalizationServer: Resource + LocalizeToken,
+		TLocalizationServer: Resource + Localize,
 		TGraphics: StaticRenderLayers + 'static;
 }
 
@@ -18,7 +18,7 @@ where
 	fn add_ui<TComponent, TLocalizationServer, TGraphics>(&mut self, on_state: TState) -> &mut Self
 	where
 		TComponent: Component + LoadUi<AssetServer> + InsertUiContent,
-		TLocalizationServer: Resource + LocalizeToken,
+		TLocalizationServer: Resource + Localize,
 		TGraphics: StaticRenderLayers + 'static,
 	{
 		self.add_systems(

--- a/src/plugins/menu/src/traits/insert_ui_content.rs
+++ b/src/plugins/menu/src/traits/insert_ui_content.rs
@@ -1,5 +1,5 @@
 use bevy::{ecs::relationship::RelatedSpawnerCommands, prelude::*};
-use common::traits::{handles_localization::LocalizeToken, thread_safe::ThreadSafe};
+use common::traits::{handles_localization::Localize, thread_safe::ThreadSafe};
 
 pub trait InsertUiContent {
 	fn insert_ui_content<TLocalization>(
@@ -7,5 +7,5 @@ pub trait InsertUiContent {
 		localization: &TLocalization,
 		parent: &mut RelatedSpawnerCommands<ChildOf>,
 	) where
-		TLocalization: LocalizeToken + ThreadSafe;
+		TLocalization: Localize + ThreadSafe;
 }

--- a/src/plugins/menu/src/traits/tooltip_ui_control.rs
+++ b/src/plugins/menu/src/traits/tooltip_ui_control.rs
@@ -1,7 +1,7 @@
 use super::insert_ui_content::InsertUiContent;
-use crate::components::tooltip::Tooltip;
+use crate::components::tooltip::{Tooltip, TooltipUiConfig};
 use bevy::prelude::*;
-use common::traits::{handles_localization::LocalizeToken, thread_safe::ThreadSafe};
+use common::traits::{handles_localization::Localize, thread_safe::ThreadSafe};
 
 pub(crate) trait DespawnAllTooltips<TUI> {
 	fn despawn_all(
@@ -14,7 +14,8 @@ pub(crate) trait DespawnAllTooltips<TUI> {
 
 pub(crate) trait DespawnOutdatedTooltips<TUI, T>
 where
-	T: ThreadSafe,
+	T: TooltipUiConfig + ThreadSafe,
+	Tooltip<T>: InsertUiContent,
 {
 	fn despawn_outdated(
 		&self,
@@ -39,7 +40,9 @@ pub(crate) struct MouseVec2(pub(crate) Vec2);
 
 pub(crate) trait SpawnTooltips<T, TLocalization>
 where
-	TLocalization: LocalizeToken + ThreadSafe,
+	T: TooltipUiConfig + ThreadSafe,
+	Tooltip<T>: InsertUiContent,
+	TLocalization: Localize + ThreadSafe,
 {
 	fn spawn(
 		&self,

--- a/src/plugins/skills/src/skills.rs
+++ b/src/plugins/skills/src/skills.rs
@@ -56,8 +56,7 @@ pub struct Skill {
 
 impl Display for Skill {
 	fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-		let Token(token) = &self.token;
-		match token.as_str() {
+		match &*self.token {
 			"" => write!(f, "Skill(<no token>)"),
 			name => write!(f, "Skill({name})"),
 		}

--- a/src/plugins/skills/src/skills/dto.rs
+++ b/src/plugins/skills/src/skills/dto.rs
@@ -40,7 +40,7 @@ impl TryLoadFrom<SkillDto> for Skill {
 		asset_server: &mut TLoadAsset,
 	) -> Result<Self, Self::TInstantiationError> {
 		Ok(Self {
-			token: Token(skill_data.token),
+			token: Token::from(skill_data.token),
 			cast_time: Duration::from(skill_data.cast_time),
 			animation: skill_data.animation,
 			behavior: RunSkillBehavior::from(skill_data.behavior),
@@ -53,7 +53,7 @@ impl TryLoadFrom<SkillDto> for Skill {
 impl From<Skill> for SkillDto {
 	fn from(skill: Skill) -> Self {
 		Self {
-			token: skill.token.0,
+			token: (*skill.token).to_owned(),
 			cast_time: DurationInSeconds::from(skill.cast_time),
 			animation: skill.animation,
 			behavior: RunSkillBehaviorDto::from(skill.behavior),


### PR DESCRIPTION
Avoid `String` cloning when `Token`, `FailedToken` or `Localized` values are cloned.