### PR TITLE
`physics` plugin handles raycasts

### DIFF
--- a/src/plugins/common/src/traits/handles_physics.rs
+++ b/src/plugins/common/src/traits/handles_physics.rs
@@ -5,9 +5,24 @@ use crate::{
 	tools::{Done, Units, speed::Speed},
 	traits::accessors::get::{GetProperty, Property},
 };
-use bevy::prelude::*;
+use bevy::{ecs::system::SystemParam, prelude::*};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
+
+pub trait HandlesColliders {
+	type TRayCast<'world, 'state>: SystemParam + Raycast<SolidObjects>;
+}
+
+pub trait Raycast<TConstraints>
+where
+	TConstraints: RaycastConstraint,
+{
+	fn raycast(&self, ray: Ray3d, constraints: TConstraints) -> TConstraints::TResult;
+}
+
+pub trait RaycastConstraint {
+	type TResult;
+}
 
 pub trait HandlesPhysicalAttributes {
 	type TDefaultAttributes: Component + From<PhysicalDefaultAttributes>;
@@ -93,4 +108,19 @@ pub enum PhysicalObject {
 	Fragile {
 		destroyed_by: HashSet<Blocker>,
 	},
+}
+
+#[derive(Debug, PartialEq, Default)]
+pub struct SolidObjects {
+	pub exclude: Vec<Entity>,
+}
+
+impl RaycastConstraint for SolidObjects {
+	type TResult = Option<RaycastHit>;
+}
+
+#[derive(Debug, PartialEq)]
+pub struct RaycastHit {
+	pub entity: Entity,
+	pub time_of_impact: f32,
 }

--- a/src/plugins/physics/src/lib.rs
+++ b/src/plugins/physics/src/lib.rs
@@ -20,12 +20,18 @@ use crate::{
 		insert_affected::InsertAffected,
 		interactions::act_on::ActOnSystem,
 	},
+	traits::ray_cast::RayCaster,
 };
 use bevy::{ecs::component::Mutable, prelude::*};
 use bevy_rapier3d::prelude::Velocity;
 use common::traits::{
 	delta::Delta,
-	handles_physics::{HandlesMotion, HandlesPhysicalAttributes, HandlesPhysicalObjects},
+	handles_physics::{
+		HandlesColliders,
+		HandlesMotion,
+		HandlesPhysicalAttributes,
+		HandlesPhysicalObjects,
+	},
 	handles_saving::{HandlesSaving, SavableComponent},
 	register_derived_component::RegisterDerivedComponent,
 	thread_safe::ThreadSafe,
@@ -175,6 +181,10 @@ impl AddPhysics for App {
 
 #[derive(SystemSet, Debug, PartialEq, Eq, Hash, Clone)]
 pub struct PhysicsSystems;
+
+impl<TDependencies> HandlesColliders for PhysicsPlugin<TDependencies> {
+	type TRayCast<'world, 'state> = RayCaster<'world, 'state>;
+}
 
 impl<TDependencies> HandlesPhysicalAttributes for PhysicsPlugin<TDependencies> {
 	type TDefaultAttributes = DefaultAttributes;

--- a/src/plugins/physics/src/traits.rs
+++ b/src/plugins/physics/src/traits.rs
@@ -1,5 +1,6 @@
 pub(crate) mod act_on;
 pub(crate) mod rapier_context;
+pub(crate) mod ray_cast;
 pub(crate) mod update_blockers;
 
 use bevy::prelude::Entity;

--- a/src/plugins/physics/src/traits/ray_cast.rs
+++ b/src/plugins/physics/src/traits/ray_cast.rs
@@ -1,0 +1,124 @@
+use bevy::{ecs::system::SystemParam, prelude::*};
+use bevy_rapier3d::prelude::{Real, *};
+use common::traits::handles_physics::{Raycast, RaycastHit, SolidObjects};
+
+/// A simple wrapper around rapier's [`ReadRapierContext`], so we can implement
+/// external traits for it.
+#[derive(SystemParam)]
+pub struct RayCaster<'w, 's> {
+	context: ReadRapierContext<'w, 's>,
+}
+
+impl Raycast<SolidObjects> for RayCaster<'_, '_> {
+	fn raycast(&self, ray: Ray3d, SolidObjects { exclude }: SolidObjects) -> Option<RaycastHit> {
+		let ray_caster = self.context.single().ok()?;
+		let mut filter = QueryFilter::default().exclude_sensors();
+
+		for entity in exclude {
+			filter = filter.exclude_rigid_body(entity);
+		}
+
+		let (entity, time_of_impact) =
+			ray_caster.cast_ray(ray.origin, *ray.direction, Real::MAX, true, filter)?;
+
+		Some(RaycastHit {
+			entity,
+			time_of_impact,
+		})
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use bevy::{
+		ecs::system::{RunSystemError, RunSystemOnce},
+		render::mesh::MeshPlugin,
+		scene::ScenePlugin,
+	};
+	use testing::SingleThreadedApp;
+
+	fn setup() -> App {
+		let mut app = App::new().single_threaded(Update);
+
+		app.add_plugins((
+			MinimalPlugins,
+			AssetPlugin::default(),
+			MeshPlugin,
+			ScenePlugin,
+			RapierPhysicsPlugin::<NoUserData>::default(),
+		));
+
+		app
+	}
+
+	#[test]
+	fn hit_object() -> Result<(), RunSystemError> {
+		let mut app = setup();
+		let entity = app
+			.world_mut()
+			.spawn((RigidBody::Fixed, Transform::default(), Collider::ball(0.5)))
+			.id();
+		app.update();
+
+		let hit = app.world_mut().run_system_once(|ray_caster: RayCaster| {
+			ray_caster.raycast(Ray3d::new(Vec3::Y, Dir3::NEG_Y), SolidObjects::default())
+		})?;
+
+		assert_eq!(
+			Some(RaycastHit {
+				entity,
+				time_of_impact: 0.5
+			}),
+			hit,
+		);
+		Ok(())
+	}
+
+	#[test]
+	fn ignore_sensor() -> Result<(), RunSystemError> {
+		let mut app = setup();
+		app.world_mut().spawn((
+			RigidBody::Fixed,
+			Transform::default(),
+			Collider::ball(0.5),
+			Sensor,
+		));
+		app.update();
+
+		let hit = app.world_mut().run_system_once(|ray_caster: RayCaster| {
+			ray_caster.raycast(Ray3d::new(Vec3::Y, Dir3::NEG_Y), SolidObjects::default())
+		})?;
+
+		assert_eq!(None, hit);
+		Ok(())
+	}
+
+	#[test]
+	fn ignore_object_rigid_body() -> Result<(), RunSystemError> {
+		let mut app = setup();
+		let entity = app
+			.world_mut()
+			.spawn((
+				RigidBody::Fixed,
+				Transform::default(),
+				children![(Transform::default(), Collider::ball(0.5))],
+			))
+			.id();
+		app.update();
+
+		let hit = app
+			.world_mut()
+			.run_system_once(move |ray_caster: RayCaster| {
+				ray_caster.raycast(
+					Ray3d::new(Vec3::Y, Dir3::NEG_Y),
+					SolidObjects {
+						exclude: vec![entity],
+					},
+				)
+			})?;
+
+		assert_eq!(None, hit);
+		Ok(())
+	}
+}


### PR DESCRIPTION
The physics plugin provides a ray caster system parameter for other plugins to use. Aims to replace the current globally available ray casting in the future.