### PR TITLE
make `ItemName` copy cheap via `Arc`

### DIFF
--- a/src/plugins/common/src/traits/loadout.rs
+++ b/src/plugins/common/src/traits/loadout.rs
@@ -1,5 +1,6 @@
 use crate::tools::action_key::slot::SlotKey;
 use serde::{Deserialize, Serialize};
+use std::{fmt::Display, ops::Deref, sync::Arc};
 
 pub trait LoadoutConfig {
 	fn inventory(&self) -> impl Iterator<Item = Option<ItemName>>;
@@ -7,13 +8,30 @@ pub trait LoadoutConfig {
 }
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-pub struct ItemName(pub String);
+pub struct ItemName(Arc<str>);
 
-impl<T> From<T> for ItemName
-where
-	T: Into<String>,
-{
-	fn from(name: T) -> Self {
-		Self(name.into())
+impl From<String> for ItemName {
+	fn from(name: String) -> Self {
+		Self(Arc::from(name))
+	}
+}
+
+impl From<&str> for ItemName {
+	fn from(name: &str) -> Self {
+		Self(Arc::from(name))
+	}
+}
+
+impl Deref for ItemName {
+	type Target = str;
+
+	fn deref(&self) -> &Self::Target {
+		&self.0
+	}
+}
+
+impl Display for ItemName {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		write!(f, "{}", self.0)
 	}
 }

--- a/src/plugins/skills/src/systems/insert_loadout.rs
+++ b/src/plugins/skills/src/systems/insert_loadout.rs
@@ -60,7 +60,7 @@ fn insert_internal<TAgent, TAssetServer>(
 	}
 }
 
-fn asset_path(ItemName(name): ItemName) -> AssetPath<'static> {
+fn asset_path(name: ItemName) -> AssetPath<'static> {
 	AssetPath::from(format!("items/{name}.item"))
 }
 


### PR DESCRIPTION
Allows passing around of copies of `ItemName` by storing the internal string as an `Arc`.