### PR TITLE
Register animations from assets

### DIFF
--- a/assets/agents/player.agent
+++ b/assets/agents/player.agent
@@ -72,5 +72,129 @@
 		},
 		"gravity_interaction": "Affected",
 		"force_interaction": "Affected"
-	}
+	},
+	"animations": [
+		[
+			"Idle",
+			{
+				"path": {
+					"Single": "models/player.glb#Animation1"
+				},
+				"play_mode": "Repeat",
+				"mask": "11111",
+				"bones": {
+					"from_root": "metarig",
+					"until_exclusive": [
+						"top_shoulder.L",
+						"top_shoulder.R",
+						"bottom_shoulder.L",
+						"bottom_shoulder.R"
+					]
+				}
+			}
+		],
+		[
+			"Walk",
+			{
+				"path": {
+					"Single": "models/player.glb#Animation2"
+				},
+				"play_mode": "Repeat",
+				"mask": "11111",
+				"bones": {
+					"from_root": "metarig",
+					"until_exclusive": [
+						"top_shoulder.L",
+						"top_shoulder.R",
+						"bottom_shoulder.L",
+						"bottom_shoulder.R"
+					]
+				}
+			}
+		],
+		[
+			"Run",
+			{
+				"path": {
+					"Directional": {
+						"forward": "models/player.glb#Animation3",
+						"backward": "models/player.glb#Animation4",
+						"right": "models/player.glb#Animation5",
+						"left": "models/player.glb#Animation6"
+					}
+				},
+				"play_mode": "Repeat",
+				"mask": "11111",
+				"bones": {
+					"from_root": "metarig",
+					"until_exclusive": [
+						"top_shoulder.L",
+						"top_shoulder.R",
+						"bottom_shoulder.L",
+						"bottom_shoulder.R"
+					]
+				}
+			}
+		],
+		[
+			{
+				"Skill": 0
+			},
+			{
+				"path": {
+					"Single": "models/player.glb#Animation9"
+				},
+				"play_mode": "Repeat",
+				"mask": "00010",
+				"bones": {
+					"from_root": "top_shoulder.L"
+				}
+			}
+		],
+		[
+			{
+				"Skill": 1
+			},
+			{
+				"path": {
+					"Single": "models/player.glb#Animation7"
+				},
+				"play_mode": "Repeat",
+				"mask": "00100",
+				"bones": {
+					"from_root": "bottom_shoulder.L"
+				}
+			}
+		],
+		[
+			{
+				"Skill": 2
+			},
+			{
+				"path": {
+					"Single": "models/player.glb#Animation8"
+				},
+				"play_mode": "Repeat",
+				"mask": "01000",
+				"bones": {
+					"from_root": "bottom_shoulder.R"
+				}
+			}
+		],
+		[
+			{
+				"Skill": 3
+			},
+			{
+				"path": {
+					"Single": "models/player.glb#Animation10"
+				},
+				"play_mode": "Repeat",
+				"mask": "10000",
+				"bones": {
+					"from_root": "top_shoulder.R"
+				}
+			}
+		]
+	]
 }

--- a/assets/agents/void_sphere.agent
+++ b/assets/agents/void_sphere.agent
@@ -18,5 +18,6 @@
 		},
 		"gravity_interaction": "Affected",
 		"force_interaction": "Affected"
-	}
+	},
+	"animations": []
 }

--- a/src/plugins/agents/src/assets/agent_config.rs
+++ b/src/plugins/agents/src/assets/agent_config.rs
@@ -7,6 +7,7 @@ use common::{
 	tools::{action_key::slot::SlotKey, path::Path},
 	traits::{
 		accessors::get::GetProperty,
+		animation::{Animation2, AnimationKey},
 		bone_key::{BoneKey, ConfiguredBones},
 		handles_custom_assets::AssetFolderPath,
 		handles_map_generation::AgentType,
@@ -26,6 +27,7 @@ pub struct AgentConfigAsset {
 	pub(crate) bones: Bones,
 	pub(crate) agent_model: AgentModel,
 	pub(crate) attributes: PhysicalDefaultAttributes,
+	pub(crate) animations: HashMap<AnimationKey, Animation2>,
 }
 
 impl AssetFolderPath for AgentConfigAsset {

--- a/src/plugins/agents/src/assets/agent_config/dto.rs
+++ b/src/plugins/agents/src/assets/agent_config/dto.rs
@@ -5,17 +5,22 @@ use crate::{
 use common::{
 	errors::Unreachable,
 	traits::{
+		animation::{Animation2, AnimationKey},
 		handles_custom_assets::{AssetFileExtensions, TryLoadFrom},
 		handles_physics::PhysicalDefaultAttributes,
 	},
 };
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use zyheeda_core::serialization::as_vec;
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct AgentConfigAssetDto {
 	pub(crate) model: Model,
 	pub(crate) loadout: Loadout,
 	pub(crate) attributes: PhysicalDefaultAttributes,
+	#[serde(with = "as_vec")]
+	pub(crate) animations: HashMap<AnimationKey, Animation2>,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -56,6 +61,7 @@ impl TryLoadFrom<AgentConfigAssetDto> for AgentConfigAsset {
 			model,
 			loadout,
 			attributes,
+			animations,
 		}: AgentConfigAssetDto,
 		_: &mut TLoadAsset,
 	) -> Result<Self, Self::TInstantiationError> {
@@ -66,6 +72,7 @@ impl TryLoadFrom<AgentConfigAssetDto> for AgentConfigAsset {
 			bones,
 			agent_model,
 			attributes,
+			animations,
 		})
 	}
 }

--- a/src/plugins/agents/src/lib.rs
+++ b/src/plugins/agents/src/lib.rs
@@ -21,7 +21,7 @@ use common::{
 	states::game_state::{GameState, LoadingEssentialAssets},
 	tools::action_key::slot::{NoValidAgentKey, PlayerSlot, SlotKey},
 	traits::{
-		animation::RegisterAnimations,
+		animation::{AnimationsParamMut, HandlesAnimations, RegisterAnimations},
 		delta::Delta,
 		handles_agents::HandlesAgents,
 		handles_custom_assets::HandlesCustomFolderAssets,
@@ -61,7 +61,7 @@ where
 	TInput: ThreadSafe + SystemSetDefinition + HandlesInput,
 	TSaveGame: ThreadSafe + HandlesSaving,
 	TPhysics: ThreadSafe + HandlesPhysicalAttributes + HandlesRaycast,
-	TAnimations: ThreadSafe + RegisterAnimations,
+	TAnimations: ThreadSafe + RegisterAnimations + HandlesAnimations,
 	TLights: ThreadSafe + HandlesLights,
 	TMaps: ThreadSafe + HandlesMapGeneration,
 	TBehaviors: ThreadSafe + HandlesMovement + HandlesOrientation + HandlesSkillControl,
@@ -97,7 +97,7 @@ where
 	TInput: ThreadSafe + SystemSetDefinition + HandlesInput,
 	TSaveGame: ThreadSafe + HandlesSaving,
 	TPhysics: ThreadSafe + HandlesPhysicalAttributes + HandlesRaycast,
-	TAnimations: ThreadSafe + RegisterAnimations,
+	TAnimations: ThreadSafe + RegisterAnimations + HandlesAnimations,
 	TLights: ThreadSafe + HandlesLights,
 	TMaps: ThreadSafe + HandlesMapGeneration,
 	TBehaviors: ThreadSafe + HandlesMovement + HandlesOrientation + HandlesSkillControl,
@@ -120,6 +120,7 @@ where
 			Update,
 			(
 				Agent::insert_model,
+				Agent::register_animations::<AnimationsParamMut<TAnimations>>,
 				Agent::<AgentConfigAsset>::insert_attributes::<TPhysics::TDefaultAttributes>,
 			),
 		);

--- a/src/plugins/agents/src/observers/agent.rs
+++ b/src/plugins/agents/src/observers/agent.rs
@@ -1,4 +1,5 @@
 pub(crate) mod insert_concrete_agent;
 pub(crate) mod insert_from;
+pub(crate) mod register_animations;
 pub(crate) mod register_skill_spawn_points;
 pub(crate) mod tag;

--- a/src/plugins/agents/src/observers/agent/register_animations.rs
+++ b/src/plugins/agents/src/observers/agent/register_animations.rs
@@ -1,0 +1,193 @@
+use crate::{assets::agent_config::AgentConfigAsset, components::agent::Agent};
+use bevy::{ecs::system::StaticSystemParam, prelude::*};
+use common::{
+	traits::{
+		accessors::get::{GetContextMut, TryApplyOn},
+		animation::{Animations, RegisterAnimations2},
+	},
+	zyheeda_commands::ZyheedaCommands,
+};
+
+impl Agent {
+	pub(crate) fn register_animations<TAnimations>(
+		mut commands: ZyheedaCommands,
+		mut animations: StaticSystemParam<TAnimations>,
+		agents: Query<(Entity, &Self), Without<marker::AnimationsRegistered>>,
+		configs: Res<Assets<AgentConfigAsset>>,
+	) where
+		TAnimations: for<'c> GetContextMut<Animations, TContext<'c>: RegisterAnimations2>,
+	{
+		for (entity, Self { config_handle, .. }) in agents {
+			let key = Animations { entity };
+
+			let Some(config) = configs.get(config_handle) else {
+				continue;
+			};
+			let Some(mut ctx) = TAnimations::get_context_mut(&mut animations, key) else {
+				continue;
+			};
+
+			commands.try_apply_on(&entity, |mut e| {
+				ctx.register_animations(&config.animations);
+				e.try_insert(marker::AnimationsRegistered);
+			});
+		}
+	}
+}
+
+mod marker {
+	use super::*;
+
+	#[derive(Component)]
+	pub struct AnimationsRegistered;
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::assets::agent_config::AgentConfigAsset;
+	use common::{
+		tools::path::Path,
+		traits::{
+			animation::{
+				AffectedAnimationBones2,
+				Animation2,
+				AnimationKey,
+				AnimationPath,
+				PlayMode,
+			},
+			handles_map_generation::AgentType,
+		},
+	};
+	use macros::NestedMocks;
+	use mockall::{automock, predicate::eq};
+	use std::collections::HashMap;
+	use testing::{NestedMocks, SingleThreadedApp, new_handle};
+
+	#[derive(Component, NestedMocks)]
+	struct _Component {
+		mock: Mock_Component,
+	}
+
+	#[automock]
+	impl RegisterAnimations2 for _Component {
+		fn register_animations(&mut self, animations: &HashMap<AnimationKey, Animation2>) {
+			self.mock.register_animations(animations);
+		}
+	}
+
+	fn setup<const N: usize>(configs: [(&Handle<AgentConfigAsset>, AgentConfigAsset); N]) -> App {
+		let mut app = App::new().single_threaded(Update);
+		let mut config_assets = Assets::default();
+
+		for (id, asset) in configs {
+			config_assets.insert(id, asset);
+		}
+
+		app.insert_resource(config_assets);
+		app.add_systems(Update, Agent::register_animations::<Query<Mut<_Component>>>);
+
+		app
+	}
+
+	#[test]
+	fn set_animations_from_config() {
+		let animations = HashMap::from([(
+			AnimationKey::Run,
+			Animation2 {
+				bones: AffectedAnimationBones2::default(),
+				path: AnimationPath::Single(Path::from("my/path")),
+				play_mode: PlayMode::Replay,
+				mask: 1 << 42,
+			},
+		)]);
+		let handle = new_handle();
+		let asset = AgentConfigAsset {
+			animations: animations.clone(),
+			..default()
+		};
+		let mut app = setup([(&handle, asset)]);
+		app.world_mut().spawn((
+			Agent {
+				agent_type: AgentType::Player,
+				config_handle: handle,
+			},
+			_Component::new().with_mock(move |mock| {
+				mock.expect_register_animations()
+					.times(1)
+					.with(eq(animations.clone()))
+					.return_const(());
+			}),
+		));
+
+		app.update();
+	}
+
+	#[test]
+	fn act_only_once() {
+		let animations = HashMap::from([(
+			AnimationKey::Run,
+			Animation2 {
+				bones: AffectedAnimationBones2::default(),
+				path: AnimationPath::Single(Path::from("my/path")),
+				play_mode: PlayMode::Replay,
+				mask: 1 << 42,
+			},
+		)]);
+		let handle = new_handle();
+		let asset = AgentConfigAsset {
+			animations: animations.clone(),
+			..default()
+		};
+		let mut app = setup([(&handle, asset)]);
+		app.world_mut().spawn((
+			Agent {
+				agent_type: AgentType::Player,
+				config_handle: handle,
+			},
+			_Component::new().with_mock(move |mock| {
+				mock.expect_register_animations().times(1).return_const(());
+			}),
+		));
+
+		app.update();
+		app.update();
+	}
+
+	#[test]
+	fn set_animations_from_config_when_config_is_late() {
+		let animations = HashMap::from([(
+			AnimationKey::Run,
+			Animation2 {
+				bones: AffectedAnimationBones2::default(),
+				path: AnimationPath::Single(Path::from("my/path")),
+				play_mode: PlayMode::Replay,
+				mask: 1 << 42,
+			},
+		)]);
+		let handle = new_handle();
+		let asset = AgentConfigAsset {
+			animations: animations.clone(),
+			..default()
+		};
+		let mut app = setup([]);
+		app.world_mut().spawn((
+			Agent {
+				agent_type: AgentType::Player,
+				config_handle: handle.clone(),
+			},
+			_Component::new().with_mock(move |mock| {
+				mock.expect_register_animations()
+					.times(1)
+					.with(eq(animations.clone()))
+					.return_const(());
+			}),
+		));
+
+		app.update();
+		app.world_mut()
+			.resource_mut::<Assets<AgentConfigAsset>>()
+			.insert(&handle, asset);
+		app.update();
+	}
+}

--- a/src/plugins/common/src/traits/animation.rs
+++ b/src/plugins/common/src/traits/animation.rs
@@ -15,6 +15,7 @@ use bevy::{
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Error};
 use std::{
 	collections::{HashMap, HashSet},
+	ops::DerefMut,
 	sync::Arc,
 };
 
@@ -29,10 +30,25 @@ pub struct Animations {
 	pub entity: Entity,
 }
 
+impl From<Animations> for Entity {
+	fn from(Animations { entity }: Animations) -> Self {
+		entity
+	}
+}
+
 pub type AnimationsParamMut<'w, 's, T> = <T as HandlesAnimations>::TAnimationsMut<'w, 's>;
 
 pub trait RegisterAnimations2 {
-	fn register_animations(&mut self, animations: HashMap<AnimationKey, Animation2>);
+	fn register_animations(&mut self, animations: &HashMap<AnimationKey, Animation2>);
+}
+
+impl<T> RegisterAnimations2 for T
+where
+	T: DerefMut<Target: RegisterAnimations2>,
+{
+	fn register_animations(&mut self, animations: &HashMap<AnimationKey, Animation2>) {
+		self.deref_mut().register_animations(animations);
+	}
 }
 
 pub trait OverrideAnimations {
@@ -180,6 +196,7 @@ pub struct Animation2 {
 #[derive(Debug, PartialEq, Default, Clone, Serialize, Deserialize)]
 pub struct AffectedAnimationBones2 {
 	pub from_root: BoneName,
+	#[serde(default)]
 	pub until_exclusive: HashSet<BoneName>,
 }
 


### PR DESCRIPTION
Part of the move to the new animations interface:
- Agent animations configured via agent config assets
- Register agent animations for a given entity when agent added or agent config asset becomes available (whatever happens last, as we need both)
- Animations register trait takes a reference to the animations map, so that implementations can decide themselves what to clone/copy