### PR TITLE
Add non mutable movement system param

### DIFF
--- a/src/plugins/behaviors/src/components/movement.rs
+++ b/src/plugins/behaviors/src/components/movement.rs
@@ -24,7 +24,7 @@ use std::marker::PhantomData;
 #[derive(Component, SavableComponent, Debug)]
 #[require(GlobalTransform)]
 #[savable_component(dto = MovementDto<TMotion>)]
-pub(crate) struct Movement<TMotion>
+pub struct Movement<TMotion>
 where
 	TMotion: ThreadSafe,
 {

--- a/src/plugins/behaviors/src/components/movement/path_or_direction.rs
+++ b/src/plugins/behaviors/src/components/movement/path_or_direction.rs
@@ -9,7 +9,7 @@ use common::{
 use std::{collections::VecDeque, marker::PhantomData};
 
 #[derive(Component, Debug, PartialEq)]
-pub(crate) struct PathOrDirection<TMotion> {
+pub struct PathOrDirection<TMotion> {
 	pub(crate) mode: Mode,
 	pub(crate) _m: PhantomData<TMotion>,
 }

--- a/src/plugins/behaviors/src/lib.rs
+++ b/src/plugins/behaviors/src/lib.rs
@@ -12,7 +12,7 @@ use crate::{
 	},
 	system_param::{
 		face_param::FaceParamMut,
-		movement_param::MovementParamMut,
+		movement_param::{MovementParam, MovementParamMut, context_changed::JustRemovedMovements},
 		skill_param::SkillParamMut,
 	},
 };
@@ -125,6 +125,8 @@ where
 		>;
 
 		app
+			// Resources
+			.init_resource::<JustRemovedMovements>()
 			// Required components
 			.register_required_components::<SkillContact, TSaveGame::TSaveEntityMarker>()
 			.register_required_components::<SkillProjection, TSaveGame::TSaveEntityMarker>()
@@ -161,6 +163,7 @@ where
 						SetFace::get_faces.pipe(execute_face::<RaycastSystemParam<TPhysics>>),
 					)
 						.chain(),
+					MovementParam::<TPhysics::TMotion>::update_just_removed,
 				)
 					.chain()
 					.in_set(BehaviorSystems)
@@ -223,6 +226,7 @@ impl<TInput, TSaveGame, TAnimations, TPhysics, TPathFinding> HandlesMovement
 where
 	TPhysics: HandlesMotion,
 {
+	type TMovement<'w, 's> = MovementParam<'w, 's, TPhysics::TMotion>;
 	type TMovementMut<'w, 's> = MovementParamMut<'w, 's, TPhysics::TMotion>;
 }
 

--- a/src/plugins/behaviors/src/system_param/movement_param.rs
+++ b/src/plugins/behaviors/src/system_param/movement_param.rs
@@ -1,21 +1,54 @@
+pub(crate) mod context_changed;
 mod current_movement;
 mod start_movement;
 mod stop_movement;
 mod update_movement;
 
-use crate::components::{
-	movement::{Movement, path_or_direction::PathOrDirection},
-	movement_definition::MovementDefinition,
+use crate::{
+	components::{
+		movement::{Movement, path_or_direction::PathOrDirection},
+		movement_definition::MovementDefinition,
+	},
+	system_param::movement_param::context_changed::JustRemovedMovements,
 };
 use bevy::{ecs::system::SystemParam, prelude::*};
 use common::{
 	traits::{
-		accessors::get::{GetContextMut, GetMut},
+		accessors::get::{GetContext, GetContextMut, GetMut},
 		handles_movement::Movement as MovementMarker,
 		thread_safe::ThreadSafe,
 	},
 	zyheeda_commands::{ZyheedaCommands, ZyheedaEntityCommands},
 };
+
+#[derive(SystemParam)]
+pub struct MovementParam<'w, 's, TMotion>
+where
+	TMotion: ThreadSafe,
+{
+	movements: Query<'w, 's, Ref<'static, Movement<PathOrDirection<TMotion>>>>,
+	just_removed_movements: Res<'w, JustRemovedMovements>,
+}
+
+impl<TMotion> GetContext<MovementMarker> for MovementParam<'_, '_, TMotion>
+where
+	TMotion: ThreadSafe,
+{
+	type TContext<'ctx> = MovementContext<'ctx, TMotion>;
+
+	fn get_context<'ctx>(
+		param: &'ctx MovementParam<TMotion>,
+		MovementMarker { entity }: MovementMarker,
+	) -> Option<Self::TContext<'ctx>> {
+		let ctx = match param.movements.get(entity) {
+			Ok(movement) => MovementContext::Movement(movement),
+			_ if param.just_removed_movements.0.contains(&entity) => MovementContext::JustRemoved,
+			_ => MovementContext::Empty,
+		};
+
+		Some(ctx)
+	}
+}
 
 #[derive(SystemParam)]
 pub struct MovementParamMut<'w, 's, TMotion>
@@ -47,6 +80,15 @@ where
 			movement,
 		})
 	}
+}
+
+pub enum MovementContext<'ctx, TMotion>
+where
+	TMotion: ThreadSafe,
+{
+	Movement(Ref<'ctx, Movement<PathOrDirection<TMotion>>>),
+	JustRemoved,
+	Empty,
 }
 
 pub struct MovementContextMut<'ctx, TMotion>

--- a/src/plugins/behaviors/src/system_param/movement_param/context_changed.rs
+++ b/src/plugins/behaviors/src/system_param/movement_param/context_changed.rs
@@ -1,0 +1,191 @@
+use crate::{
+	components::movement::{Movement, path_or_direction::PathOrDirection},
+	system_param::movement_param::{MovementContext, MovementParam},
+};
+use bevy::prelude::*;
+use common::traits::{accessors::get::ContextChanged, thread_safe::ThreadSafe};
+use std::collections::HashSet;
+
+impl<TMotion> ContextChanged for MovementContext<'_, TMotion>
+where
+	TMotion: ThreadSafe,
+{
+	fn context_changed(&self) -> bool {
+		match self {
+			MovementContext::Movement(movement) => movement.is_changed(),
+			MovementContext::JustRemoved => true,
+			MovementContext::Empty => false,
+		}
+	}
+}
+
+impl<TMotion> MovementParam<'_, '_, TMotion>
+where
+	TMotion: ThreadSafe,
+{
+	pub(crate) fn update_just_removed(
+		mut just_removed: ResMut<JustRemovedMovements>,
+		mut removed: RemovedComponents<Movement<PathOrDirection<TMotion>>>,
+	) {
+		if !just_removed.0.is_empty() {
+			just_removed.0.clear();
+		}
+
+		for entity in removed.read() {
+			just_removed.0.insert(entity);
+		}
+	}
+}
+
+#[derive(Resource, Default)]
+pub(crate) struct JustRemovedMovements(pub(crate) HashSet<Entity>);
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::{
+		components::movement::{Movement, path_or_direction::PathOrDirection},
+		system_param::movement_param::MovementParam,
+	};
+	use common::traits::{
+		accessors::get::GetContext,
+		handles_movement::Movement as MovementMarker,
+	};
+	use testing::SingleThreadedApp;
+
+	struct _Motion;
+
+	#[derive(Component, Debug, PartialEq)]
+	struct _ContextChanged(bool);
+
+	fn setup() -> App {
+		let mut app = App::new().single_threaded(Update);
+
+		app.init_resource::<JustRemovedMovements>().add_systems(
+			Update,
+			(
+				MovementParam::<_Motion>::update_just_removed,
+				|mut commands: Commands, m: MovementParam<_Motion>, entities: Query<Entity>| {
+					for entity in &entities {
+						let key = MovementMarker { entity };
+						let Some(ctx) = MovementParam::get_context(&m, key) else {
+							continue;
+						};
+
+						commands
+							.entity(entity)
+							.try_insert(_ContextChanged(ctx.context_changed()));
+					}
+				},
+			)
+				.chain(),
+		);
+
+		app
+	}
+
+	#[test]
+	fn is_changed_when_movement_added() {
+		let mut app = setup();
+		let entity = app
+			.world_mut()
+			.spawn(Movement::<PathOrDirection<_Motion>>::to(Vec3::new(
+				1., 2., 3.,
+			)))
+			.id();
+
+		app.update();
+
+		assert_eq!(
+			Some(&_ContextChanged(true)),
+			app.world().entity(entity).get::<_ContextChanged>()
+		);
+	}
+
+	#[test]
+	fn is_not_changed_when_movement_not_added() {
+		let mut app = setup();
+		let entity = app
+			.world_mut()
+			.spawn(Movement::<PathOrDirection<_Motion>>::to(Vec3::new(
+				1., 2., 3.,
+			)))
+			.id();
+
+		app.update();
+		app.update();
+
+		assert_eq!(
+			Some(&_ContextChanged(false)),
+			app.world().entity(entity).get::<_ContextChanged>()
+		);
+	}
+
+	#[test]
+	fn is_changed_when_movement_changed() {
+		let mut app = setup();
+		let entity = app
+			.world_mut()
+			.spawn(Movement::<PathOrDirection<_Motion>>::to(Vec3::new(
+				1., 2., 3.,
+			)))
+			.id();
+
+		app.update();
+		app.world_mut()
+			.entity_mut(entity)
+			.get_mut::<Movement<PathOrDirection<_Motion>>>()
+			.as_deref_mut();
+		app.update();
+
+		assert_eq!(
+			Some(&_ContextChanged(true)),
+			app.world().entity(entity).get::<_ContextChanged>()
+		);
+	}
+
+	#[test]
+	fn is_changed_when_movement_just_removed() {
+		let mut app = setup();
+		let entity = app
+			.world_mut()
+			.spawn(Movement::<PathOrDirection<_Motion>>::to(Vec3::new(
+				1., 2., 3.,
+			)))
+			.id();
+
+		app.update();
+		app.world_mut()
+			.entity_mut(entity)
+			.remove::<Movement<PathOrDirection<_Motion>>>();
+		app.update();
+
+		assert_eq!(
+			Some(&_ContextChanged(true)),
+			app.world().entity(entity).get::<_ContextChanged>()
+		);
+	}
+
+	#[test]
+	fn is_not_changed_when_movement_not_just_removed() {
+		let mut app = setup();
+		let entity = app
+			.world_mut()
+			.spawn(Movement::<PathOrDirection<_Motion>>::to(Vec3::new(
+				1., 2., 3.,
+			)))
+			.id();
+
+		app.update();
+		app.world_mut()
+			.entity_mut(entity)
+			.remove::<Movement<PathOrDirection<_Motion>>>();
+		app.update();
+		app.update();
+
+		assert_eq!(
+			Some(&_ContextChanged(false)),
+			app.world().entity(entity).get::<_ContextChanged>()
+		);
+	}
+}

--- a/src/plugins/common/src/traits/handles_movement.rs
+++ b/src/plugins/common/src/traits/handles_movement.rs
@@ -1,16 +1,22 @@
 use crate::{
 	tools::{Units, UnitsPerSecond},
-	traits::{accessors::get::GetContextMut, animation::Animation},
+	traits::{
+		accessors::get::{GetContext, GetContextMut},
+		animation::Animation,
+	},
 };
 use bevy::{ecs::system::SystemParam, prelude::*};
 use serde::{Deserialize, Serialize};
 use std::ops::{Deref, DerefMut};
 
 pub trait HandlesMovement {
+	type TMovement<'w, 's>: SystemParam
+		+ for<'c> GetContext<Movement, TContext<'c>: CurrentMovement>;
 	type TMovementMut<'w, 's>: SystemParam
 		+ for<'c> GetContextMut<Movement, TContext<'c>: ControlMovement>;
 }
 
+pub type MovementSystemParam<'w, 's, T> = <T as HandlesMovement>::TMovement<'w, 's>;
 pub type MovementSystemParamMut<'w, 's, T> = <T as HandlesMovement>::TMovementMut<'w, 's>;
 
 pub trait ControlMovement: StartMovement + UpdateMovement + StopMovement + CurrentMovement {}


### PR DESCRIPTION
Add system param in `HandlesMovement` to allow non mutable access, should some plugin wish to inspect the current movement without wanting to do mutations. 