### PR TITLE
`GetParamEntry` always returns option

### DIFF
--- a/src/plugins/common/src/traits/accessors/get.rs
+++ b/src/plugins/common/src/traits/accessors/get.rs
@@ -16,20 +16,20 @@ pub trait GetRef<TKey> {
 	fn get_ref(&self, key: &TKey) -> Option<Self::TValue<'_>>;
 }
 
-pub type AsParamEntry<'w, 's, T, TKey> = <T as GetParamEntry<'w, 's, TKey>>::TEntry;
-pub type AsParam<'w, 's, T, TKey> = <T as GetParamEntry<'w, 's, TKey>>::TParam;
-pub type AsParamItem<'w, 's, 'w2, 's2, T, TKey> =
-	<AsParam<'w, 's, T, TKey> as SystemParam>::Item<'w2, 's2>;
+pub type AssociatedParamEntry<'w, 's, T, TKey> = <T as GetParamEntry<'w, 's, TKey>>::TItem;
+pub type AssociatedParam<'w, 's, T, TKey> = <T as GetParamEntry<'w, 's, TKey>>::TParam;
+pub type AssociatedParamItem<'w, 's, 'w2, 's2, T, TKey> =
+	<AssociatedParam<'w, 's, T, TKey> as SystemParam>::Item<'w2, 's2>;
 
 pub trait GetParamEntry<'w, 's, TKey> {
 	type TParam: SystemParam;
-	type TEntry;
+	type TItem;
 
 	fn get_param_entry(
 		&self,
 		key: &TKey,
 		assets: &<Self::TParam as SystemParam>::Item<'_, '_>,
-	) -> Self::TEntry;
+	) -> Option<Self::TItem>;
 }
 
 pub trait GetMut<TKey> {

--- a/src/plugins/common/src/traits/handles_loadout.rs
+++ b/src/plugins/common/src/traits/handles_loadout.rs
@@ -6,16 +6,16 @@ pub mod slot_component;
 use crate::traits::handles_loadout::{
 	combos_component::CombosComponent,
 	inventory_component::InventoryComponent,
-	loadout::{LoadoutItemEntry, LoadoutSkill, SwapExternal},
+	loadout::{LoadoutSkill, LoadoutSkillItem, SwapExternal},
 	slot_component::SlotComponent,
 };
 
 pub trait HandlesLoadout {
-	type TItemEntry: LoadoutItemEntry;
+	type TItem: LoadoutSkillItem;
 	type TSkill: LoadoutSkill;
 	type TSkills: IntoIterator<Item = Self::TSkill>;
 
-	type TInventory: InventoryComponent<Self::TItemEntry> + SwapExternal<Self::TSlots>;
-	type TSlots: SlotComponent<Self::TItemEntry, Self::TSkills> + SwapExternal<Self::TInventory>;
+	type TInventory: InventoryComponent<Self::TItem> + SwapExternal<Self::TSlots>;
+	type TSlots: SlotComponent<Self::TItem, Self::TSkills> + SwapExternal<Self::TInventory>;
 	type TCombos: CombosComponent<Self::TSkill>;
 }

--- a/src/plugins/common/src/traits/handles_loadout/inventory_component.rs
+++ b/src/plugins/common/src/traits/handles_loadout/inventory_component.rs
@@ -7,20 +7,20 @@ use crate::{
 };
 use bevy::{ecs::component::Mutable, prelude::*};
 
-pub trait InventoryComponent<TItemEntry>:
+pub trait InventoryComponent<TItem>:
 	Component<Mutability = Mutable>
 	+ LoadoutKey<TKey = InventoryKey>
-	+ LoadoutItem<TItem = TItemEntry>
+	+ LoadoutItem<TItem = TItem>
 	+ SwapInternal
-	+ for<'w, 's> GetParamEntry<'w, 's, InventoryKey, TEntry = TItemEntry>
+	+ for<'w, 's> GetParamEntry<'w, 's, InventoryKey, TItem = TItem>
 {
 }
 
-impl<T, TItemEntry> InventoryComponent<TItemEntry> for T where
+impl<T, TItem> InventoryComponent<TItem> for T where
 	T: Component<Mutability = Mutable>
 		+ LoadoutKey<TKey = InventoryKey>
-		+ LoadoutItem<TItem = TItemEntry>
+		+ LoadoutItem<TItem = TItem>
 		+ SwapInternal
-		+ for<'w, 's> GetParamEntry<'w, 's, InventoryKey, TEntry = TItemEntry>
+		+ for<'w, 's> GetParamEntry<'w, 's, InventoryKey, TItem = TItem>
 {
 }

--- a/src/plugins/common/src/traits/handles_loadout/loadout.rs
+++ b/src/plugins/common/src/traits/handles_loadout/loadout.rs
@@ -28,16 +28,16 @@ where
 		TOtherKey: Into<TOther::TKey> + 'static;
 }
 
-pub trait LoadoutItemEntry:
-	for<'a> RefInto<'a, Result<ItemToken<'a>, NoItem>>
+pub trait LoadoutSkillItem:
+	for<'a> RefInto<'a, ItemToken<'a>>
 	+ for<'a> RefInto<'a, Result<SkillToken<'a>, NoSkill>>
 	+ for<'a> RefInto<'a, Result<SkillIcon<'a>, NoSkill>>
 	+ for<'a> RefInto<'a, Result<&'a SkillExecution, NoSkill>>
 {
 }
 
-impl<T> LoadoutItemEntry for T where
-	T: for<'a> RefInto<'a, Result<ItemToken<'a>, NoItem>>
+impl<T> LoadoutSkillItem for T where
+	T: for<'a> RefInto<'a, ItemToken<'a>>
 		+ for<'a> RefInto<'a, Result<SkillToken<'a>, NoSkill>>
 		+ for<'a> RefInto<'a, Result<SkillIcon<'a>, NoSkill>>
 		+ for<'a> RefInto<'a, Result<&'a SkillExecution, NoSkill>>
@@ -70,9 +70,6 @@ pub struct SkillToken<'a>(pub &'a Token);
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct SkillIcon<'a>(pub &'a Handle<Image>);
-
-#[derive(Debug, PartialEq)]
-pub struct NoItem;
 
 #[derive(Debug, PartialEq)]
 pub struct NoSkill;

--- a/src/plugins/common/src/traits/handles_loadout/slot_component.rs
+++ b/src/plugins/common/src/traits/handles_loadout/slot_component.rs
@@ -7,23 +7,23 @@ use crate::{
 };
 use bevy::{ecs::component::Mutable, prelude::*};
 
-pub trait SlotComponent<TItemEntry, TSkills>:
+pub trait SlotComponent<TItem, TSkills>:
 	Component<Mutability = Mutable>
 	+ LoadoutKey<TKey = SlotKey>
-	+ LoadoutItem<TItem = TItemEntry>
+	+ LoadoutItem<TItem = TItem>
 	+ SwapInternal
-	+ for<'w, 's> GetParamEntry<'w, 's, SlotKey, TEntry = TItemEntry>
-	+ for<'w, 's> GetParamEntry<'w, 's, AvailableSkills<SlotKey>, TEntry = TSkills>
+	+ for<'w, 's> GetParamEntry<'w, 's, SlotKey, TItem = TItem>
+	+ for<'w, 's> GetParamEntry<'w, 's, AvailableSkills<SlotKey>, TItem = TSkills>
 {
 }
 
-impl<T, TItemEntry, TSkills> SlotComponent<TItemEntry, TSkills> for T where
+impl<T, TItem, TSkills> SlotComponent<TItem, TSkills> for T where
 	T: Component<Mutability = Mutable>
 		+ LoadoutKey<TKey = SlotKey>
-		+ LoadoutItem<TItem = TItemEntry>
+		+ LoadoutItem<TItem = TItem>
 		+ SwapInternal
-		+ for<'w, 's> GetParamEntry<'w, 's, SlotKey, TEntry = TItemEntry>
-		+ for<'w, 's> GetParamEntry<'w, 's, AvailableSkills<SlotKey>, TEntry = TSkills>
+		+ for<'w, 's> GetParamEntry<'w, 's, SlotKey, TItem = TItem>
+		+ for<'w, 's> GetParamEntry<'w, 's, AvailableSkills<SlotKey>, TItem = TSkills>
 {
 }
 

--- a/src/plugins/menu/src/systems/combos/visualize_invalid_skill.rs
+++ b/src/plugins/menu/src/systems/combos/visualize_invalid_skill.rs
@@ -6,7 +6,7 @@ use bevy::{ecs::system::StaticSystemParam, prelude::*};
 use common::{
 	tools::action_key::slot::SlotKey,
 	traits::{
-		accessors::get::{AsParam, AsParamEntry, GetParamEntry, TryApplyOn},
+		accessors::get::{AssociatedParam, AssociatedParamEntry, GetParamEntry, TryApplyOn},
 		handles_loadout::slot_component::AvailableSkills,
 		thread_safe::ThreadSafe,
 	},
@@ -21,12 +21,12 @@ where
 		mut commands: ZyheedaCommands,
 		buttons: Query<(Entity, &Self), Added<Self>>,
 		slots: Query<&TSlots, With<TAgent>>,
-		param: StaticSystemParam<AsParam<TSlots, AvailableSkills<SlotKey>>>,
+		param: StaticSystemParam<AssociatedParam<TSlots, AvailableSkills<SlotKey>>>,
 	) where
 		TVisualize: InsertContentOn,
 		TAgent: Component,
 		for<'w, 's> TSlots: Component + GetParamEntry<'w, 's, AvailableSkills<SlotKey>>,
-		for<'w, 's> AsParamEntry<'w, 's, TSlots, AvailableSkills<SlotKey>>:
+		for<'w, 's> AssociatedParamEntry<'w, 's, TSlots, AvailableSkills<SlotKey>>:
 			IntoIterator<Item = TSkill>,
 		TSkill: PartialEq,
 	{
@@ -35,11 +35,10 @@ where
 				let Some(key) = button.key_path.last() else {
 					continue;
 				};
-				let is_compatible = slots
-					.get_param_entry(&AvailableSkills(*key), &param)
-					.into_iter()
-					.any(|skill| skill == button.skill);
-				if is_compatible {
+				let Some(items) = slots.get_param_entry(&AvailableSkills(*key), &param) else {
+					continue;
+				};
+				if items.into_iter().any(|skill| skill == button.skill) {
 					continue;
 				}
 
@@ -72,14 +71,14 @@ mod tests {
 
 	impl<'w, 's> GetParamEntry<'w, 's, AvailableSkills<SlotKey>> for _Slots {
 		type TParam = ();
-		type TEntry = Vec<_Skill>;
+		type TItem = Vec<_Skill>;
 
 		fn get_param_entry(
 			&self,
 			AvailableSkills(key): &AvailableSkills<SlotKey>,
 			_: &(),
-		) -> Self::TEntry {
-			self.0.get(key).cloned().unwrap_or_default()
+		) -> Option<Self::TItem> {
+			self.0.get(key).cloned()
 		}
 	}
 

--- a/src/plugins/skills/src/components/inventory.rs
+++ b/src/plugins/skills/src/components/inventory.rs
@@ -36,32 +36,28 @@ where
 
 impl<'w, 's> GetParamEntry<'w, 's, InventoryKey> for Inventory {
 	type TParam = SkillItemAssets<'w>;
-	type TEntry = SkillItem;
+	type TItem = SkillItem;
 
 	fn get_param_entry(
 		&self,
 		InventoryKey(index): &InventoryKey,
 		SkillItemAssets { items, skills }: &SkillItemAssets,
-	) -> Self::TEntry {
+	) -> Option<Self::TItem> {
 		let Self(inventory) = self;
 		let item = inventory
 			.get(*index)
 			.and_then(|item| item.as_ref())
-			.and_then(|item| items.get(item));
-
-		let Some(item) = item else {
-			return SkillItem::None;
-		};
+			.and_then(|item| items.get(item))?;
 		let skill = item.skill.as_ref().and_then(|skill| skills.get(skill));
 
-		SkillItem::Some {
+		Some(SkillItem {
 			token: item.token.clone(),
 			skill: skill.map(|skill| ItemSkill {
 				token: skill.token.clone(),
 				icon: skill.icon.clone(),
 				execution: SkillExecution::None,
 			}),
-		}
+		})
 	}
 }
 
@@ -176,7 +172,7 @@ mod tests {
 				let inventory = Inventory::from([]);
 
 				assert_eq!(
-					SkillItem::None,
+					None,
 					inventory.get_param_entry(&InventoryKey(0), &skill_items)
 				);
 			})
@@ -211,14 +207,14 @@ mod tests {
 				let inventory = Inventory::from([Some(item_handle.clone())]);
 
 				assert_eq!(
-					SkillItem::Some {
+					Some(SkillItem {
 						token: Token::from("my item"),
 						skill: Some(ItemSkill {
 							token: Token::from("my skill"),
 							icon: icon_handle.clone(),
 							execution: SkillExecution::None
 						})
-					},
+					}),
 					inventory.get_param_entry(&InventoryKey(0), &skill_items)
 				);
 			})
@@ -253,14 +249,14 @@ mod tests {
 				let inventory = Inventory::from([None, None, Some(item_handle.clone())]);
 
 				assert_eq!(
-					SkillItem::Some {
+					Some(SkillItem {
 						token: Token::from("my item"),
 						skill: Some(ItemSkill {
 							token: Token::from("my skill"),
 							icon: icon_handle.clone(),
 							execution: SkillExecution::None
 						})
-					},
+					}),
 					inventory.get_param_entry(&InventoryKey(2), &skill_items)
 				);
 			})

--- a/src/plugins/skills/src/item.rs
+++ b/src/plugins/skills/src/item.rs
@@ -11,7 +11,7 @@ use common::{
 	tools::{item_type::ItemType, skill_execution::SkillExecution},
 	traits::{
 		accessors::get::RefInto,
-		handles_loadout::loadout::{ItemToken, NoItem, NoSkill, SkillIcon, SkillToken},
+		handles_loadout::loadout::{ItemToken, NoSkill, SkillIcon, SkillToken},
 		handles_localization::Token,
 		visible_slots::{EssenceSlot, ForearmSlot, HandSlot},
 	},
@@ -84,12 +84,9 @@ impl VisualizeItem for HandSlot {
 }
 
 #[derive(Debug, PartialEq, Clone)]
-pub enum SkillItem {
-	Some {
-		token: Token,
-		skill: Option<ItemSkill>,
-	},
-	None,
+pub struct SkillItem {
+	pub(crate) token: Token,
+	pub(crate) skill: Option<ItemSkill>,
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -99,24 +96,16 @@ pub struct ItemSkill {
 	pub(crate) execution: SkillExecution,
 }
 
-impl<'a> From<&'a SkillItem> for Result<ItemToken<'a>, NoItem> {
+impl<'a> From<&'a SkillItem> for ItemToken<'a> {
 	fn from(item: &'a SkillItem) -> Self {
-		match item {
-			SkillItem::Some {
-				token: item_token, ..
-			} => Ok(ItemToken(item_token)),
-			SkillItem::None => Err(NoItem),
-		}
+		ItemToken(&item.token)
 	}
 }
 
 impl<'a> From<&'a SkillItem> for Result<SkillToken<'a>, NoSkill> {
 	fn from(item: &'a SkillItem) -> Self {
-		match item {
-			SkillItem::Some {
-				skill: Some(ItemSkill { token, .. }),
-				..
-			} => Ok(SkillToken(token)),
+		match &item.skill {
+			Some(ItemSkill { token, .. }) => Ok(SkillToken(token)),
 			_ => Err(NoSkill),
 		}
 	}
@@ -124,11 +113,8 @@ impl<'a> From<&'a SkillItem> for Result<SkillToken<'a>, NoSkill> {
 
 impl<'a> From<&'a SkillItem> for Result<SkillIcon<'a>, NoSkill> {
 	fn from(item: &'a SkillItem) -> Self {
-		match item {
-			SkillItem::Some {
-				skill: Some(ItemSkill { icon, .. }),
-				..
-			} => Ok(SkillIcon(icon)),
+		match &item.skill {
+			Some(ItemSkill { icon, .. }) => Ok(SkillIcon(icon)),
 			_ => Err(NoSkill),
 		}
 	}
@@ -136,11 +122,8 @@ impl<'a> From<&'a SkillItem> for Result<SkillIcon<'a>, NoSkill> {
 
 impl<'a> From<&'a SkillItem> for Result<&'a SkillExecution, NoSkill> {
 	fn from(item: &'a SkillItem) -> Self {
-		match item {
-			SkillItem::Some {
-				skill: Some(ItemSkill { execution, .. }),
-				..
-			} => Ok(execution),
+		match &item.skill {
+			Some(ItemSkill { execution, .. }) => Ok(execution),
 			_ => Err(NoSkill),
 		}
 	}

--- a/src/plugins/skills/src/lib.rs
+++ b/src/plugins/skills/src/lib.rs
@@ -208,7 +208,7 @@ where
 }
 
 impl<TDependencies> HandlesLoadout for SkillsPlugin<TDependencies> {
-	type TItemEntry = SkillItem;
+	type TItem = SkillItem;
 	type TSkill = Skill;
 	type TSkills = Vec<Skill>;
 


### PR DESCRIPTION
Aims to avoids usage of an entry style item (which handles some and none cases) in favor of directly naming the item.