### PR TITLE
animate idle

### DIFF
--- a/src/plugins/agents/src/components.rs
+++ b/src/plugins/agents/src/components.rs
@@ -1,4 +1,5 @@
 pub(crate) mod agent;
+pub(crate) mod animate_idle;
 pub(crate) mod enemy;
 pub(crate) mod movement_config;
 pub(crate) mod player;

--- a/src/plugins/agents/src/components/agent.rs
+++ b/src/plugins/agents/src/components/agent.rs
@@ -2,7 +2,7 @@ pub(crate) mod tag;
 
 use crate::{
 	assets::agent_config::{AgentConfigAsset, AgentConfigData},
-	components::{enemy::void_sphere::VoidSphere, player::Player},
+	components::{animate_idle::AnimateIdle, enemy::void_sphere::VoidSphere, player::Player},
 	observers::agent::{insert_concrete_agent::InsertEnemyOrPlayer, insert_from::AgentHandle},
 };
 use bevy::prelude::*;
@@ -33,6 +33,7 @@ use macros::{SavableComponent, agent_asset};
 	RigidBody = RigidBody::Dynamic,
 	GravityScale = GravityScale(0.),
 	IsBlocker = [Blocker::Character],
+	AnimateIdle,
 )]
 pub struct Agent<TAsset = AgentConfigAsset>
 where

--- a/src/plugins/agents/src/components/animate_idle.rs
+++ b/src/plugins/agents/src/components/animate_idle.rs
@@ -1,0 +1,4 @@
+use bevy::prelude::*;
+
+#[derive(Component, Debug, PartialEq, Default)]
+pub(crate) struct AnimateIdle;

--- a/src/plugins/agents/src/lib.rs
+++ b/src/plugins/agents/src/lib.rs
@@ -7,6 +7,7 @@ use crate::{
 	assets::agent_config::{AgentConfigAsset, AgentConfigData, dto::AgentConfigAssetDto},
 	components::{
 		agent::{Agent, tag::AgentTag},
+		animate_idle::AnimateIdle,
 		enemy::{Enemy, attack_phase::EnemyAttackPhase, void_sphere::VoidSphere},
 		movement_config::MovementConfig,
 		player::Player,
@@ -189,7 +190,9 @@ where
 					Update::delta.pipe(Enemy::advance_attack_phase),
 				)
 					.chain(),
+				AnimateIdle::execute::<AnimationsSystemParamMut<TAnimations>>,
 			)
+				.chain()
 				.run_if(in_state(GameState::Play))
 				.after(TInput::SYSTEMS),
 		);

--- a/src/plugins/agents/src/systems/agent.rs
+++ b/src/plugins/agents/src/systems/agent.rs
@@ -1,2 +1,3 @@
+pub(crate) mod animate_idle;
 pub(crate) mod insert_attributes;
 pub(crate) mod insert_model;

--- a/src/plugins/agents/src/systems/agent/animate_idle.rs
+++ b/src/plugins/agents/src/systems/agent/animate_idle.rs
@@ -1,0 +1,159 @@
+use crate::components::animate_idle::AnimateIdle;
+use bevy::{ecs::system::StaticSystemParam, prelude::*};
+use common::{
+	traits::{
+		accessors::get::{GetContextMut, TryApplyOn},
+		animation::{ActiveAnimationsMut, AnimationKey, AnimationPriority, Animations},
+	},
+	zyheeda_commands::ZyheedaCommands,
+};
+use std::collections::HashSet;
+
+impl AnimateIdle {
+	pub(crate) fn execute<TAnimations>(
+		mut commands: ZyheedaCommands,
+		mut animations: StaticSystemParam<TAnimations>,
+		idlers: Query<Entity, With<Self>>,
+	) where
+		TAnimations: for<'c> GetContextMut<Animations, TContext<'c>: ActiveAnimationsMut>,
+	{
+		for entity in &idlers {
+			let key = Animations { entity };
+			let Some(mut animations) = TAnimations::get_context_mut(&mut animations, key) else {
+				continue;
+			};
+			let Ok(movement_animations) = animations.active_animations_mut(Idle) else {
+				continue;
+			};
+
+			*movement_animations = HashSet::from([AnimationKey::Idle]);
+			commands.try_apply_on(&entity, |mut e| {
+				e.try_remove::<Self>();
+			});
+		}
+	}
+}
+
+struct Idle;
+
+impl From<Idle> for AnimationPriority {
+	fn from(_: Idle) -> Self {
+		Self::Low
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use crate::systems::player::animate_movement::tests::_Animations;
+	use common::traits::animation::AnimationKey;
+	use std::collections::{HashMap, HashSet};
+	use testing::SingleThreadedApp;
+
+	fn setup() -> App {
+		let mut app = App::new().single_threaded(Update);
+
+		app.add_systems(Update, AnimateIdle::execute::<Query<&mut _Animations>>);
+
+		app
+	}
+
+	#[test]
+	fn animate_idle() {
+		let mut app = setup();
+		let entity = app
+			.world_mut()
+			.spawn((AnimateIdle, _Animations::default()))
+			.id();
+
+		app.update();
+
+		assert_eq!(
+			Some(&_Animations::Prepared(HashMap::from([(
+				Idle.into(),
+				HashSet::from([AnimationKey::Idle])
+			)]))),
+			app.world().entity(entity).get::<_Animations>()
+		);
+	}
+
+	#[test]
+	fn override_other_idle_animations() {
+		let mut app = setup();
+		let entity = app
+			.world_mut()
+			.spawn((
+				AnimateIdle,
+				_Animations::Prepared(HashMap::from([(
+					Idle.into(),
+					HashSet::from([AnimationKey::Walk]),
+				)])),
+			))
+			.id();
+
+		app.update();
+
+		assert_eq!(
+			Some(&_Animations::Prepared(HashMap::from([(
+				Idle.into(),
+				HashSet::from([AnimationKey::Idle])
+			)]))),
+			app.world().entity(entity).get::<_Animations>()
+		);
+	}
+
+	#[test]
+	fn do_nothing_if_animate_idle_missing() {
+		let mut app = setup();
+		let entity = app.world_mut().spawn(_Animations::default()).id();
+
+		app.update();
+
+		assert_eq!(
+			Some(&_Animations::default()),
+			app.world().entity(entity).get::<_Animations>()
+		);
+	}
+
+	#[test]
+	fn remove_animate_idle_component() {
+		let mut app = setup();
+		let entity = app
+			.world_mut()
+			.spawn((AnimateIdle, _Animations::default()))
+			.id();
+
+		app.update();
+
+		assert_eq!(None, app.world().entity(entity).get::<AnimateIdle>());
+	}
+
+	#[test]
+	fn do_not_remove_animate_idle_component_when_animations_for_entity_are_missing() {
+		let mut app = setup();
+		let entity = app.world_mut().spawn(AnimateIdle).id();
+
+		app.update();
+
+		assert_eq!(
+			Some(&AnimateIdle),
+			app.world().entity(entity).get::<AnimateIdle>(),
+		);
+	}
+
+	#[test]
+	fn do_not_remove_animate_idle_component_when_animations_unprepared() {
+		let mut app = setup();
+		let entity = app.world_mut().spawn(AnimateIdle).id();
+		app.world_mut()
+			.entity_mut(entity)
+			.insert(_Animations::Unprepared(entity));
+
+		app.update();
+
+		assert_eq!(
+			Some(&AnimateIdle),
+			app.world().entity(entity).get::<AnimateIdle>(),
+		);
+	}
+}


### PR DESCRIPTION
Agents set idle animation on the lowest priority animation layer. This way, if any higher priority layer does not play any animation, we fallback to the idle animation.