### PR TITLE
add ray_cast to ground

### DIFF
--- a/src/plugins/common/src/traits/handles_physics.rs
+++ b/src/plugins/common/src/traits/handles_physics.rs
@@ -3,14 +3,17 @@ use crate::{
 	components::is_blocker::Blocker,
 	effects::{force::Force, gravity::Gravity, health_damage::HealthDamage},
 	tools::{Done, Units, speed::Speed},
-	traits::accessors::get::{GetProperty, Property},
+	traits::{
+		accessors::get::{GetProperty, Property},
+		cast_ray::TimeOfImpact,
+	},
 };
 use bevy::{ecs::system::SystemParam, prelude::*};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
 pub trait HandlesColliders {
-	type TRayCast<'world, 'state>: SystemParam + Raycast<SolidObjects>;
+	type TRayCast<'world, 'state>: SystemParam + Raycast<SolidObjects> + Raycast<Ground>;
 }
 
 pub trait Raycast<TConstraints>
@@ -108,6 +111,13 @@ pub enum PhysicalObject {
 	Fragile {
 		destroyed_by: HashSet<Blocker>,
 	},
+}
+
+#[derive(Debug, PartialEq)]
+pub struct Ground;
+
+impl RaycastConstraint for Ground {
+	type TResult = Option<TimeOfImpact>;
 }
 
 #[derive(Debug, PartialEq, Default)]

--- a/src/plugins/physics/src/traits/ray_cast.rs
+++ b/src/plugins/physics/src/traits/ray_cast.rs
@@ -1,124 +1,12 @@
+mod ground;
+mod solid_objects;
+
 use bevy::{ecs::system::SystemParam, prelude::*};
-use bevy_rapier3d::prelude::{Real, *};
-use common::traits::handles_physics::{Raycast, RaycastHit, SolidObjects};
+use bevy_rapier3d::prelude::*;
 
 /// A simple wrapper around rapier's [`ReadRapierContext`], so we can implement
 /// external traits for it.
 #[derive(SystemParam)]
 pub struct RayCaster<'w, 's> {
 	context: ReadRapierContext<'w, 's>,
-}
-
-impl Raycast<SolidObjects> for RayCaster<'_, '_> {
-	fn raycast(&self, ray: Ray3d, SolidObjects { exclude }: SolidObjects) -> Option<RaycastHit> {
-		let ray_caster = self.context.single().ok()?;
-		let mut filter = QueryFilter::default().exclude_sensors();
-
-		for entity in exclude {
-			filter = filter.exclude_rigid_body(entity);
-		}
-
-		let (entity, time_of_impact) =
-			ray_caster.cast_ray(ray.origin, *ray.direction, Real::MAX, true, filter)?;
-
-		Some(RaycastHit {
-			entity,
-			time_of_impact,
-		})
-	}
-}
-
-#[cfg(test)]
-mod tests {
-	use super::*;
-	use bevy::{
-		ecs::system::{RunSystemError, RunSystemOnce},
-		render::mesh::MeshPlugin,
-		scene::ScenePlugin,
-	};
-	use testing::SingleThreadedApp;
-
-	fn setup() -> App {
-		let mut app = App::new().single_threaded(Update);
-
-		app.add_plugins((
-			MinimalPlugins,
-			AssetPlugin::default(),
-			MeshPlugin,
-			ScenePlugin,
-			RapierPhysicsPlugin::<NoUserData>::default(),
-		));
-
-		app
-	}
-
-	#[test]
-	fn hit_object() -> Result<(), RunSystemError> {
-		let mut app = setup();
-		let entity = app
-			.world_mut()
-			.spawn((RigidBody::Fixed, Transform::default(), Collider::ball(0.5)))
-			.id();
-		app.update();
-
-		let hit = app.world_mut().run_system_once(|ray_caster: RayCaster| {
-			ray_caster.raycast(Ray3d::new(Vec3::Y, Dir3::NEG_Y), SolidObjects::default())
-		})?;
-
-		assert_eq!(
-			Some(RaycastHit {
-				entity,
-				time_of_impact: 0.5
-			}),
-			hit,
-		);
-		Ok(())
-	}
-
-	#[test]
-	fn ignore_sensor() -> Result<(), RunSystemError> {
-		let mut app = setup();
-		app.world_mut().spawn((
-			RigidBody::Fixed,
-			Transform::default(),
-			Collider::ball(0.5),
-			Sensor,
-		));
-		app.update();
-
-		let hit = app.world_mut().run_system_once(|ray_caster: RayCaster| {
-			ray_caster.raycast(Ray3d::new(Vec3::Y, Dir3::NEG_Y), SolidObjects::default())
-		})?;
-
-		assert_eq!(None, hit);
-		Ok(())
-	}
-
-	#[test]
-	fn ignore_object_rigid_body() -> Result<(), RunSystemError> {
-		let mut app = setup();
-		let entity = app
-			.world_mut()
-			.spawn((
-				RigidBody::Fixed,
-				Transform::default(),
-				children![(Transform::default(), Collider::ball(0.5))],
-			))
-			.id();
-		app.update();
-
-		let hit = app
-			.world_mut()
-			.run_system_once(move |ray_caster: RayCaster| {
-				ray_caster.raycast(
-					Ray3d::new(Vec3::Y, Dir3::NEG_Y),
-					SolidObjects {
-						exclude: vec![entity],
-					},
-				)
-			})?;
-
-		assert_eq!(None, hit);
-		Ok(())
-	}
 }

--- a/src/plugins/physics/src/traits/ray_cast/ground.rs
+++ b/src/plugins/physics/src/traits/ray_cast/ground.rs
@@ -1,0 +1,60 @@
+use crate::traits::ray_cast::RayCaster;
+use bevy::prelude::*;
+use common::traits::{
+	cast_ray::TimeOfImpact,
+	handles_physics::{Ground, Raycast},
+};
+
+const HORIZONTAL_PLANE: InfinitePlane3d = InfinitePlane3d { normal: Dir3::Y };
+
+impl Raycast<Ground> for RayCaster<'_, '_> {
+	fn raycast(&self, ray: Ray3d, _: Ground) -> Option<TimeOfImpact> {
+		ray.intersect_plane(Vec3::ZERO, HORIZONTAL_PLANE)
+			.map(TimeOfImpact)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use bevy::ecs::system::{RunSystemError, RunSystemOnce};
+	use testing::SingleThreadedApp;
+
+	fn setup() -> App {
+		App::new().single_threaded(Update)
+	}
+
+	#[test]
+	fn intersect_origin() -> Result<(), RunSystemError> {
+		let mut app = setup();
+
+		let hit = app.world_mut().run_system_once(|ray_caster: RayCaster| {
+			ray_caster.raycast(
+				Ray3d {
+					origin: Vec3::Y,
+					direction: Dir3::NEG_Y,
+				},
+				Ground,
+			)
+		})?;
+		assert_eq!(Some(TimeOfImpact(1.)), hit);
+		Ok(())
+	}
+
+	#[test]
+	fn intersect_off() -> Result<(), RunSystemError> {
+		let mut app = setup();
+
+		let hit = app.world_mut().run_system_once(|ray_caster: RayCaster| {
+			ray_caster.raycast(
+				Ray3d {
+					origin: Vec3::new(10., 8., 22.),
+					direction: Dir3::try_from(Vec3::new(-3., -4., 0.)).unwrap(),
+				},
+				Ground,
+			)
+		})?;
+		assert_eq!(Some(TimeOfImpact(10.)), hit);
+		Ok(())
+	}
+}

--- a/src/plugins/physics/src/traits/ray_cast/solid_objects.rs
+++ b/src/plugins/physics/src/traits/ray_cast/solid_objects.rs
@@ -1,0 +1,118 @@
+use crate::traits::ray_cast::RayCaster;
+use bevy::prelude::*;
+use bevy_rapier3d::prelude::{Real, *};
+use common::traits::handles_physics::{Raycast, RaycastHit, SolidObjects};
+
+impl Raycast<SolidObjects> for RayCaster<'_, '_> {
+	fn raycast(&self, ray: Ray3d, SolidObjects { exclude }: SolidObjects) -> Option<RaycastHit> {
+		let ray_caster = self.context.single().ok()?;
+		let mut filter = QueryFilter::default().exclude_sensors();
+
+		for entity in exclude {
+			filter = filter.exclude_rigid_body(entity);
+		}
+
+		let (entity, time_of_impact) =
+			ray_caster.cast_ray(ray.origin, *ray.direction, Real::MAX, true, filter)?;
+
+		Some(RaycastHit {
+			entity,
+			time_of_impact,
+		})
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use bevy::{
+		ecs::system::{RunSystemError, RunSystemOnce},
+		render::mesh::MeshPlugin,
+		scene::ScenePlugin,
+	};
+	use testing::SingleThreadedApp;
+
+	fn setup() -> App {
+		let mut app = App::new().single_threaded(Update);
+
+		app.add_plugins((
+			MinimalPlugins,
+			AssetPlugin::default(),
+			MeshPlugin,
+			ScenePlugin,
+			RapierPhysicsPlugin::<NoUserData>::default(),
+		));
+
+		app
+	}
+
+	#[test]
+	fn hit_object() -> Result<(), RunSystemError> {
+		let mut app = setup();
+		let entity = app
+			.world_mut()
+			.spawn((RigidBody::Fixed, Transform::default(), Collider::ball(0.5)))
+			.id();
+		app.update();
+
+		let hit = app.world_mut().run_system_once(|ray_caster: RayCaster| {
+			ray_caster.raycast(Ray3d::new(Vec3::Y, Dir3::NEG_Y), SolidObjects::default())
+		})?;
+
+		assert_eq!(
+			Some(RaycastHit {
+				entity,
+				time_of_impact: 0.5
+			}),
+			hit,
+		);
+		Ok(())
+	}
+
+	#[test]
+	fn ignore_sensor() -> Result<(), RunSystemError> {
+		let mut app = setup();
+		app.world_mut().spawn((
+			RigidBody::Fixed,
+			Transform::default(),
+			Collider::ball(0.5),
+			Sensor,
+		));
+		app.update();
+
+		let hit = app.world_mut().run_system_once(|ray_caster: RayCaster| {
+			ray_caster.raycast(Ray3d::new(Vec3::Y, Dir3::NEG_Y), SolidObjects::default())
+		})?;
+
+		assert_eq!(None, hit);
+		Ok(())
+	}
+
+	#[test]
+	fn ignore_object_rigid_body() -> Result<(), RunSystemError> {
+		let mut app = setup();
+		let entity = app
+			.world_mut()
+			.spawn((
+				RigidBody::Fixed,
+				Transform::default(),
+				children![(Transform::default(), Collider::ball(0.5))],
+			))
+			.id();
+		app.update();
+
+		let hit = app
+			.world_mut()
+			.run_system_once(move |ray_caster: RayCaster| {
+				ray_caster.raycast(
+					Ray3d::new(Vec3::Y, Dir3::NEG_Y),
+					SolidObjects {
+						exclude: vec![entity],
+					},
+				)
+			})?;
+
+		assert_eq!(None, hit);
+		Ok(())
+	}
+}


### PR DESCRIPTION
Adds a naive implementation to raycast to ground level. We currently only work on elevation zero. So we can defer to bevies built in intersection method.