### PR TITLE
Folder asset abort control

### DIFF
--- a/src/plugins/common/src/traits/handles_custom_assets.rs
+++ b/src/plugins/common/src/traits/handles_custom_assets.rs
@@ -15,11 +15,18 @@ pub trait HandlesCustomAssets {
 }
 
 pub trait HandlesCustomFolderAssets {
-	fn register_custom_folder_assets<TAsset, TDto, TLoadGroup>(app: &mut App)
-	where
+	fn register_custom_folder_assets<TAsset, TDto, TLoadGroup>(
+		app: &mut App,
+		on_load_error: OnLoadError,
+	) where
 		TAsset: Asset + AssetFolderPath + TryLoadFrom<TDto> + Clone + Debug,
 		for<'a> TDto: Deserialize<'a> + AssetFileExtensions + ThreadSafe,
 		TLoadGroup: ThreadSafe;
+}
+
+pub enum OnLoadError {
+	SkipAsset,
+	Panic,
 }
 
 pub trait AssetFolderPath {

--- a/src/plugins/loading/src/lib.rs
+++ b/src/plugins/loading/src/lib.rs
@@ -29,6 +29,7 @@ use common::{
 			AssetFolderPath,
 			HandlesCustomAssets,
 			HandlesCustomFolderAssets,
+			OnLoadError,
 			TryLoadFrom,
 		},
 		handles_load_tracking::{
@@ -242,8 +243,10 @@ impl HandlesCustomAssets for LoadingPlugin {
 }
 
 impl HandlesCustomFolderAssets for LoadingPlugin {
-	fn register_custom_folder_assets<TAsset, TDto, TLoadGroup>(app: &mut App)
-	where
+	fn register_custom_folder_assets<TAsset, TDto, TLoadGroup>(
+		app: &mut App,
+		on_load_error: OnLoadError,
+	) where
 		TAsset: Asset + AssetFolderPath + TryLoadFrom<TDto> + Clone + std::fmt::Debug,
 		for<'a> TDto: Deserialize<'a> + AssetFileExtensions + ThreadSafe,
 		TLoadGroup: ThreadSafe,

--- a/src/plugins/skills/src/lib.rs
+++ b/src/plugins/skills/src/lib.rs
@@ -24,7 +24,7 @@ use common::{
 	systems::log::OnError,
 	tools::action_key::slot::SlotKey,
 	traits::{
-		handles_custom_assets::{HandlesCustomAssets, HandlesCustomFolderAssets},
+		handles_custom_assets::{HandlesCustomAssets, HandlesCustomFolderAssets, OnLoadError},
 		handles_enemies::HandlesEnemies,
 		handles_load_tracking::{DependenciesProgress, HandlesLoadTracking, LoadTrackingInApp},
 		handles_loadout::HandlesLoadout,
@@ -100,7 +100,10 @@ where
 	}
 
 	fn skill_load(&self, app: &mut App) {
-		TLoading::register_custom_folder_assets::<Skill, SkillDto, LoadingGame>(app);
+		TLoading::register_custom_folder_assets::<Skill, SkillDto, LoadingGame>(
+			app,
+			OnLoadError::SkipAsset,
+		);
 	}
 
 	fn item_load(&self, app: &mut App) {


### PR DESCRIPTION
Adding a way to panic, when essential folder assets failed to load. For skills, we still skip when they could not be loaded. However, the upcoming changes to agents needs a way to end the application when agent configurations could not be loaded. 

The implementation in the loading plugin is a bit dirty but should be sufficient to communicate:
- asset failed to load (properly logged)
- application aborted via `panic`