### PR TITLE
Replace `RefInto` with `GetProperty`

### DIFF
--- a/src/plugins/agents/src/components/enemy.rs
+++ b/src/plugins/agents/src/components/enemy.rs
@@ -15,6 +15,8 @@ use common::{
 	effects::{force::Force, gravity::Gravity},
 	errors::Error,
 	tools::{
+		Units,
+		UnitsPerSecond,
 		action_key::slot::SlotKey,
 		aggro_range::AggroRange,
 		attack_range::AttackRange,
@@ -25,6 +27,8 @@ use common::{
 		speed::Speed,
 	},
 	traits::{
+		accessors::get::GetProperty,
+		animation::Animation,
 		handles_enemies::{EnemySkillUsage, EnemyTarget, EnemyType},
 		handles_skill_behaviors::SkillSpawner,
 		load_asset::LoadAsset,
@@ -65,39 +69,65 @@ impl From<EnemyType> for Enemy {
 	}
 }
 
-impl From<&Enemy> for Speed {
-	fn from(enemy: &Enemy) -> Self {
-		enemy.speed
+impl GetProperty<Speed> for Enemy {
+	fn get_property(&self) -> UnitsPerSecond {
+		self.speed.0
 	}
 }
 
-impl<'a> From<&'a Enemy> for Option<&'a MovementAnimation> {
-	fn from(enemy: &'a Enemy) -> Self {
-		enemy.movement_animation.as_ref()
+impl GetProperty<Option<MovementAnimation>> for Enemy {
+	fn get_property(&self) -> Option<&'_ Animation> {
+		self.movement_animation
+			.as_ref()
+			.map(|MovementAnimation(animation)| animation)
 	}
 }
 
-impl From<&Enemy> for AggroRange {
-	fn from(enemy: &Enemy) -> Self {
-		enemy.aggro_range
+impl GetProperty<AggroRange> for Enemy {
+	fn get_property(&self) -> Units {
+		self.aggro_range.0
 	}
 }
 
-impl From<&Enemy> for AttackRange {
-	fn from(enemy: &Enemy) -> Self {
-		enemy.attack_range
+impl GetProperty<AttackRange> for Enemy {
+	fn get_property(&self) -> Units {
+		self.attack_range.0
 	}
 }
 
-impl From<&Enemy> for EnemyTarget {
-	fn from(enemy: &Enemy) -> Self {
-		enemy.target
+impl GetProperty<EnemyTarget> for Enemy {
+	fn get_property(&self) -> EnemyTarget {
+		self.target
 	}
 }
 
-impl From<&Enemy> for ColliderRadius {
-	fn from(enemy: &Enemy) -> Self {
-		enemy.collider_radius
+impl GetProperty<ColliderRadius> for Enemy {
+	fn get_property(&self) -> Units {
+		self.collider_radius.0
+	}
+}
+
+impl GetProperty<AttributeOnSpawn<Health>> for Enemy {
+	fn get_property(&self) -> Health {
+		match self.enemy_type {
+			EnemyTypeInternal::VoidSphere(_) => Health::new(5.),
+		}
+	}
+}
+
+impl GetProperty<AttributeOnSpawn<EffectTarget<Gravity>>> for Enemy {
+	fn get_property(&self) -> EffectTarget<Gravity> {
+		match self.enemy_type {
+			EnemyTypeInternal::VoidSphere(_) => EffectTarget::Affected,
+		}
+	}
+}
+
+impl GetProperty<AttributeOnSpawn<EffectTarget<Force>>> for Enemy {
+	fn get_property(&self) -> EffectTarget<Force> {
+		match self.enemy_type {
+			EnemyTypeInternal::VoidSphere(_) => EffectTarget::Affected,
+		}
 	}
 }
 
@@ -138,30 +168,6 @@ impl Mapper<Bone<'_>, Option<ForearmSlot>> for Enemy {
 impl Mapper<Bone<'_>, Option<SkillSpawner>> for Enemy {
 	fn map(&self, bone: Bone) -> Option<SkillSpawner> {
 		self.enemy_type.map(bone)
-	}
-}
-
-impl From<&Enemy> for AttributeOnSpawn<Health> {
-	fn from(enemy: &Enemy) -> Self {
-		match enemy.enemy_type {
-			EnemyTypeInternal::VoidSphere(_) => Self(Health::new(5.)),
-		}
-	}
-}
-
-impl From<&Enemy> for AttributeOnSpawn<EffectTarget<Gravity>> {
-	fn from(enemy: &Enemy) -> Self {
-		match enemy.enemy_type {
-			EnemyTypeInternal::VoidSphere(_) => Self(EffectTarget::Affected),
-		}
-	}
-}
-
-impl From<&Enemy> for AttributeOnSpawn<EffectTarget<Force>> {
-	fn from(enemy: &Enemy) -> Self {
-		match enemy.enemy_type {
-			EnemyTypeInternal::VoidSphere(_) => Self(EffectTarget::Affected),
-		}
 	}
 }
 

--- a/src/plugins/agents/src/components/player.rs
+++ b/src/plugins/agents/src/components/player.rs
@@ -24,6 +24,7 @@ use common::{
 		iter_helpers::{first, next},
 	},
 	traits::{
+		accessors::get::GetProperty,
 		animation::{
 			Animation,
 			AnimationAsset,
@@ -207,21 +208,21 @@ impl<'a> Mapper<Bone<'a>, Option<HandSlot>> for Player {
 	}
 }
 
-impl From<&Player> for AttributeOnSpawn<Health> {
-	fn from(_: &Player) -> Self {
-		Self(Health::new(100.))
+impl GetProperty<AttributeOnSpawn<Health>> for Player {
+	fn get_property(&self) -> Health {
+		Health::new(100.)
 	}
 }
 
-impl From<&Player> for AttributeOnSpawn<EffectTarget<Gravity>> {
-	fn from(_: &Player) -> Self {
-		Self(EffectTarget::Affected)
+impl GetProperty<AttributeOnSpawn<EffectTarget<Gravity>>> for Player {
+	fn get_property(&self) -> EffectTarget<Gravity> {
+		EffectTarget::Affected
 	}
 }
 
-impl From<&Player> for AttributeOnSpawn<EffectTarget<Force>> {
-	fn from(_: &Player) -> Self {
-		Self(EffectTarget::Affected)
+impl GetProperty<AttributeOnSpawn<EffectTarget<Force>>> for Player {
+	fn get_property(&self) -> EffectTarget<Force> {
+		EffectTarget::Affected
 	}
 }
 

--- a/src/plugins/agents/src/components/player_movement.rs
+++ b/src/plugins/agents/src/components/player_movement.rs
@@ -1,12 +1,16 @@
 use bevy::prelude::Component;
 use common::{
 	tools::{
+		Units,
 		UnitsPerSecond,
 		collider_radius::ColliderRadius,
 		movement_animation::MovementAnimation,
 		speed::Speed,
 	},
-	traits::animation::{Animation, AnimationAsset, PlayMode},
+	traits::{
+		accessors::get::GetProperty,
+		animation::{Animation, AnimationAsset, PlayMode},
+	},
 };
 use macros::SavableComponent;
 use serde::{Deserialize, Serialize};
@@ -41,38 +45,26 @@ impl Default for Config {
 	}
 }
 
-impl From<&PlayerMovement> for Speed {
-	fn from(
-		PlayerMovement {
-			mode, fast, slow, ..
-		}: &PlayerMovement,
-	) -> Self {
-		match mode {
-			MovementMode::Fast => fast.speed,
-			MovementMode::Slow => slow.speed,
+impl GetProperty<Speed> for PlayerMovement {
+	fn get_property(&self) -> UnitsPerSecond {
+		match self.mode {
+			MovementMode::Fast => self.fast.speed.0,
+			MovementMode::Slow => self.slow.speed.0,
 		}
 	}
 }
 
-impl From<&PlayerMovement> for ColliderRadius {
-	fn from(
-		PlayerMovement {
-			collider_radius, ..
-		}: &PlayerMovement,
-	) -> Self {
-		*collider_radius
+impl GetProperty<ColliderRadius> for PlayerMovement {
+	fn get_property(&self) -> Units {
+		self.collider_radius.0
 	}
 }
 
-impl<'a> From<&'a PlayerMovement> for Option<&'a MovementAnimation> {
-	fn from(
-		PlayerMovement {
-			mode, fast, slow, ..
-		}: &'a PlayerMovement,
-	) -> Self {
-		match mode {
-			MovementMode::Fast => Some(&fast.animation),
-			MovementMode::Slow => Some(&slow.animation),
+impl GetProperty<Option<MovementAnimation>> for PlayerMovement {
+	fn get_property(&self) -> Option<&Animation> {
+		match self.mode {
+			MovementMode::Fast => Some(&self.fast.animation.0),
+			MovementMode::Slow => Some(&self.slow.animation.0),
 		}
 	}
 }

--- a/src/plugins/agents/src/resources/cam_ray.rs
+++ b/src/plugins/agents/src/resources/cam_ray.rs
@@ -1,12 +1,12 @@
 use bevy::prelude::*;
-use common::traits::intersect_at::IntersectAt;
+use common::traits::{accessors::get::GetProperty, intersect_at::IntersectAt};
 
 #[derive(Resource, Default)]
 pub struct CamRay(pub(crate) Option<Ray3d>);
 
-impl<'a> From<&'a CamRay> for Option<&'a Ray3d> {
-	fn from(CamRay(ray): &'a CamRay) -> Self {
-		ray.as_ref()
+impl GetProperty<Option<Ray3d>> for CamRay {
+	fn get_property(&self) -> Option<Ray3d> {
+		self.0
 	}
 }
 

--- a/src/plugins/agents/src/resources/mouse_hover.rs
+++ b/src/plugins/agents/src/resources/mouse_hover.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use common::tools::collider_info::ColliderInfo;
+use common::{tools::collider_info::ColliderInfo, traits::accessors::get::GetProperty};
 
 #[derive(Resource, Debug, PartialEq, Clone)]
 pub struct MouseHover<T = Entity>(pub(crate) Option<ColliderInfo<T>>);
@@ -13,5 +13,11 @@ impl<T> Default for MouseHover<T> {
 impl<'a, T> From<&'a MouseHover<T>> for Option<&'a ColliderInfo<T>> {
 	fn from(MouseHover(info): &'a MouseHover<T>) -> Self {
 		info.as_ref()
+	}
+}
+
+impl GetProperty<Option<ColliderInfo<Entity>>> for MouseHover {
+	fn get_property(&self) -> Option<ColliderInfo<Entity>> {
+		self.0
 	}
 }

--- a/src/plugins/behaviors/src/systems/face/execute_player_face.rs
+++ b/src/plugins/behaviors/src/systems/face/execute_player_face.rs
@@ -6,7 +6,7 @@ use common::{
 	},
 	tools::collider_info::ColliderInfo,
 	traits::{
-		accessors::get::{GetMut, RefAs, RefInto},
+		accessors::get::{GetMut, GetProperty},
 		handles_orientation::Face,
 		intersect_at::IntersectAt,
 	},
@@ -22,7 +22,7 @@ pub(crate) fn execute_player_face<TMouseHover, TCursor>(
 	cursor: Res<TCursor>,
 	hover: Res<TMouseHover>,
 ) where
-	TMouseHover: Resource + for<'a> RefInto<'a, Option<&'a ColliderInfo<Entity>>>,
+	TMouseHover: Resource + GetProperty<Option<ColliderInfo<Entity>>>,
 	TCursor: IntersectAt + Resource,
 {
 	let Some(target) = get_cursor_target(&transforms, cursor.deref(), hover.deref()) else {
@@ -78,10 +78,10 @@ fn get_cursor_target<TMouseHover, TCursor>(
 	hover: &TMouseHover,
 ) -> Option<(Option<Entity>, Vec3)>
 where
-	TMouseHover: Resource + for<'a> RefInto<'a, Option<&'a ColliderInfo<Entity>>>,
+	TMouseHover: Resource + GetProperty<Option<ColliderInfo<Entity>>>,
 	TCursor: IntersectAt + Resource,
 {
-	let Some(collider_info) = hover.ref_as::<Option<&ColliderInfo<Entity>>>() else {
+	let Some(collider_info) = hover.get_property() else {
 		return cursor.intersect_at(0.).map(|t| (None, t));
 	};
 
@@ -140,9 +140,9 @@ mod tests {
 	#[derive(Resource, Default)]
 	struct _MouseHover(Option<ColliderInfo<Entity>>);
 
-	impl<'a> RefInto<'a, Option<&'a ColliderInfo<Entity>>> for _MouseHover {
-		fn ref_into(&self) -> Option<&ColliderInfo<Entity>> {
-			self.0.as_ref()
+	impl GetProperty<Option<ColliderInfo<Entity>>> for _MouseHover {
+		fn get_property(&self) -> Option<ColliderInfo<Entity>> {
+			self.0
 		}
 	}
 

--- a/src/plugins/behaviors/src/systems/movement/execute_move_update.rs
+++ b/src/plugins/behaviors/src/systems/movement/execute_move_update.rs
@@ -2,13 +2,13 @@ use crate::traits::MovementUpdate;
 use bevy::prelude::*;
 use common::{
 	tools::speed::Speed,
-	traits::accessors::get::{RefAs, RefInto, TryApplyOn},
+	traits::accessors::get::{GetProperty, TryApplyOn},
 	zyheeda_commands::ZyheedaCommands,
 };
 
-impl<T> ExecuteMovement for T where T: Component + Sized + for<'a> RefInto<'a, Speed> {}
+impl<T> ExecuteMovement for T where T: Component + Sized + GetProperty<Speed> {}
 
-pub(crate) trait ExecuteMovement: Component + Sized + for<'a> RefInto<'a, Speed> {
+pub(crate) trait ExecuteMovement: Component + Sized + GetProperty<Speed> {
 	fn execute_movement<TMovement>(
 		mut commands: ZyheedaCommands,
 		mut agents: Query<
@@ -20,7 +20,7 @@ pub(crate) trait ExecuteMovement: Component + Sized + for<'a> RefInto<'a, Speed>
 	{
 		for (entity, components, config, movement) in &mut agents {
 			commands.try_apply_on(&entity, |mut e| {
-				let speed = config.ref_as::<Speed>();
+				let speed = Speed(config.get_property());
 
 				if !movement.update(&mut e, components, speed).is_done() {
 					return;
@@ -44,11 +44,12 @@ mod tests {
 	#[derive(Component, Default)]
 	struct _Agent(Speed);
 
-	impl RefInto<'_, Speed> for _Agent {
-		fn ref_into(&self) -> Speed {
-			self.0
+	impl GetProperty<Speed> for _Agent {
+		fn get_property(&self) -> UnitsPerSecond {
+			self.0.0
 		}
 	}
+
 	#[derive(Component, PartialEq, Debug, Clone, Copy)]
 	struct _Component;
 

--- a/src/plugins/common/src/attributes/health.rs
+++ b/src/plugins/common/src/attributes/health.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use crate::traits::accessors::get::Property;
+
 #[derive(Debug, PartialEq, Clone, Copy, Serialize, Deserialize)]
 pub struct Health {
 	pub current: f32,
@@ -13,4 +15,8 @@ impl Health {
 			max: value,
 		}
 	}
+}
+
+impl Property for Health {
+	type TValue<'a> = Self;
 }

--- a/src/plugins/common/src/systems/ui_input_primer/apply_input.rs
+++ b/src/plugins/common/src/systems/ui_input_primer/apply_input.rs
@@ -1,26 +1,19 @@
 use crate::{
 	components::ui_input_primer::JustChangedInput,
 	tools::action_key::user_input::UserInput,
+	traits::accessors::get::GetProperty,
 };
 use bevy::prelude::*;
 
-impl<T> ApplyInput for T
-where
-	T: Component,
-	for<'a> JustChangedInput: From<&'a Self>,
-{
-}
+impl<T> ApplyInput for T where T: Component + GetProperty<JustChangedInput> {}
 
-pub(crate) trait ApplyInput: Component + Sized
-where
-	for<'a> JustChangedInput: From<&'a Self>,
-{
+pub(crate) trait ApplyInput: Component + Sized + GetProperty<JustChangedInput> {
 	fn apply_input(
 		mut input: ResMut<ButtonInput<UserInput>>,
 		primers: Query<&Self, Changed<Self>>,
 	) {
 		for primer in &primers {
-			match JustChangedInput::from(primer) {
+			match primer.get_property() {
 				JustChangedInput::JustPressed(user_input) => {
 					input.press(user_input);
 				}
@@ -42,9 +35,9 @@ mod tests {
 	#[derive(Component)]
 	struct _Input(JustChangedInput);
 
-	impl From<&_Input> for JustChangedInput {
-		fn from(_Input(input): &_Input) -> Self {
-			*input
+	impl GetProperty<JustChangedInput> for _Input {
+		fn get_property(&self) -> JustChangedInput {
+			self.0
 		}
 	}
 

--- a/src/plugins/common/src/tools.rs
+++ b/src/plugins/common/src/tools.rs
@@ -27,6 +27,8 @@ use std::{
 	ops::{Deref, DerefMut},
 };
 
+use crate::traits::accessors::get::Property;
+
 #[derive(Debug, PartialEq)]
 pub struct This<'a, T: Debug + PartialEq>(pub &'a mut T);
 
@@ -100,6 +102,10 @@ impl From<bool> for Done {
 	fn from(done: bool) -> Self {
 		Self(done)
 	}
+}
+
+impl Property for Done {
+	type TValue<'a> = bool;
 }
 
 #[cfg(test)]

--- a/src/plugins/common/src/tools/action_key/slot.rs
+++ b/src/plugins/common/src/tools/action_key/slot.rs
@@ -4,6 +4,7 @@ use super::{ActionKey, user_input::UserInput};
 use crate::{
 	errors::{Error, IsNot, Level},
 	traits::{
+		accessors::get::Property,
 		handles_localization::Token,
 		handles_settings::InvalidInput,
 		iteration::{Iter, IterFinite},
@@ -14,6 +15,10 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Copy, Default, Eq, Hash, PartialEq, Debug, Serialize, Deserialize)]
 pub struct SlotKey(pub u8);
+
+impl Property for SlotKey {
+	type TValue<'a> = Self;
+}
 
 #[derive(Clone, Copy, Eq, Hash, PartialEq, Debug, Serialize, Deserialize)]
 pub enum PlayerSlot {
@@ -119,6 +124,10 @@ impl TryFrom<SlotKey> for PlayerSlot {
 			slot_key => Err(NoValidSlotKey { slot_key }),
 		}
 	}
+}
+
+impl Property for PlayerSlot {
+	type TValue<'a> = Self;
 }
 
 #[derive(Debug, PartialEq)]

--- a/src/plugins/common/src/tools/action_key/user_input.rs
+++ b/src/plugins/common/src/tools/action_key/user_input.rs
@@ -1,4 +1,7 @@
-use crate::{errors::IsNot, traits::handles_localization::Token};
+use crate::{
+	errors::IsNot,
+	traits::{accessors::get::Property, handles_localization::Token},
+};
 use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -58,4 +61,8 @@ impl TryFrom<UserInput> for MouseButton {
 
 		Ok(mouse_button)
 	}
+}
+
+impl Property for UserInput {
+	type TValue<'a> = Self;
 }

--- a/src/plugins/common/src/tools/aggro_range.rs
+++ b/src/plugins/common/src/tools/aggro_range.rs
@@ -1,3 +1,5 @@
+use crate::traits::accessors::get::Property;
+
 use super::Units;
 use serde::{Deserialize, Serialize};
 use std::ops::Deref;
@@ -17,4 +19,8 @@ impl Deref for AggroRange {
 	fn deref(&self) -> &Self::Target {
 		&self.0
 	}
+}
+
+impl Property for AggroRange {
+	type TValue<'a> = Units;
 }

--- a/src/plugins/common/src/tools/attack_range.rs
+++ b/src/plugins/common/src/tools/attack_range.rs
@@ -1,3 +1,5 @@
+use crate::traits::accessors::get::Property;
+
 use super::Units;
 use serde::{Deserialize, Serialize};
 use std::ops::Deref;
@@ -17,4 +19,8 @@ impl Deref for AttackRange {
 	fn deref(&self) -> &Self::Target {
 		&self.0
 	}
+}
+
+impl Property for AttackRange {
+	type TValue<'a> = Units;
 }

--- a/src/plugins/common/src/tools/attribute.rs
+++ b/src/plugins/common/src/tools/attribute.rs
@@ -1,2 +1,8 @@
+use crate::traits::accessors::get::Property;
+
 #[derive(Debug, PartialEq)]
 pub struct AttributeOnSpawn<T>(pub T);
+
+impl<T> Property for AttributeOnSpawn<T> {
+	type TValue<'a> = T;
+}

--- a/src/plugins/common/src/tools/collider_info.rs
+++ b/src/plugins/common/src/tools/collider_info.rs
@@ -1,4 +1,4 @@
-use crate::components::outdated::Outdated;
+use crate::{components::outdated::Outdated, traits::accessors::get::Property};
 use bevy::prelude::*;
 
 #[derive(Debug, PartialEq, Clone, Copy)]
@@ -25,4 +25,11 @@ impl ColliderInfo<Entity> {
 			}),
 		})
 	}
+}
+
+impl<T> Property for ColliderInfo<T>
+where
+	T: Property,
+{
+	type TValue<'a> = ColliderInfo<T::TValue<'a>>;
 }

--- a/src/plugins/common/src/tools/collider_radius.rs
+++ b/src/plugins/common/src/tools/collider_radius.rs
@@ -1,3 +1,5 @@
+use crate::traits::accessors::get::Property;
+
 use super::Units;
 use serde::{Deserialize, Serialize};
 use std::ops::Deref;
@@ -18,4 +20,8 @@ impl Deref for ColliderRadius {
 		let ColliderRadius(radius) = self;
 		radius
 	}
+}
+
+impl Property for ColliderRadius {
+	type TValue<'a> = Units;
 }

--- a/src/plugins/common/src/tools/item_type.rs
+++ b/src/plugins/common/src/tools/item_type.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
+use crate::traits::accessors::get::Property;
+
 #[derive(Debug, Default, Hash, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
 pub enum ItemType {
 	#[default]
@@ -10,6 +12,10 @@ pub enum ItemType {
 	VoidBeam,
 }
 
+impl Property for ItemType {
+	type TValue<'a> = Self;
+}
+
 #[derive(Debug, Default, PartialEq, Eq, Clone)]
 pub struct CompatibleItems(pub HashSet<ItemType>);
 
@@ -17,4 +23,8 @@ impl<const N: usize> From<[ItemType; N]> for CompatibleItems {
 	fn from(value: [ItemType; N]) -> Self {
 		Self(HashSet::from(value))
 	}
+}
+
+impl Property for CompatibleItems {
+	type TValue<'a> = &'a HashSet<ItemType>;
 }

--- a/src/plugins/common/src/tools/movement_animation.rs
+++ b/src/plugins/common/src/tools/movement_animation.rs
@@ -1,4 +1,4 @@
-use crate::traits::animation::Animation;
+use crate::traits::{accessors::get::Property, animation::Animation};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
@@ -8,4 +8,8 @@ impl From<Animation> for MovementAnimation {
 	fn from(animation: Animation) -> Self {
 		MovementAnimation(animation)
 	}
+}
+
+impl Property for MovementAnimation {
+	type TValue<'a> = &'a Animation;
 }

--- a/src/plugins/common/src/tools/skill_execution.rs
+++ b/src/plugins/common/src/tools/skill_execution.rs
@@ -1,7 +1,13 @@
+use crate::traits::accessors::get::Property;
+
 #[derive(Debug, PartialEq, Eq, Hash, Default, Clone, Copy)]
 pub enum SkillExecution {
 	#[default]
 	None,
 	Active,
 	Queued,
+}
+
+impl Property for SkillExecution {
+	type TValue<'a> = Self;
 }

--- a/src/plugins/common/src/tools/speed.rs
+++ b/src/plugins/common/src/tools/speed.rs
@@ -1,3 +1,5 @@
+use crate::traits::accessors::get::Property;
+
 use super::UnitsPerSecond;
 use serde::{Deserialize, Serialize};
 use std::ops::Deref;
@@ -17,4 +19,8 @@ impl Deref for Speed {
 	fn deref(&self) -> &Self::Target {
 		&self.0
 	}
+}
+
+impl Property for Speed {
+	type TValue<'a> = UnitsPerSecond;
 }

--- a/src/plugins/common/src/traits/accessors/get.rs
+++ b/src/plugins/common/src/traits/accessors/get.rs
@@ -1,5 +1,8 @@
 mod assets;
+mod entity;
+mod handle;
 mod option;
+mod ray;
 mod result;
 
 use bevy::ecs::system::{StaticSystemParam, SystemParam};
@@ -259,63 +262,6 @@ impl<T> DynProperty for T {
 		Self: GetProperty<TProperty>,
 	{
 		GetProperty::<TProperty>::get_property(self)
-	}
-}
-
-/// A getter style conversion ("into" from a reference)
-///
-/// A blanket implementation exists for types that implement `From<&SomeType>`, which - similar
-/// to `Into` vs. `From` - should be preferably implemented.
-pub trait RefInto<'a, TValue> {
-	fn ref_into(&'a self) -> TValue;
-}
-
-impl<'a, TFrom, TInto> RefInto<'a, TInto> for TFrom
-where
-	TFrom: 'a,
-	TInto: From<&'a TFrom> + 'a,
-{
-	fn ref_into(&'a self) -> TInto {
-		TInto::from(self)
-	}
-}
-
-/// Getter like blanket trait for calling [`RefInto::ref_into()`]
-///
-/// Allows more explicit type conversion, like:
-/// ```
-/// use common::traits::accessors::get::RefAs;
-///
-/// struct MySpaceShip;
-///
-/// #[derive(Debug, PartialEq)]
-/// enum FtlMethod {
-///   Warp,
-///   Wormhole,
-/// }
-///
-/// impl From<&MySpaceShip> for FtlMethod {
-///   fn from(_: &MySpaceShip) -> FtlMethod {
-///     FtlMethod::Wormhole
-///   }
-/// }
-///
-/// let ship = MySpaceShip;
-///
-/// assert_eq!(FtlMethod::Wormhole, ship.ref_as::<FtlMethod>());
-/// ```
-pub trait RefAs {
-	fn ref_as<'a, T>(&'a self) -> T
-	where
-		Self: RefInto<'a, T>;
-}
-
-impl<TSource> RefAs for TSource {
-	fn ref_as<'a, T>(&'a self) -> T
-	where
-		Self: RefInto<'a, T>,
-	{
-		self.ref_into()
 	}
 }
 

--- a/src/plugins/common/src/traits/accessors/get.rs
+++ b/src/plugins/common/src/traits/accessors/get.rs
@@ -134,6 +134,133 @@ pub trait TryApplyOn<'a, TKey>: GetMut<TKey> + 'a {
 
 impl<'a, T, TEntity> TryApplyOn<'a, TEntity> for T where T: GetMut<TEntity> + 'a {}
 
+/// A type-level descriptor for use with [`GetProperty`].
+///
+/// Implementors of this trait define how a value should be accessed through [`GetProperty`].
+/// The associated type [`TValue<'a>`](Property::TValue) determines whether the value is retrieved
+/// by reference (useful for computation-heavy or non-`Clone` types) or by value.
+///
+/// This can also be used for declarative wrapper types to expose their inner value in a
+/// specific way.
+/// # Example
+/// ```
+/// use common::traits::accessors::get::{Property};
+///
+/// // Small types can be returned by value.
+/// #[derive(Clone, Copy)]
+/// enum TinyEnum {
+///   A,
+///   B,
+/// }
+///
+/// impl Property for TinyEnum {
+///   type TValue<'a> = Self;
+/// }
+///
+/// // Large or expensive-to-clone types are better returned by reference.
+/// struct GiantArray([String; 100_000]);
+///
+/// impl Property for GiantArray {
+///   type TValue<'a> = &'a Self;
+/// }
+///
+/// // Wrapper types can choose to expose their inner value directly,
+/// // independent of how the value itself is stored.
+/// struct NumberOfLimbs(u8);
+///
+/// impl Property for NumberOfLimbs {
+///   type TValue<'a> = u8;
+/// }
+/// ```
+pub trait Property {
+	type TValue<'a>;
+}
+
+/// A generic getter trait over a [`Property`].
+///
+/// The property specifies how the value is exposed (by reference, by value, or via a transformed
+/// inner type). This allows consumers to request a value in a uniform way, while letting the
+/// property control the retrieval strategy.
+///
+/// # Example
+/// ```
+/// use common::traits::accessors::get::{Property, GetProperty};
+///
+/// #[derive(Debug, PartialEq)]
+/// struct MyProperty;
+///
+/// impl Property for MyProperty {
+///   type TValue<'a> = Self;
+/// }
+///
+/// struct Obj;
+///
+/// impl GetProperty<MyProperty> for Obj {
+///   fn get_property(&self) -> MyProperty {
+///     MyProperty
+///   }
+/// }
+///
+/// let obj = Obj;
+///
+/// assert_eq!(MyProperty, obj.get_property());
+/// ```
+pub trait GetProperty<TProperty>
+where
+	TProperty: Property,
+{
+	fn get_property(&self) -> TProperty::TValue<'_>;
+}
+
+/// A convenience trait to access any [`Property`] dynamically.
+///
+/// Useful when you want to name the retrieved property directly on the call.
+///
+/// ```
+/// use common::traits::accessors::get::{Property, GetProperty, DynProperty};
+///
+/// #[derive(Debug, PartialEq)]
+/// struct MyProperty;
+///
+/// impl Property for MyProperty {
+///   type TValue<'a> = Self;
+/// }
+///
+/// struct Obj;
+///
+/// impl GetProperty<MyProperty> for Obj {
+///   fn get_property(&self) -> MyProperty {
+///     MyProperty
+///   }
+/// }
+///
+/// let obj = Obj;
+///
+/// // when rust cannot determine which `GetProperty` impl of many to use:
+/// let a: MyProperty = obj.get_property();
+///
+/// // same issue as above, but using `DynProperty`:
+/// let b = obj.dyn_property::<MyProperty>();
+///
+/// assert_eq!(a, b);
+/// ```
+pub trait DynProperty {
+	fn dyn_property<TProperty>(&self) -> TProperty::TValue<'_>
+	where
+		TProperty: Property,
+		Self: GetProperty<TProperty>;
+}
+
+impl<T> DynProperty for T {
+	fn dyn_property<TProperty>(&self) -> TProperty::TValue<'_>
+	where
+		TProperty: Property,
+		Self: GetProperty<TProperty>,
+	{
+		GetProperty::<TProperty>::get_property(self)
+	}
+}
+
 /// A getter style conversion ("into" from a reference)
 ///
 /// A blanket implementation exists for types that implement `From<&SomeType>`, which - similar

--- a/src/plugins/common/src/traits/accessors/get.rs
+++ b/src/plugins/common/src/traits/accessors/get.rs
@@ -1,8 +1,9 @@
-use std::ops::Deref;
+mod assets;
+mod option;
+mod result;
 
 use bevy::ecs::system::{StaticSystemParam, SystemParam};
-
-mod assets;
+use std::ops::Deref;
 
 pub trait Get<TKey> {
 	type TValue;

--- a/src/plugins/common/src/traits/accessors/get/entity.rs
+++ b/src/plugins/common/src/traits/accessors/get/entity.rs
@@ -1,0 +1,6 @@
+use crate::traits::accessors::get::Property;
+use bevy::ecs::entity::Entity;
+
+impl Property for Entity {
+	type TValue<'a> = Self;
+}

--- a/src/plugins/common/src/traits/accessors/get/handle.rs
+++ b/src/plugins/common/src/traits/accessors/get/handle.rs
@@ -1,0 +1,9 @@
+use crate::traits::accessors::get::Property;
+use bevy::asset::{Asset, Handle};
+
+impl<T> Property for Handle<T>
+where
+	T: Asset,
+{
+	type TValue<'a> = &'a Self;
+}

--- a/src/plugins/common/src/traits/accessors/get/option.rs
+++ b/src/plugins/common/src/traits/accessors/get/option.rs
@@ -1,0 +1,8 @@
+use crate::traits::accessors::get::Property;
+
+impl<T> Property for Option<T>
+where
+	T: Property,
+{
+	type TValue<'a> = Option<T::TValue<'a>>;
+}

--- a/src/plugins/common/src/traits/accessors/get/ray.rs
+++ b/src/plugins/common/src/traits/accessors/get/ray.rs
@@ -1,0 +1,6 @@
+use crate::traits::accessors::get::Property;
+use bevy::prelude::*;
+
+impl Property for Ray3d {
+	type TValue<'a> = Self;
+}

--- a/src/plugins/common/src/traits/accessors/get/result.rs
+++ b/src/plugins/common/src/traits/accessors/get/result.rs
@@ -1,0 +1,8 @@
+use crate::traits::accessors::get::Property;
+
+impl<T, TError> Property for Result<T, TError>
+where
+	T: Property,
+{
+	type TValue<'a> = Result<T::TValue<'a>, TError>;
+}

--- a/src/plugins/common/src/traits/handles_enemies.rs
+++ b/src/plugins/common/src/traits/handles_enemies.rs
@@ -1,4 +1,3 @@
-use super::accessors::get::RefInto;
 use crate::{
 	attributes::{effect_target::EffectTarget, health::Health},
 	components::persistent_entity::PersistentEntity,
@@ -14,6 +13,7 @@ use crate::{
 		speed::Speed,
 	},
 	traits::{
+		accessors::get::{GetProperty, Property},
 		handles_skill_behaviors::SkillSpawner,
 		iteration::{Iter, IterFinite},
 		loadout::LoadoutConfig,
@@ -31,15 +31,15 @@ pub trait HandlesEnemies {
 		+ LoadoutConfig
 		+ VisibleSlots
 		+ EnemySkillUsage
-		+ for<'a> RefInto<'a, Speed>
-		+ for<'a> RefInto<'a, Option<&'a MovementAnimation>>
-		+ for<'a> RefInto<'a, EnemyTarget>
-		+ for<'a> RefInto<'a, AggroRange>
-		+ for<'a> RefInto<'a, AttackRange>
-		+ for<'a> RefInto<'a, ColliderRadius>
-		+ for<'a> RefInto<'a, AttributeOnSpawn<Health>>
-		+ for<'a> RefInto<'a, AttributeOnSpawn<EffectTarget<Gravity>>>
-		+ for<'a> RefInto<'a, AttributeOnSpawn<EffectTarget<Force>>>
+		+ GetProperty<Speed>
+		+ GetProperty<Option<MovementAnimation>>
+		+ GetProperty<EnemyTarget>
+		+ GetProperty<AggroRange>
+		+ GetProperty<AttackRange>
+		+ GetProperty<ColliderRadius>
+		+ GetProperty<AttributeOnSpawn<Health>>
+		+ GetProperty<AttributeOnSpawn<EffectTarget<Gravity>>>
+		+ GetProperty<AttributeOnSpawn<EffectTarget<Force>>>
 		+ for<'a> Mapper<Bone<'a>, Option<EssenceSlot>>
 		+ for<'a> Mapper<Bone<'a>, Option<HandSlot>>
 		+ for<'a> Mapper<Bone<'a>, Option<ForearmSlot>>
@@ -57,6 +57,10 @@ pub enum EnemyTarget {
 	#[default]
 	Player,
 	Entity(PersistentEntity),
+}
+
+impl Property for EnemyTarget {
+	type TValue<'a> = Self;
 }
 
 #[derive(Debug, PartialEq, Clone, Copy)]
@@ -80,6 +84,10 @@ impl IterFinite for EnemyType {
 			EnemyType::VoidSphere => None,
 		}
 	}
+}
+
+impl Property for EnemyType {
+	type TValue<'a> = Self;
 }
 
 #[cfg(test)]

--- a/src/plugins/common/src/traits/handles_loadout/loadout.rs
+++ b/src/plugins/common/src/traits/handles_loadout/loadout.rs
@@ -1,6 +1,10 @@
 use crate::{
 	tools::skill_execution::SkillExecution,
-	traits::{accessors::get::RefInto, handles_localization::Token, thread_safe::ThreadSafe},
+	traits::{
+		accessors::get::{GetProperty, Property},
+		handles_localization::Token,
+		thread_safe::ThreadSafe,
+	},
 };
 use bevy::prelude::*;
 
@@ -29,18 +33,18 @@ where
 }
 
 pub trait LoadoutSkillItem:
-	for<'a> RefInto<'a, ItemToken<'a>>
-	+ for<'a> RefInto<'a, Result<SkillToken<'a>, NoSkill>>
-	+ for<'a> RefInto<'a, Result<SkillIcon<'a>, NoSkill>>
-	+ for<'a> RefInto<'a, Result<&'a SkillExecution, NoSkill>>
+	for<'a> GetProperty<ItemToken<'a>>
+	+ for<'a> GetProperty<Result<SkillToken<'a>, NoSkill>>
+	+ for<'a> GetProperty<Result<SkillIcon<'a>, NoSkill>>
+	+ GetProperty<Result<SkillExecution, NoSkill>>
 {
 }
 
 impl<T> LoadoutSkillItem for T where
-	T: for<'a> RefInto<'a, ItemToken<'a>>
-		+ for<'a> RefInto<'a, Result<SkillToken<'a>, NoSkill>>
-		+ for<'a> RefInto<'a, Result<SkillIcon<'a>, NoSkill>>
-		+ for<'a> RefInto<'a, Result<&'a SkillExecution, NoSkill>>
+	T: for<'a> GetProperty<ItemToken<'a>>
+		+ for<'a> GetProperty<Result<SkillToken<'a>, NoSkill>>
+		+ for<'a> GetProperty<Result<SkillIcon<'a>, NoSkill>>
+		+ GetProperty<Result<SkillExecution, NoSkill>>
 {
 }
 
@@ -48,8 +52,8 @@ pub trait LoadoutSkill:
 	PartialEq
 	+ Clone
 	+ ThreadSafe
-	+ for<'a> RefInto<'a, SkillToken<'a>>
-	+ for<'a> RefInto<'a, SkillIcon<'a>>
+	+ for<'a> GetProperty<SkillToken<'a>>
+	+ for<'a> GetProperty<SkillIcon<'a>>
 {
 }
 
@@ -57,19 +61,31 @@ impl<T> LoadoutSkill for T where
 	T: PartialEq
 		+ Clone
 		+ ThreadSafe
-		+ for<'a> RefInto<'a, SkillToken<'a>>
-		+ for<'a> RefInto<'a, SkillIcon<'a>>
+		+ for<'a> GetProperty<SkillToken<'a>>
+		+ for<'a> GetProperty<SkillIcon<'a>>
 {
 }
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct ItemToken<'a>(pub &'a Token);
 
+impl Property for ItemToken<'_> {
+	type TValue<'a> = &'a Token;
+}
+
 #[derive(Debug, PartialEq, Clone)]
 pub struct SkillToken<'a>(pub &'a Token);
 
+impl Property for SkillToken<'_> {
+	type TValue<'a> = &'a Token;
+}
+
 #[derive(Debug, PartialEq, Clone)]
 pub struct SkillIcon<'a>(pub &'a Handle<Image>);
+
+impl Property for SkillIcon<'_> {
+	type TValue<'a> = &'a Handle<Image>;
+}
 
 #[derive(Debug, PartialEq)]
 pub struct NoSkill;

--- a/src/plugins/common/src/traits/handles_localization.rs
+++ b/src/plugins/common/src/traits/handles_localization.rs
@@ -8,6 +8,8 @@ use localized::Localized;
 use std::{fmt::Display, ops::Deref, sync::Arc};
 use unic_langid::LanguageIdentifier;
 
+use crate::traits::accessors::get::Property;
+
 pub trait HandlesLocalization {
 	type TLocalizationServer: Resource + SetLocalization + Localize;
 }
@@ -71,6 +73,10 @@ impl Deref for Token {
 	fn deref(&self) -> &Self::Target {
 		self.0.as_ref()
 	}
+}
+
+impl Property for Token {
+	type TValue<'a> = &'a Self;
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/src/plugins/common/src/traits/handles_map_generation.rs
+++ b/src/plugins/common/src/traits/handles_map_generation.rs
@@ -1,5 +1,5 @@
 use super::thread_safe::ThreadSafe;
-use crate::{tools::Units, traits::accessors::get::RefInto};
+use crate::{tools::Units, traits::accessors::get::GetProperty};
 use bevy::prelude::*;
 use std::{fmt::Debug, hash::Hash};
 
@@ -7,7 +7,7 @@ pub trait HandlesMapGeneration {
 	type TMap: Component;
 	type TGraph: Graph + for<'a> From<&'a Self::TMap> + ThreadSafe;
 	type TSystemSet: SystemSet;
-	type TMapRef: Component + for<'a> RefInto<'a, Entity>;
+	type TMapRef: Component + GetProperty<Entity>;
 
 	const SYSTEMS: Self::TSystemSet;
 }

--- a/src/plugins/common/src/traits/handles_path_finding.rs
+++ b/src/plugins/common/src/traits/handles_path_finding.rs
@@ -1,10 +1,10 @@
-use crate::{tools::Units, traits::accessors::get::RefInto};
+use crate::{tools::Units, traits::accessors::get::GetProperty};
 use bevy::prelude::*;
 
 pub trait HandlesPathFinding {
 	type TComputePath: Component + ComputePath;
 	type TSystemSet: SystemSet;
-	type TComputerRef: Component + for<'a> RefInto<'a, Entity>;
+	type TComputerRef: Component + GetProperty<Entity>;
 
 	const SYSTEMS: Self::TSystemSet;
 }

--- a/src/plugins/common/src/traits/handles_physics.rs
+++ b/src/plugins/common/src/traits/handles_physics.rs
@@ -3,7 +3,7 @@ use crate::{
 	components::is_blocker::Blocker,
 	effects::{force::Force, gravity::Gravity, health_damage::HealthDamage},
 	tools::{Done, Units, speed::Speed},
-	traits::accessors::get::RefInto,
+	traits::accessors::get::{GetProperty, Property},
 };
 use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -21,10 +21,7 @@ pub trait HandlesMotion {
 	///
 	/// Implementors must make sure this works on top level entities. No guarantees are made for
 	/// entities that are a child of other entities.
-	type TMotion: Component
-		+ From<LinearMotion>
-		+ for<'a> RefInto<'a, Done>
-		+ for<'a> RefInto<'a, LinearMotion>;
+	type TMotion: Component + From<LinearMotion> + GetProperty<Done> + GetProperty<LinearMotion>;
 }
 
 #[derive(Debug, PartialEq, Clone, Copy, Serialize, Deserialize)]
@@ -32,6 +29,10 @@ pub enum LinearMotion {
 	Direction { speed: Speed, direction: Dir3 },
 	ToTarget { speed: Speed, target: Vec3 },
 	Stop,
+}
+
+impl Property for LinearMotion {
+	type TValue<'a> = Self;
 }
 
 pub trait HandlesAllPhysicalEffects:
@@ -55,12 +56,12 @@ where
 }
 
 pub trait HandlesLife:
-	HandlesPhysicalEffect<HealthDamage, TAffectedComponent: for<'a> RefInto<'a, Health>>
+	HandlesPhysicalEffect<HealthDamage, TAffectedComponent: GetProperty<Health>>
 {
 }
 
 impl<T> HandlesLife for T where
-	T: HandlesPhysicalEffect<HealthDamage, TAffectedComponent: for<'a> RefInto<'a, Health>>
+	T: HandlesPhysicalEffect<HealthDamage, TAffectedComponent: GetProperty<Health>>
 {
 }
 

--- a/src/plugins/common/src/traits/handles_player.rs
+++ b/src/plugins/common/src/traits/handles_player.rs
@@ -1,4 +1,4 @@
-use super::{accessors::get::RefInto, intersect_at::IntersectAt};
+use super::intersect_at::IntersectAt;
 use crate::{
 	attributes::{effect_target::EffectTarget, health::Health},
 	effects::{force::Force, gravity::Gravity},
@@ -13,6 +13,7 @@ use crate::{
 		speed::Speed,
 	},
 	traits::{
+		accessors::get::GetProperty,
 		handles_skill_behaviors::SkillSpawner,
 		loadout::LoadoutConfig,
 		mapper::Mapper,
@@ -33,9 +34,9 @@ pub trait HandlesPlayer {
 		+ for<'a> Mapper<Bone<'a>, Option<EssenceSlot>>
 		+ for<'a> Mapper<Bone<'a>, Option<HandSlot>>
 		+ for<'a> Mapper<Bone<'a>, Option<ForearmSlot>>
-		+ for<'a> RefInto<'a, AttributeOnSpawn<Health>>
-		+ for<'a> RefInto<'a, AttributeOnSpawn<EffectTarget<Gravity>>>
-		+ for<'a> RefInto<'a, AttributeOnSpawn<EffectTarget<Force>>>;
+		+ GetProperty<AttributeOnSpawn<Health>>
+		+ GetProperty<AttributeOnSpawn<EffectTarget<Gravity>>>
+		+ GetProperty<AttributeOnSpawn<EffectTarget<Force>>>;
 }
 
 pub trait PlayerMainCamera {
@@ -43,18 +44,18 @@ pub trait PlayerMainCamera {
 }
 
 pub trait HandlesPlayerCameras {
-	type TCamRay: Resource + for<'a> RefInto<'a, Option<&'a Ray3d>> + IntersectAt;
+	type TCamRay: Resource + GetProperty<Option<Ray3d>> + IntersectAt;
 }
 
 pub trait HandlesPlayerMouse {
-	type TMouseHover: Resource + for<'a> RefInto<'a, Option<&'a ColliderInfo<Entity>>>;
+	type TMouseHover: Resource + GetProperty<Option<ColliderInfo<Entity>>>;
 }
 
 pub trait ConfiguresPlayerMovement {
 	type TPlayerMovement: Component
-		+ for<'a> RefInto<'a, Speed>
-		+ for<'a> RefInto<'a, ColliderRadius>
-		+ for<'a> RefInto<'a, Option<&'a MovementAnimation>>;
+		+ GetProperty<Speed>
+		+ GetProperty<ColliderRadius>
+		+ GetProperty<Option<MovementAnimation>>;
 }
 
 pub trait ConfiguresPlayerSkillAnimations {

--- a/src/plugins/common/src/traits/visible_slots.rs
+++ b/src/plugins/common/src/traits/visible_slots.rs
@@ -1,4 +1,4 @@
-use crate::tools::action_key::slot::SlotKey;
+use crate::{tools::action_key::slot::SlotKey, traits::accessors::get::GetProperty};
 
 pub trait VisibleSlots {
 	fn visible_slots(&self) -> impl Iterator<Item = SlotKey>;
@@ -13,9 +13,9 @@ impl From<SlotKey> for EssenceSlot {
 	}
 }
 
-impl From<&EssenceSlot> for SlotKey {
-	fn from(EssenceSlot(slot_key): &EssenceSlot) -> Self {
-		*slot_key
+impl GetProperty<SlotKey> for EssenceSlot {
+	fn get_property(&self) -> SlotKey {
+		self.0
 	}
 }
 
@@ -28,9 +28,9 @@ impl From<SlotKey> for HandSlot {
 	}
 }
 
-impl From<&HandSlot> for SlotKey {
-	fn from(HandSlot(slot_key): &HandSlot) -> Self {
-		*slot_key
+impl GetProperty<SlotKey> for HandSlot {
+	fn get_property(&self) -> SlotKey {
+		self.0
 	}
 }
 
@@ -43,8 +43,8 @@ impl From<SlotKey> for ForearmSlot {
 	}
 }
 
-impl From<&ForearmSlot> for SlotKey {
-	fn from(ForearmSlot(slot_key): &ForearmSlot) -> Self {
-		*slot_key
+impl GetProperty<SlotKey> for ForearmSlot {
+	fn get_property(&self) -> SlotKey {
+		self.0
 	}
 }

--- a/src/plugins/map_generation/src/components/map_agents.rs
+++ b/src/plugins/map_generation/src/components/map_agents.rs
@@ -1,5 +1,8 @@
 use bevy::{ecs::entity::EntityHashSet, prelude::*};
-use common::components::persistent_entity::PersistentEntity;
+use common::{
+	components::persistent_entity::PersistentEntity,
+	traits::accessors::get::GetProperty,
+};
 use macros::SavableComponent;
 use serde::{Deserialize, Serialize};
 
@@ -11,9 +14,9 @@ pub struct GridAgents(EntityHashSet);
 #[relationship(relationship_target = GridAgents)]
 pub struct GridAgentOf(pub(crate) Entity);
 
-impl From<&GridAgentOf> for Entity {
-	fn from(GridAgentOf(entity): &GridAgentOf) -> Self {
-		*entity
+impl GetProperty<Entity> for GridAgentOf {
+	fn get_property(&self) -> Entity {
+		self.0
 	}
 }
 

--- a/src/plugins/menu/src/components/combo_overview.rs
+++ b/src/plugins/menu/src/components/combo_overview.rs
@@ -22,7 +22,7 @@ use bevy::{ecs::relationship::RelatedSpawnerCommands, prelude::*};
 use common::{
 	tools::action_key::slot::{PlayerSlot, SlotKey},
 	traits::{
-		accessors::get::{RefAs, RefInto},
+		accessors::get::{DynProperty, GetProperty},
 		handles_loadout::loadout::{LoadoutItem, LoadoutKey, SkillIcon, SkillToken},
 		handles_localization::{Localize, LocalizeToken, localized::Localized},
 		load_asset::{LoadAsset, Path},
@@ -322,8 +322,8 @@ where
 	TSkill: Clone
 		+ PartialEq
 		+ ThreadSafe
-		+ for<'a> RefInto<'a, SkillToken<'a>>
-		+ for<'a> RefInto<'a, SkillIcon<'a>>,
+		+ for<'a> GetProperty<SkillToken<'a>>
+		+ for<'a> GetProperty<SkillIcon<'a>>,
 {
 	fn insert_ui_content<TLocalization>(
 		&self,
@@ -400,8 +400,8 @@ fn add_combo_list<TSkill, TLocalization>(
 	TSkill: Clone
 		+ PartialEq
 		+ ThreadSafe
-		+ for<'a> RefInto<'a, SkillToken<'a>>
-		+ for<'a> RefInto<'a, SkillIcon<'a>>,
+		+ for<'a> GetProperty<SkillToken<'a>>
+		+ for<'a> GetProperty<SkillIcon<'a>>,
 	TLocalization: Localize + 'static,
 {
 	parent
@@ -434,8 +434,8 @@ fn add_combo<TSkill, TLocalization>(
 	TSkill: Clone
 		+ PartialEq
 		+ ThreadSafe
-		+ for<'a> RefInto<'a, SkillToken<'a>>
-		+ for<'a> RefInto<'a, SkillIcon<'a>>,
+		+ for<'a> GetProperty<SkillToken<'a>>
+		+ for<'a> GetProperty<SkillIcon<'a>>,
 	TLocalization: Localize + 'static,
 {
 	parent
@@ -530,8 +530,8 @@ impl<TSkill, TLocalization> AddPanel<'_, TSkill, TLocalization>
 where
 	TSkill: Clone
 		+ ThreadSafe
-		+ for<'a> RefInto<'a, SkillToken<'a>>
-		+ for<'a> RefInto<'a, SkillIcon<'a>>,
+		+ for<'a> GetProperty<SkillToken<'a>>
+		+ for<'a> GetProperty<SkillIcon<'a>>,
 	TLocalization: Localize,
 {
 	fn spawn_as_child(
@@ -576,8 +576,8 @@ where
 	) {
 		let skill_bundle = (
 			ComboSkillButton::<DropdownTrigger, TSkill>::new(skill.clone(), key_path.to_vec()),
-			UILabel::from(skill.ref_as::<SkillToken>()),
-			ComboOverview::skill_button(skill.ref_as::<SkillIcon>()),
+			UILabel(skill.dyn_property::<SkillToken>().clone()),
+			ComboOverview::skill_button(skill.dyn_property::<SkillIcon>().clone()),
 			SkillSelectDropdownCommand::<Vertical>::new(key_path.to_vec()),
 		);
 

--- a/src/plugins/menu/src/components/combo_skill_button.rs
+++ b/src/plugins/menu/src/components/combo_skill_button.rs
@@ -4,7 +4,7 @@ use bevy::{ecs::relationship::RelatedSpawnerCommands, prelude::*};
 use common::{
 	tools::action_key::slot::SlotKey,
 	traits::{
-		accessors::get::{RefAs, RefInto},
+		accessors::get::{DynProperty, GetProperty},
 		handles_loadout::loadout::{SkillIcon, SkillToken},
 		handles_localization::Localize,
 		thread_safe::ThreadSafe,
@@ -47,8 +47,8 @@ where
 	T: Clone + ThreadSafe,
 	TSkill: Clone
 		+ ThreadSafe
-		+ for<'a> RefInto<'a, SkillToken<'a>>
-		+ for<'a> RefInto<'a, SkillIcon<'a>>,
+		+ for<'a> GetProperty<SkillToken<'a>>
+		+ for<'a> GetProperty<SkillIcon<'a>>,
 {
 	fn insert_ui_content<TLocalization>(
 		&self,
@@ -59,8 +59,8 @@ where
 	{
 		parent.spawn((
 			self.clone(),
-			ComboOverview::skill_button(self.skill.ref_as::<SkillIcon>()),
-			UILabel::from(self.skill.ref_as::<SkillToken>()),
+			ComboOverview::skill_button(self.skill.dyn_property::<SkillIcon>().clone()),
+			UILabel(self.skill.dyn_property::<SkillToken>().clone()),
 		));
 	}
 }

--- a/src/plugins/menu/src/components/inventory_panel.rs
+++ b/src/plugins/menu/src/components/inventory_panel.rs
@@ -4,7 +4,7 @@ use crate::{
 	traits::colors::{HasPanelColors, PanelColors},
 };
 use bevy::prelude::*;
-use common::traits::accessors::set::Setter;
+use common::traits::accessors::{get::GetProperty, set::Setter};
 
 #[derive(Component, Debug, PartialEq)]
 #[require(UILabel)]
@@ -16,9 +16,9 @@ impl From<PanelState> for InventoryPanel {
 	}
 }
 
-impl From<&InventoryPanel> for PanelState {
-	fn from(InventoryPanel(state): &InventoryPanel) -> Self {
-		*state
+impl GetProperty<PanelState> for InventoryPanel {
+	fn get_property(&self) -> PanelState {
+		self.0
 	}
 }
 
@@ -35,18 +35,17 @@ impl HasPanelColors for InventoryPanel {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use common::traits::accessors::get::RefAs;
 
 	#[test]
 	fn get_empty() {
 		let panel = InventoryPanel::from(PanelState::Empty);
-		assert_eq!(PanelState::Empty, panel.ref_as::<PanelState>());
+		assert_eq!(PanelState::Empty, panel.get_property());
 	}
 
 	#[test]
 	fn get_filled() {
 		let panel = InventoryPanel::from(PanelState::Filled);
-		assert_eq!(PanelState::Filled, panel.ref_as::<PanelState>());
+		assert_eq!(PanelState::Filled, panel.get_property());
 	}
 
 	#[test]

--- a/src/plugins/menu/src/components/label.rs
+++ b/src/plugins/menu/src/components/label.rs
@@ -1,9 +1,6 @@
 use crate::components::icon::Icon;
 use bevy::prelude::*;
-use common::traits::{
-	handles_loadout::loadout::SkillToken,
-	handles_localization::{Token, localized::Localized},
-};
+use common::traits::handles_localization::localized::Localized;
 use std::sync::LazyLock;
 
 /// Display the localized text:
@@ -28,12 +25,6 @@ impl UILabel {
 impl Default for UILabel {
 	fn default() -> Self {
 		Self::empty()
-	}
-}
-
-impl<'a> From<SkillToken<'a>> for UILabel<Token> {
-	fn from(SkillToken(token): SkillToken<'a>) -> Self {
-		Self(token.clone())
 	}
 }
 

--- a/src/plugins/menu/src/components/quickbar_panel.rs
+++ b/src/plugins/menu/src/components/quickbar_panel.rs
@@ -3,7 +3,10 @@ use crate::{
 	traits::colors::{ColorConfig, HasPanelColors, PanelColors},
 };
 use bevy::{color::Color, ecs::component::Component};
-use common::tools::action_key::slot::{PlayerSlot, SlotKey};
+use common::{
+	tools::action_key::slot::{PlayerSlot, SlotKey},
+	traits::accessors::get::GetProperty,
+};
 
 #[derive(Component)]
 pub struct QuickbarPanel {
@@ -41,21 +44,21 @@ impl From<PlayerSlot> for QuickbarPanel {
 	}
 }
 
-impl From<&QuickbarPanel> for PanelState {
-	fn from(QuickbarPanel { state, .. }: &QuickbarPanel) -> Self {
-		*state
+impl GetProperty<PanelState> for QuickbarPanel {
+	fn get_property(&self) -> PanelState {
+		self.state
 	}
 }
 
-impl From<&QuickbarPanel> for PlayerSlot {
-	fn from(QuickbarPanel { key, .. }: &QuickbarPanel) -> Self {
-		*key
+impl GetProperty<PlayerSlot> for QuickbarPanel {
+	fn get_property(&self) -> PlayerSlot {
+		self.key
 	}
 }
 
-impl From<&QuickbarPanel> for SlotKey {
-	fn from(QuickbarPanel { key, .. }: &QuickbarPanel) -> Self {
-		Self::from(*key)
+impl GetProperty<SlotKey> for QuickbarPanel {
+	fn get_property(&self) -> SlotKey {
+		SlotKey::from(self.key)
 	}
 }
 
@@ -66,7 +69,7 @@ impl HasPanelColors for QuickbarPanel {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use common::{tools::action_key::slot::Side, traits::accessors::get::RefAs};
+	use common::{tools::action_key::slot::Side, traits::accessors::get::DynProperty};
 
 	#[test]
 	fn get_empty() {
@@ -74,7 +77,7 @@ mod tests {
 			key: PlayerSlot::Lower(Side::Right),
 			state: PanelState::Empty,
 		};
-		assert_eq!(PanelState::Empty, panel.ref_as::<PanelState>());
+		assert_eq!(PanelState::Empty, panel.dyn_property::<PanelState>());
 	}
 
 	#[test]
@@ -83,7 +86,7 @@ mod tests {
 			key: PlayerSlot::Lower(Side::Right),
 			state: PanelState::Filled,
 		};
-		assert_eq!(PanelState::Filled, panel.ref_as::<PanelState>());
+		assert_eq!(PanelState::Filled, panel.dyn_property::<PanelState>());
 	}
 
 	#[test]
@@ -93,7 +96,10 @@ mod tests {
 			state: PanelState::Empty,
 		};
 
-		assert_eq!(PlayerSlot::Lower(Side::Left), panel.ref_as::<PlayerSlot>());
+		assert_eq!(
+			PlayerSlot::Lower(Side::Left),
+			panel.dyn_property::<PlayerSlot>()
+		);
 	}
 
 	#[test]
@@ -105,7 +111,7 @@ mod tests {
 
 		assert_eq!(
 			SlotKey::from(PlayerSlot::Lower(Side::Left)),
-			panel.ref_as::<SlotKey>()
+			panel.dyn_property::<SlotKey>(),
 		);
 	}
 }

--- a/src/plugins/menu/src/components/start_menu_button.rs
+++ b/src/plugins/menu/src/components/start_menu_button.rs
@@ -10,6 +10,7 @@ use common::{
 	errors::Error,
 	states::game_state::GameState,
 	traits::{
+		accessors::get::GetProperty,
 		handles_localization::localized::Localized,
 		load_asset::LoadAsset,
 		prefab::{Prefab, PrefabEntityCommands},
@@ -36,8 +37,8 @@ impl StartMenuButton {
 	}
 }
 
-impl From<&StartMenuButton> for PanelState {
-	fn from(_: &StartMenuButton) -> Self {
+impl GetProperty<PanelState> for StartMenuButton {
+	fn get_property(&self) -> PanelState {
 		PanelState::Filled
 	}
 }

--- a/src/plugins/menu/src/systems/inventory_panel/set_label.rs
+++ b/src/plugins/menu/src/systems/inventory_panel/set_label.rs
@@ -9,7 +9,7 @@ use common::{
 			AssociatedItem,
 			AssociatedStaticSystemParam,
 			GetFromSystemParam,
-			RefInto,
+			GetProperty,
 			TryApplyOn,
 		},
 		handles_loadout::loadout::{ItemToken, LoadoutKey},
@@ -28,7 +28,7 @@ impl InventoryPanel {
 		for<'w, 's> TContainer:
 			Component + LoadoutKey + GetFromSystemParam<'w, 's, TContainer::TKey>,
 		for<'w, 's, 'i, 'a> AssociatedItem<'w, 's, 'i, TContainer, TContainer::TKey>:
-			RefInto<'a, ItemToken<'a>>,
+			GetProperty<ItemToken<'a>>,
 	{
 		for container in &containers {
 			for (entity, mut panel, KeyedPanel(key)) in &mut panels {
@@ -40,9 +40,8 @@ impl InventoryPanel {
 						PanelState::Empty
 					}
 					Some(item) => {
-						let ItemToken(token) = item.ref_into();
 						commands.try_apply_on(&entity, |mut e| {
-							e.try_insert(UILabel(token.clone()));
+							e.try_insert(UILabel(item.get_property().clone()));
 						});
 						PanelState::Filled
 					}
@@ -73,9 +72,9 @@ mod tests {
 	#[derive(Clone)]
 	struct _Item(ItemToken<'static>);
 
-	impl<'a> From<&'a _Item> for ItemToken<'a> {
-		fn from(_Item(token): &'a _Item) -> Self {
-			token.clone()
+	impl GetProperty<ItemToken<'_>> for _Item {
+		fn get_property(&self) -> &'_ Token {
+			self.0.0
 		}
 	}
 

--- a/src/plugins/menu/src/systems/update_panels/colors.rs
+++ b/src/plugins/menu/src/systems/update_panels/colors.rs
@@ -5,16 +5,16 @@ use crate::{
 };
 use bevy::prelude::*;
 use common::{
-	traits::accessors::get::{RefAs, RefInto, TryApplyOn},
+	traits::accessors::get::{GetProperty, TryApplyOn},
 	zyheeda_commands::ZyheedaCommands,
 };
 
-pub fn panel_colors<TPanel: Component + for<'a> RefInto<'a, PanelState> + HasPanelColors>(
+pub fn panel_colors<TPanel: Component + GetProperty<PanelState> + HasPanelColors>(
 	mut commands: ZyheedaCommands,
 	mut panels: Query<(Entity, &Interaction, &TPanel, Option<&UIDisabled>), Without<ColorOverride>>,
 ) {
 	for (entity, interaction, panel, disabled) in &mut panels {
-		let config = match (interaction, panel.ref_as::<PanelState>(), disabled) {
+		let config = match (interaction, panel.get_property(), disabled) {
 			(.., Some(UIDisabled)) => &TPanel::PANEL_COLORS.disabled,
 			(Interaction::Pressed, ..) => &TPanel::PANEL_COLORS.pressed,
 			(Interaction::Hovered, ..) => &TPanel::PANEL_COLORS.hovered,
@@ -42,8 +42,8 @@ mod tests {
 	#[derive(Component)]
 	struct _Empty;
 
-	impl From<&_Empty> for PanelState {
-		fn from(_: &_Empty) -> Self {
+	impl GetProperty<PanelState> for _Empty {
+		fn get_property(&self) -> PanelState {
 			PanelState::Empty
 		}
 	}
@@ -51,8 +51,8 @@ mod tests {
 	#[derive(Component)]
 	struct _Filled;
 
-	impl From<&_Filled> for PanelState {
-		fn from(_: &_Filled) -> Self {
+	impl GetProperty<PanelState> for _Filled {
+		fn get_property(&self) -> PanelState {
 			PanelState::Filled
 		}
 	}

--- a/src/plugins/menu/src/tools.rs
+++ b/src/plugins/menu/src/tools.rs
@@ -1,11 +1,15 @@
 use bevy::ui::{UiRect, Val};
-use common::tools::Index;
+use common::{tools::Index, traits::accessors::get::Property};
 use std::ops::{Add, Div, Mul, Sub};
 
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum PanelState {
 	Empty,
 	Filled,
+}
+
+impl Property for PanelState {
+	type TValue<'a> = Self;
 }
 
 pub enum Layout {

--- a/src/plugins/physics/src/components/force_affected.rs
+++ b/src/plugins/physics/src/components/force_affected.rs
@@ -4,7 +4,7 @@ use common::{
 	effects::force::Force,
 	tools::attribute::AttributeOnSpawn,
 	traits::{
-		accessors::get::RefInto,
+		accessors::get::GetProperty,
 		register_derived_component::{DerivableFrom, InsertDerivedComponent},
 	},
 };
@@ -16,14 +16,13 @@ pub struct ForceAffected(pub(crate) EffectTarget<Force>);
 
 impl<T> DerivableFrom<'_, '_, T> for ForceAffected
 where
-	T: for<'a> RefInto<'a, AttributeOnSpawn<EffectTarget<Force>>>,
+	T: GetProperty<AttributeOnSpawn<EffectTarget<Force>>>,
 {
 	const INSERT: InsertDerivedComponent = InsertDerivedComponent::IfNew;
 
 	type TParam = ();
 
 	fn derive_from(_: Entity, component: &T, _: &()) -> Self {
-		let AttributeOnSpawn(attr) = component.ref_into();
-		Self(attr)
+		Self(component.get_property())
 	}
 }

--- a/src/plugins/physics/src/components/gravity_affected.rs
+++ b/src/plugins/physics/src/components/gravity_affected.rs
@@ -6,7 +6,7 @@ use common::{
 	effects::gravity::Gravity,
 	tools::{UnitsPerSecond, attribute::AttributeOnSpawn},
 	traits::{
-		accessors::get::RefInto,
+		accessors::get::GetProperty,
 		register_derived_component::{DerivableFrom, InsertDerivedComponent},
 	},
 };
@@ -77,16 +77,16 @@ impl<'a> Iterator for DrainPulls<'a> {
 
 impl<T> DerivableFrom<'_, '_, T> for GravityAffected
 where
-	T: for<'a> RefInto<'a, AttributeOnSpawn<EffectTarget<Gravity>>>,
+	T: GetProperty<AttributeOnSpawn<EffectTarget<Gravity>>>,
 {
 	const INSERT: InsertDerivedComponent = InsertDerivedComponent::IfNew;
 
 	type TParam = ();
 
 	fn derive_from(_: Entity, component: &T, _: &()) -> Self {
-		match component.ref_into() {
-			AttributeOnSpawn(EffectTarget::Affected) => Self::affected([]),
-			AttributeOnSpawn(EffectTarget::Immune) => Self::Immune,
+		match component.get_property() {
+			EffectTarget::Affected => Self::affected([]),
+			EffectTarget::Immune => Self::Immune,
 		}
 	}
 }

--- a/src/plugins/physics/src/components/life.rs
+++ b/src/plugins/physics/src/components/life.rs
@@ -3,7 +3,7 @@ use common::{
 	attributes::health::Health,
 	tools::attribute::AttributeOnSpawn,
 	traits::{
-		accessors::get::RefInto,
+		accessors::get::GetProperty,
 		register_derived_component::{DerivableFrom, InsertDerivedComponent},
 	},
 };
@@ -32,23 +32,22 @@ impl From<Health> for Life {
 	}
 }
 
-impl From<&Life> for Health {
-	fn from(Life(health): &Life) -> Self {
-		*health
+impl GetProperty<Health> for Life {
+	fn get_property(&self) -> Health {
+		self.0
 	}
 }
 
 impl<T> DerivableFrom<'_, '_, T> for Life
 where
-	T: for<'a> RefInto<'a, AttributeOnSpawn<Health>>,
+	T: GetProperty<AttributeOnSpawn<Health>>,
 {
 	const INSERT: InsertDerivedComponent = InsertDerivedComponent::IfNew;
 
 	type TParam = ();
 
 	fn derive_from(_: Entity, component: &T, _: &()) -> Self {
-		let AttributeOnSpawn(health) = component.ref_into();
-		Life(health)
+		Life(component.get_property())
 	}
 }
 

--- a/src/plugins/physics/src/components/motion.rs
+++ b/src/plugins/physics/src/components/motion.rs
@@ -3,6 +3,7 @@ use bevy_rapier3d::prelude::*;
 use common::{
 	tools::{Done, speed::Speed},
 	traits::{
+		accessors::get::GetProperty,
 		handles_physics::LinearMotion,
 		register_derived_component::{DerivableFrom, InsertDerivedComponent},
 	},
@@ -23,18 +24,18 @@ impl From<LinearMotion> for Motion {
 	}
 }
 
-impl From<&Motion> for LinearMotion {
-	fn from(motion: &Motion) -> Self {
-		match motion {
+impl GetProperty<LinearMotion> for Motion {
+	fn get_property(&self) -> LinearMotion {
+		match self {
 			Motion::Ongoing(linear_motion) => *linear_motion,
 			Motion::Done(linear_motion) => *linear_motion,
 		}
 	}
 }
 
-impl From<&Motion> for Done {
-	fn from(motion: &Motion) -> Self {
-		Done::when(matches!(motion, Motion::Done(..)))
+impl GetProperty<Done> for Motion {
+	fn get_property(&self) -> bool {
+		matches!(self, Motion::Done(..))
 	}
 }
 

--- a/src/plugins/skills/src/components/skill_executer.rs
+++ b/src/plugins/skills/src/components/skill_executer.rs
@@ -114,6 +114,7 @@ mod tests {
 			collider_info::ColliderInfo,
 		},
 		traits::{
+			accessors::get::GetProperty,
 			handles_physics::{Effect, HandlesPhysicalEffect},
 			handles_skill_behaviors::{Contact, HoldSkills, Projection, SkillEntities, SkillRoot},
 			register_persistent_entities::RegisterPersistentEntities,
@@ -148,8 +149,8 @@ mod tests {
 	#[derive(Component)]
 	struct _Affected;
 
-	impl From<&_Affected> for Health {
-		fn from(_: &_Affected) -> Self {
+	impl GetProperty<Health> for _Affected {
+		fn get_property(&self) -> Health {
 			panic!("NOT USED")
 		}
 	}

--- a/src/plugins/skills/src/skills.rs
+++ b/src/plugins/skills/src/skills.rs
@@ -12,9 +12,12 @@ use crate::{
 };
 use bevy::prelude::*;
 use common::{
-	tools::{action_key::slot::SlotKey, item_type::CompatibleItems},
+	tools::{
+		action_key::slot::SlotKey,
+		item_type::{CompatibleItems, ItemType},
+	},
 	traits::{
-		accessors::get::{GetMut, RefInto},
+		accessors::get::{GetMut, GetProperty},
 		handles_custom_assets::AssetFolderPath,
 		handles_loadout::loadout::{SkillIcon, SkillToken},
 		handles_localization::Token,
@@ -26,6 +29,7 @@ use common::{
 };
 use serde::{Deserialize, Serialize};
 use std::{
+	collections::HashSet,
 	fmt::{Display, Formatter, Result as FmtResult},
 	time::Duration,
 };
@@ -64,25 +68,21 @@ impl AssetFolderPath for Skill {
 	}
 }
 
-impl<'a> From<&'a Skill> for SkillToken<'a> {
-	fn from(Skill { token, .. }: &'a Skill) -> Self {
-		SkillToken(token)
+impl GetProperty<SkillToken<'_>> for Skill {
+	fn get_property(&self) -> &'_ Token {
+		&self.token
 	}
 }
 
-impl<'a> From<&'a Skill> for SkillIcon<'a> {
-	fn from(Skill { icon, .. }: &'a Skill) -> Self {
-		Self(icon)
+impl GetProperty<SkillIcon<'_>> for Skill {
+	fn get_property(&self) -> &'_ Handle<Image> {
+		&self.icon
 	}
 }
 
-impl<'a> From<&'a Skill> for &'a CompatibleItems {
-	fn from(
-		Skill {
-			compatible_items, ..
-		}: &'a Skill,
-	) -> Self {
-		compatible_items
+impl GetProperty<CompatibleItems> for Skill {
+	fn get_property(&self) -> &'_ HashSet<ItemType> {
+		&self.compatible_items.0
 	}
 }
 
@@ -111,14 +111,14 @@ impl QueuedSkill {
 	}
 }
 
-impl From<&QueuedSkill> for SlotKey {
-	fn from(QueuedSkill { key, .. }: &QueuedSkill) -> Self {
-		*key
+impl GetProperty<SlotKey> for QueuedSkill {
+	fn get_property(&self) -> SlotKey {
+		self.key
 	}
 }
 
-impl<'a> RefInto<'a, &'a Token> for QueuedSkill {
-	fn ref_into(&self) -> &Token {
+impl GetProperty<Token> for QueuedSkill {
+	fn get_property(&self) -> &'_ Token {
 		&self.skill.token
 	}
 }
@@ -290,8 +290,8 @@ mod tests {
 	#[derive(Component)]
 	struct _Affected;
 
-	impl From<&_Affected> for Health {
-		fn from(_: &_Affected) -> Self {
+	impl GetProperty<Health> for _Affected {
+		fn get_property(&self) -> Health {
 			panic!("NOT USED")
 		}
 	}

--- a/src/plugins/skills/src/systems/execute.rs
+++ b/src/plugins/skills/src/systems/execute.rs
@@ -4,7 +4,7 @@ use common::{
 	components::persistent_entity::PersistentEntity,
 	tools::collider_info::ColliderInfo,
 	traits::{
-		accessors::get::RefInto,
+		accessors::get::GetProperty,
 		handles_player::{HandlesPlayerCameras, HandlesPlayerMouse},
 	},
 	zyheeda_commands::ZyheedaCommands,
@@ -38,15 +38,15 @@ fn get_target<TCamRay, TMouseHover>(
 	transforms: &Query<&GlobalTransform>,
 ) -> Option<SkillTarget>
 where
-	TCamRay: Resource + for<'a> RefInto<'a, Option<&'a Ray3d>>,
-	TMouseHover: Resource + for<'a> RefInto<'a, Option<&'a ColliderInfo<Entity>>>,
+	TCamRay: Resource + GetProperty<Option<Ray3d>>,
+	TMouseHover: Resource + GetProperty<Option<ColliderInfo<Entity>>>,
 {
 	let get_transform = |entity| transforms.get(entity).ok().cloned();
 
 	Some(SkillTarget {
-		ray: cam_ray.ref_into().cloned()?,
+		ray: cam_ray.get_property()?,
 		collision_info: hover
-			.ref_into()
+			.get_property()
 			.and_then(|collider_info| collider_info.with_component(get_transform)),
 	})
 }
@@ -75,9 +75,9 @@ mod tests {
 	#[derive(Resource, Default)]
 	pub struct _CamRay(Option<Ray3d>);
 
-	impl<'a> From<&'a _CamRay> for Option<&'a Ray3d> {
-		fn from(_CamRay(ray): &'a _CamRay) -> Self {
-			ray.as_ref()
+	impl GetProperty<Option<Ray3d>> for _CamRay {
+		fn get_property(&self) -> Option<Ray3d> {
+			self.0
 		}
 	}
 
@@ -90,9 +90,9 @@ mod tests {
 	#[derive(Resource, Default)]
 	pub struct _MouseHover(Option<ColliderInfo<Entity>>);
 
-	impl<'a> From<&'a _MouseHover> for Option<&'a ColliderInfo<Entity>> {
-		fn from(_MouseHover(info): &'a _MouseHover) -> Self {
-			info.as_ref()
+	impl GetProperty<Option<ColliderInfo<Entity>>> for _MouseHover {
+		fn get_property(&self) -> Option<ColliderInfo<Entity>> {
+			self.0
 		}
 	}
 

--- a/src/plugins/skills/src/systems/slot/visualization/visualize_item.rs
+++ b/src/plugins/skills/src/systems/slot/visualization/visualize_item.rs
@@ -7,7 +7,7 @@ use bevy::prelude::*;
 use common::{
 	tools::action_key::slot::SlotKey,
 	traits::{
-		accessors::get::{GetRef, RefAs, RefInto, TryApplyOn},
+		accessors::get::{GetProperty, GetRef, TryApplyOn},
 		thread_safe::ThreadSafe,
 	},
 	zyheeda_commands::ZyheedaCommands,
@@ -16,7 +16,7 @@ use std::hash::Hash;
 
 impl<TKey> SlotVisualization<TKey>
 where
-	TKey: Eq + Hash + ThreadSafe + VisualizeItem + for<'a> RefInto<'a, SlotKey>,
+	TKey: Eq + Hash + ThreadSafe + VisualizeItem + GetProperty<SlotKey>,
 {
 	pub(crate) fn visualize_items(
 		mut commands: ZyheedaCommands,
@@ -26,7 +26,7 @@ where
 		for (slots, visualization) in &slots {
 			for (key, entity) in &visualization.slots {
 				let item = slots
-					.get_ref(&key.ref_as::<SlotKey>())
+					.get_ref(&key.get_property())
 					.and_then(|slot| items.get(slot));
 
 				commands.try_apply_on(entity, |mut e| {
@@ -50,9 +50,9 @@ mod tests {
 	#[derive(Debug, PartialEq, Eq, Hash)]
 	struct _Key(SlotKey);
 
-	impl From<&_Key> for SlotKey {
-		fn from(_Key(slot_key): &_Key) -> Self {
-			*slot_key
+	impl GetProperty<SlotKey> for _Key {
+		fn get_property(&self) -> SlotKey {
+			self.0
 		}
 	}
 


### PR DESCRIPTION
Replacing the old `RefInto` with `GetProperty` has mainly several advantages:
- better communication of purpose
- streamlined access patter depending on the type retrieved ("heavy" types by ref, "light" types by value)
- less lifetimes required in constraints
- better auto discovery of `DynProperty` over the previous `RefAs` in vscode
- lifetime of the returned type bound to the call lifetime, not to the source lifetime 