### PR TITLE
Physics as independent plugin

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -46,10 +46,17 @@ fn prepare_game(app: &mut App) -> Result<(), ZyheedaAppError> {
 	let settings = SettingsPlugin::from_plugin(&loading);
 	let localization = LocalizationPlugin::from_plugin(&loading);
 	let savegame = SavegamePlugin::from_plugin(&settings).with_game_directory(game_dir);
+	let physics = PhysicsPlugin::from_plugin(&savegame);
 	let animations = AnimationsPlugin::from_plugin(&savegame);
 	let light = LightPlugin::from_plugin(&savegame);
-	let agents = AgentsPlugin::from_plugins(&loading, &settings, &savegame, &animations, &light);
-	let physics = PhysicsPlugin::from_plugin(&savegame);
+	let agents = AgentsPlugin::from_plugins(
+		&loading,
+		&settings,
+		&savegame,
+		&physics,
+		&animations,
+		&light,
+	);
 	let map_generation = MapGenerationPlugin::from_plugins(&loading, &savegame, &light, &agents);
 	let path_finding = PathFindingPlugin::from_plugin(&map_generation);
 	let behaviors = BehaviorsPlugin::from_plugins(

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,7 +49,7 @@ fn prepare_game(app: &mut App) -> Result<(), ZyheedaAppError> {
 	let animations = AnimationsPlugin::from_plugin(&savegame);
 	let light = LightPlugin::from_plugin(&savegame);
 	let agents = AgentsPlugin::from_plugins(&loading, &settings, &savegame, &animations, &light);
-	let physics = PhysicsPlugin::from_plugin(&savegame, &agents);
+	let physics = PhysicsPlugin::from_plugin(&savegame);
 	let map_generation = MapGenerationPlugin::from_plugins(&loading, &savegame, &light, &agents);
 	let path_finding = PathFindingPlugin::from_plugin(&map_generation);
 	let behaviors = BehaviorsPlugin::from_plugins(

--- a/src/plugins/agents/src/assets/agent_config.rs
+++ b/src/plugins/agents/src/assets/agent_config.rs
@@ -11,6 +11,7 @@ use common::{
 		accessors::get::GetProperty,
 		handles_agents::AgentType,
 		handles_custom_assets::AssetFolderPath,
+		handles_physics::PhysicalDefaultAttributes,
 		handles_skill_behaviors::SkillSpawner,
 		load_asset::Path,
 		loadout::{ItemName, LoadoutConfig},
@@ -27,12 +28,18 @@ pub struct AgentConfigAsset {
 	pub(crate) loadout: Loadout,
 	pub(crate) bones: Bones,
 	pub(crate) agent_model: AgentModel,
-	pub(crate) attributes: Attributes,
+	pub(crate) attributes: PhysicalDefaultAttributes,
 }
 
 impl AssetFolderPath for AgentConfigAsset {
 	fn asset_folder_path() -> Path {
 		Path::from("agents")
+	}
+}
+
+impl GetProperty<PhysicalDefaultAttributes> for AgentConfigAsset {
+	fn get_property(&self) -> PhysicalDefaultAttributes {
+		self.attributes
 	}
 }
 
@@ -148,12 +155,4 @@ impl PartialEq for AgentModel {
 			_ => false,
 		}
 	}
-}
-
-#[derive(Debug, PartialEq, Clone, Copy, Serialize, Deserialize)]
-
-pub(crate) struct Attributes {
-	health: Health,
-	gravity_interaction: EffectTarget<Gravity>,
-	force_interaction: EffectTarget<Force>,
 }

--- a/src/plugins/agents/src/assets/agent_config.rs
+++ b/src/plugins/agents/src/assets/agent_config.rs
@@ -3,10 +3,8 @@ pub(crate) mod dto;
 use crate::systems::agent::insert_model::InsertModel;
 use bevy::{asset::Asset, reflect::TypePath};
 use common::{
-	attributes::{effect_target::EffectTarget, health::Health},
 	components::asset_model::AssetModel,
-	effects::{force::Force, gravity::Gravity},
-	tools::{action_key::slot::SlotKey, attribute::AttributeOnSpawn, bone::Bone},
+	tools::{action_key::slot::SlotKey, bone::Bone},
 	traits::{
 		accessors::get::GetProperty,
 		handles_agents::AgentType,
@@ -95,24 +93,6 @@ impl Mapper<Bone<'_>, Option<ForearmSlot>> for AgentConfigData<'_> {
 			.get(bone)
 			.copied()
 			.map(ForearmSlot::from)
-	}
-}
-
-impl GetProperty<AttributeOnSpawn<Health>> for AgentConfigData<'_> {
-	fn get_property(&self) -> Health {
-		self.asset.attributes.health
-	}
-}
-
-impl GetProperty<AttributeOnSpawn<EffectTarget<Gravity>>> for AgentConfigData<'_> {
-	fn get_property(&self) -> EffectTarget<Gravity> {
-		self.asset.attributes.gravity_interaction
-	}
-}
-
-impl GetProperty<AttributeOnSpawn<EffectTarget<Force>>> for AgentConfigData<'_> {
-	fn get_property(&self) -> EffectTarget<Force> {
-		self.asset.attributes.force_interaction
 	}
 }
 

--- a/src/plugins/agents/src/assets/agent_config/dto.rs
+++ b/src/plugins/agents/src/assets/agent_config/dto.rs
@@ -1,10 +1,13 @@
 use crate::{
-	assets::agent_config::{AgentConfigAsset, AgentModel, Attributes, Bones, Loadout},
+	assets::agent_config::{AgentConfigAsset, AgentModel, Bones, Loadout},
 	components::enemy::void_sphere::VoidSphere,
 };
 use common::{
 	errors::Unreachable,
-	traits::handles_custom_assets::{AssetFileExtensions, TryLoadFrom},
+	traits::{
+		handles_custom_assets::{AssetFileExtensions, TryLoadFrom},
+		handles_physics::PhysicalDefaultAttributes,
+	},
 };
 use serde::{Deserialize, Serialize};
 
@@ -12,7 +15,7 @@ use serde::{Deserialize, Serialize};
 pub struct AgentConfigAssetDto {
 	pub(crate) model: Model,
 	pub(crate) loadout: Loadout,
-	pub(crate) attributes: Attributes,
+	pub(crate) attributes: PhysicalDefaultAttributes,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]

--- a/src/plugins/agents/src/systems/agent.rs
+++ b/src/plugins/agents/src/systems/agent.rs
@@ -1,1 +1,2 @@
+pub(crate) mod insert_attributes;
 pub(crate) mod insert_model;

--- a/src/plugins/agents/src/systems/agent/insert_attributes.rs
+++ b/src/plugins/agents/src/systems/agent/insert_attributes.rs
@@ -1,0 +1,156 @@
+use crate::components::agent::Agent;
+use bevy::prelude::*;
+use common::{
+	traits::{
+		accessors::get::{GetProperty, TryApplyOn},
+		handles_physics::PhysicalDefaultAttributes,
+	},
+	zyheeda_commands::ZyheedaCommands,
+};
+
+impl<TAsset> Agent<TAsset>
+where
+	TAsset: Asset + GetProperty<PhysicalDefaultAttributes>,
+{
+	pub(crate) fn insert_attributes<TComponent>(
+		mut commands: ZyheedaCommands,
+		agents: Query<(Entity, &Self), Without<TComponent>>,
+		configs: Res<Assets<TAsset>>,
+	) where
+		TComponent: Component + From<PhysicalDefaultAttributes>,
+	{
+		for (entity, Agent { config_handle, .. }) in &agents {
+			let Some(config) = configs.get(config_handle) else {
+				continue;
+			};
+
+			commands.try_apply_on(&entity, |mut e| {
+				let default_attributes = config.get_property();
+				e.try_insert(TComponent::from(default_attributes));
+			});
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use common::{
+		attributes::{effect_target::EffectTarget, health::Health},
+		traits::handles_agents::AgentType,
+	};
+	use testing::{SingleThreadedApp, new_handle};
+
+	#[derive(Asset, TypePath)]
+	struct _Config(PhysicalDefaultAttributes);
+
+	impl GetProperty<PhysicalDefaultAttributes> for _Config {
+		fn get_property(&self) -> PhysicalDefaultAttributes {
+			self.0
+		}
+	}
+
+	#[derive(Component, Debug, PartialEq)]
+	struct _Component(PhysicalDefaultAttributes);
+
+	impl From<PhysicalDefaultAttributes> for _Component {
+		fn from(attributes: PhysicalDefaultAttributes) -> Self {
+			Self(attributes)
+		}
+	}
+
+	fn setup<const N: usize>(attributes: [(&Handle<_Config>, _Config); N]) -> App {
+		let mut app = App::new().single_threaded(Update);
+		let mut assets = Assets::default();
+
+		for (id, asset) in attributes {
+			assets.insert(id, asset);
+		}
+
+		app.insert_resource(assets);
+		app.add_systems(Update, Agent::<_Config>::insert_attributes::<_Component>);
+
+		app
+	}
+
+	#[test]
+	fn insert_default_attributes() {
+		let config_handle = new_handle();
+		let attributes = PhysicalDefaultAttributes {
+			health: Health::new(100.),
+			force_interaction: EffectTarget::Immune,
+			gravity_interaction: EffectTarget::Affected,
+		};
+		let mut app = setup([(&config_handle, _Config(attributes))]);
+		let entity = app
+			.world_mut()
+			.spawn(Agent {
+				agent_type: AgentType::Player,
+				config_handle,
+			})
+			.id();
+
+		app.update();
+
+		assert_eq!(
+			Some(&_Component(attributes)),
+			app.world().entity(entity).get::<_Component>(),
+		);
+	}
+
+	#[test]
+	fn insert_only_once() {
+		let config_handle = new_handle();
+		let attributes = PhysicalDefaultAttributes {
+			health: Health::new(100.),
+			force_interaction: EffectTarget::Immune,
+			gravity_interaction: EffectTarget::Affected,
+		};
+		let mut app = setup([(&config_handle, _Config(attributes))]);
+		let entity = app
+			.world_mut()
+			.spawn(Agent {
+				agent_type: AgentType::Player,
+				config_handle: config_handle.clone(),
+			})
+			.id();
+
+		app.update();
+		let mut configs = app.world_mut().resource_mut::<Assets<_Config>>();
+		let config = configs.get_mut(&config_handle).unwrap();
+		config.0.health = Health::new(42.);
+		app.update();
+
+		assert_eq!(
+			Some(&_Component(attributes)),
+			app.world().entity(entity).get::<_Component>(),
+		);
+	}
+
+	#[test]
+	fn insert_again_when_target_component_removed() {
+		let config_handle = new_handle();
+		let attributes = PhysicalDefaultAttributes {
+			health: Health::new(100.),
+			force_interaction: EffectTarget::Immune,
+			gravity_interaction: EffectTarget::Affected,
+		};
+		let mut app = setup([(&config_handle, _Config(attributes))]);
+		let entity = app
+			.world_mut()
+			.spawn(Agent {
+				agent_type: AgentType::Player,
+				config_handle: config_handle.clone(),
+			})
+			.id();
+
+		app.update();
+		app.world_mut().entity_mut(entity).remove::<_Component>();
+		app.update();
+
+		assert_eq!(
+			Some(&_Component(attributes)),
+			app.world().entity(entity).get::<_Component>(),
+		);
+	}
+}

--- a/src/plugins/agents/src/systems/agent/insert_model.rs
+++ b/src/plugins/agents/src/systems/agent/insert_model.rs
@@ -7,12 +7,12 @@ use common::{
 	zyheeda_commands::{ZyheedaCommands, ZyheedaEntityCommands},
 };
 
-impl<T> InsertModelObserver for T where
+impl<T> InsertModelSystem for T where
 	T: Component + for<'a> GetFromSystemParam<AgentConfig, TItem<'a>: InsertModel>
 {
 }
 
-pub(crate) trait InsertModelObserver:
+pub(crate) trait InsertModelSystem:
 	Component + for<'a> GetFromSystemParam<AgentConfig, TItem<'a>: InsertModel> + Sized
 {
 	fn insert_model(

--- a/src/plugins/common/src/traits/handles_agents.rs
+++ b/src/plugins/common/src/traits/handles_agents.rs
@@ -1,9 +1,7 @@
 use crate::{
-	attributes::{effect_target::EffectTarget, health::Health},
-	effects::{force::Force, gravity::Gravity},
-	tools::{attribute::AttributeOnSpawn, bone::Bone},
+	tools::bone::Bone,
 	traits::{
-		accessors::get::{GetFromSystemParam, GetProperty},
+		accessors::get::GetFromSystemParam,
 		handles_enemies::EnemyType,
 		handles_skill_behaviors::SkillSpawner,
 		loadout::LoadoutConfig,
@@ -20,10 +18,7 @@ pub trait HandlesAgents {
 		+ Mapper<Bone<'a>, Option<SkillSpawner>>
 		+ Mapper<Bone<'a>, Option<EssenceSlot>>
 		+ Mapper<Bone<'a>, Option<HandSlot>>
-		+ Mapper<Bone<'a>, Option<ForearmSlot>>
-		+ GetProperty<AttributeOnSpawn<Health>>
-		+ GetProperty<AttributeOnSpawn<EffectTarget<Gravity>>>
-		+ GetProperty<AttributeOnSpawn<EffectTarget<Force>>>;
+		+ Mapper<Bone<'a>, Option<ForearmSlot>>;
 	type TAgent: Component
 		+ Spawn
 		+ for<'i> GetFromSystemParam<AgentConfig, TItem<'i> = Self::TAgentConfig<'i>>;

--- a/src/plugins/common/src/traits/handles_physics.rs
+++ b/src/plugins/common/src/traits/handles_physics.rs
@@ -1,5 +1,5 @@
 use crate::{
-	attributes::health::Health,
+	attributes::{effect_target::EffectTarget, health::Health},
 	components::is_blocker::Blocker,
 	effects::{force::Force, gravity::Gravity, health_damage::HealthDamage},
 	tools::{Done, Units, speed::Speed},
@@ -8,6 +8,10 @@ use crate::{
 use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
+
+pub trait HandlesPhysicalAttributes {
+	type TDefaultAttributes: Component + From<DefaultPhysicalAttributes>;
+}
 
 pub trait HandlesPhysicalObjects {
 	type TSystems: SystemSet;
@@ -67,6 +71,13 @@ impl<T> HandlesLife for T where
 
 pub trait Effect {
 	type TTarget;
+}
+
+#[derive(Debug, PartialEq)]
+pub struct DefaultPhysicalAttributes {
+	pub health: Health,
+	pub force_interaction: EffectTarget<Force>,
+	pub gravity_interaction: EffectTarget<Gravity>,
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/src/plugins/common/src/traits/handles_physics.rs
+++ b/src/plugins/common/src/traits/handles_physics.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
 pub trait HandlesPhysicalAttributes {
-	type TDefaultAttributes: Component + From<DefaultPhysicalAttributes>;
+	type TDefaultAttributes: Component + From<PhysicalDefaultAttributes>;
 }
 
 pub trait HandlesPhysicalObjects {
@@ -73,11 +73,15 @@ pub trait Effect {
 	type TTarget;
 }
 
-#[derive(Debug, PartialEq)]
-pub struct DefaultPhysicalAttributes {
+#[derive(Debug, PartialEq, Clone, Copy, Serialize, Deserialize)]
+pub struct PhysicalDefaultAttributes {
 	pub health: Health,
 	pub force_interaction: EffectTarget<Force>,
 	pub gravity_interaction: EffectTarget<Gravity>,
+}
+
+impl Property for PhysicalDefaultAttributes {
+	type TValue<'a> = Self;
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/src/plugins/physics/src/components.rs
+++ b/src/plugins/physics/src/components.rs
@@ -1,6 +1,7 @@
 pub(crate) mod active_beam;
 pub(crate) mod affected;
 pub(crate) mod blockable;
+pub(crate) mod default_attributes;
 pub(crate) mod effect;
 pub(crate) mod interacting_entities;
 pub(crate) mod motion;

--- a/src/plugins/physics/src/components/default_attributes.rs
+++ b/src/plugins/physics/src/components/default_attributes.rs
@@ -3,14 +3,14 @@ use common::{
 	attributes::{effect_target::EffectTarget, health::Health},
 	effects::{force::Force, gravity::Gravity},
 	tools::attribute::AttributeOnSpawn,
-	traits::{accessors::get::GetProperty, handles_physics::DefaultPhysicalAttributes},
+	traits::{accessors::get::GetProperty, handles_physics::PhysicalDefaultAttributes},
 };
 
 #[derive(Component, Debug, PartialEq)]
-pub struct DefaultAttributes(DefaultPhysicalAttributes);
+pub struct DefaultAttributes(PhysicalDefaultAttributes);
 
-impl From<DefaultPhysicalAttributes> for DefaultAttributes {
-	fn from(attributes: DefaultPhysicalAttributes) -> Self {
+impl From<PhysicalDefaultAttributes> for DefaultAttributes {
+	fn from(attributes: PhysicalDefaultAttributes) -> Self {
 		Self(attributes)
 	}
 }

--- a/src/plugins/physics/src/components/default_attributes.rs
+++ b/src/plugins/physics/src/components/default_attributes.rs
@@ -1,0 +1,34 @@
+use bevy::prelude::*;
+use common::{
+	attributes::{effect_target::EffectTarget, health::Health},
+	effects::{force::Force, gravity::Gravity},
+	tools::attribute::AttributeOnSpawn,
+	traits::{accessors::get::GetProperty, handles_physics::DefaultPhysicalAttributes},
+};
+
+#[derive(Component, Debug, PartialEq)]
+pub struct DefaultAttributes(DefaultPhysicalAttributes);
+
+impl From<DefaultPhysicalAttributes> for DefaultAttributes {
+	fn from(attributes: DefaultPhysicalAttributes) -> Self {
+		Self(attributes)
+	}
+}
+
+impl GetProperty<AttributeOnSpawn<Health>> for DefaultAttributes {
+	fn get_property(&self) -> Health {
+		self.0.health
+	}
+}
+
+impl GetProperty<AttributeOnSpawn<EffectTarget<Gravity>>> for DefaultAttributes {
+	fn get_property(&self) -> EffectTarget<Gravity> {
+		self.0.gravity_interaction
+	}
+}
+
+impl GetProperty<AttributeOnSpawn<EffectTarget<Force>>> for DefaultAttributes {
+	fn get_property(&self) -> EffectTarget<Force> {
+		self.0.force_interaction
+	}
+}

--- a/src/plugins/physics/src/lib.rs
+++ b/src/plugins/physics/src/lib.rs
@@ -25,7 +25,6 @@ use bevy::{ecs::component::Mutable, prelude::*};
 use bevy_rapier3d::prelude::Velocity;
 use common::traits::{
 	delta::Delta,
-	handles_agents::HandlesAgents,
 	handles_physics::{HandlesMotion, HandlesPhysicalAttributes, HandlesPhysicalObjects},
 	handles_saving::{HandlesSaving, SavableComponent},
 	register_derived_component::RegisterDerivedComponent,
@@ -60,20 +59,18 @@ use traits::act_on::ActOn;
 
 pub struct PhysicsPlugin<TDependencies>(PhantomData<TDependencies>);
 
-impl<TSaveGame, TAgents> PhysicsPlugin<(TSaveGame, TAgents)>
+impl<TSaveGame> PhysicsPlugin<TSaveGame>
 where
 	TSaveGame: ThreadSafe + HandlesSaving,
-	TAgents: ThreadSafe + HandlesAgents,
 {
-	pub fn from_plugin(_: &TSaveGame, _: &TAgents) -> Self {
+	pub fn from_plugin(_: &TSaveGame) -> Self {
 		Self(PhantomData)
 	}
 }
 
-impl<TSaveGame, TAgents> Plugin for PhysicsPlugin<(TSaveGame, TAgents)>
+impl<TSaveGame> Plugin for PhysicsPlugin<TSaveGame>
 where
 	TSaveGame: ThreadSafe + HandlesSaving,
-	TAgents: ThreadSafe + HandlesAgents,
 {
 	fn build(&self, app: &mut App) {
 		TSaveGame::register_savable_component::<Motion>(app);

--- a/src/plugins/physics/src/lib.rs
+++ b/src/plugins/physics/src/lib.rs
@@ -10,6 +10,7 @@ use crate::{
 	components::{
 		affected::{force_affected::ForceAffected, gravity_affected::GravityAffected, life::Life},
 		blockable::Blockable,
+		default_attributes::DefaultAttributes,
 		effect::force::ForceEffect,
 		motion::Motion,
 	},
@@ -25,7 +26,7 @@ use bevy_rapier3d::prelude::Velocity;
 use common::traits::{
 	delta::Delta,
 	handles_agents::HandlesAgents,
-	handles_physics::{HandlesMotion, HandlesPhysicalObjects},
+	handles_physics::{HandlesMotion, HandlesPhysicalAttributes, HandlesPhysicalObjects},
 	handles_saving::{HandlesSaving, SavableComponent},
 	register_derived_component::RegisterDerivedComponent,
 	thread_safe::ThreadSafe,
@@ -92,7 +93,7 @@ where
 			.add_observer(HealthDamageEffect::update_blockers)
 			.add_systems(
 				Update,
-				(Life::insert_on::<TAgents::TAgent>, Life::despawn_dead)
+				(Life::insert_from::<DefaultAttributes>, Life::despawn_dead)
 					.chain()
 					.in_set(PhysicsSystems),
 			)
@@ -102,7 +103,7 @@ where
 			.add_systems(
 				Update,
 				(
-					GravityAffected::insert_on::<TAgents::TAgent>,
+					GravityAffected::insert_from::<DefaultAttributes>,
 					Update::delta.pipe(GravityAffected::apply_pull),
 				)
 					.chain()
@@ -113,7 +114,7 @@ where
 			.add_observer(ForceEffect::update_blockers)
 			.add_systems(
 				Update,
-				ForceAffected::insert_on::<TAgents::TAgent>.in_set(PhysicsSystems),
+				ForceAffected::insert_from::<DefaultAttributes>.in_set(PhysicsSystems),
 			)
 			// Apply interactions
 			.add_event::<InteractionEvent>()
@@ -177,6 +178,10 @@ impl AddPhysics for App {
 
 #[derive(SystemSet, Debug, PartialEq, Eq, Hash, Clone)]
 pub struct PhysicsSystems;
+
+impl<TDependencies> HandlesPhysicalAttributes for PhysicsPlugin<TDependencies> {
+	type TDefaultAttributes = DefaultAttributes;
+}
 
 impl<TDependencies> HandlesPhysicalObjects for PhysicsPlugin<TDependencies> {
 	type TSystems = PhysicsSystems;


### PR DESCRIPTION
Physics plugin should be largely independent, because in the future, all other plugins that need collision detection or physical interactions should ask the physics plugin for that information. The only remaining dependency is the savegame plugin, which is needed to safe the current motion (and in the future the active skills).