### PR TITLE
Use a dedicated loadout preparation system param

### DIFF
--- a/src/plugins/common/src/traits/handles_loadout.rs
+++ b/src/plugins/common/src/traits/handles_loadout.rs
@@ -27,6 +27,9 @@ use std::fmt::Debug;
 pub trait HandlesLoadout {
 	type TSkillID: Debug + PartialEq + Copy + ThreadSafe;
 
+	type TLoadoutPrep<'w, 's>: SystemParam
+		+ for<'c> GetContextMut<NotLoadedOut, TContext<'c>: InsertDefaultLoadout>;
+
 	type TLoadoutRead<'w, 's>: SystemParam
 		+ for<'c> GetContext<Items, TContext<'c>: ReadItems>
 		+ for<'c> GetContext<Skills, TContext<'c>: ReadSkills>
@@ -35,13 +38,13 @@ pub trait HandlesLoadout {
 
 	type TLoadoutMut<'w, 's>: SystemParam
 		+ for<'c> GetContextMut<Items, TContext<'c>: SwapItems>
-		+ for<'c> GetContextMut<Combos, TContext<'c>: UpdateCombos<Self::TSkillID>>
-		+ for<'c> GetContextMut<NotLoadedOut, TContext<'c>: InsertDefaultLoadout>;
+		+ for<'c> GetContextMut<Combos, TContext<'c>: UpdateCombos<Self::TSkillID>>;
 
 	type TLoadoutActivity<'w, 's>: SystemParam
 		+ for<'c> GetContext<Skills, TContext<'c>: ActiveSkills>;
 }
 
+pub type LoadoutPrepParam<'w, 's, T> = <T as HandlesLoadout>::TLoadoutPrep<'w, 's>;
 pub type LoadoutReadParam<'w, 's, T> = <T as HandlesLoadout>::TLoadoutRead<'w, 's>;
 pub type LoadoutMutParam<'w, 's, T> = <T as HandlesLoadout>::TLoadoutMut<'w, 's>;
 pub type LoadoutActivityParam<'w, 's, T> = <T as HandlesLoadout>::TLoadoutActivity<'w, 's>;

--- a/src/plugins/skills/src/lib.rs
+++ b/src/plugins/skills/src/lib.rs
@@ -18,7 +18,7 @@ use crate::{
 	},
 	skills::SkillId,
 	system_parameters::{
-		loadout::{LoadoutReader, LoadoutWriter},
+		loadout::{LoadoutPrep, LoadoutReader, LoadoutWriter},
 		loadout_activity::LoadoutActivity,
 	},
 	systems::enqueue::EnqueueSystem,
@@ -167,6 +167,7 @@ where
 
 impl<TDependencies> HandlesLoadout for SkillsPlugin<TDependencies> {
 	type TSkillID = SkillId;
+	type TLoadoutPrep<'w, 's> = LoadoutPrep<'w, 's>;
 	type TLoadoutRead<'w, 's> = LoadoutReader<'w, 's>;
 	type TLoadoutMut<'w, 's> = LoadoutWriter<'w, 's>;
 	type TLoadoutActivity<'w, 's> = LoadoutActivity<'w, 's>;

--- a/src/plugins/skills/src/system_parameters/loadout.rs
+++ b/src/plugins/skills/src/system_parameters/loadout.rs
@@ -24,14 +24,20 @@ type ReadComponents = (
 );
 
 #[derive(SystemParam)]
-pub struct LoadoutWriter<'w, 's, TAssetServer = AssetServer>
+pub struct LoadoutWriter<'w, 's> {
+	slots: Query<'w, 's, &'static mut Slots>,
+	inventories: Query<'w, 's, &'static mut Inventory>,
+	combos: Query<'w, 's, &'static mut Combos>,
+	skills: Res<'w, Assets<Skill>>,
+}
+
+#[derive(SystemParam)]
+pub struct LoadoutPrep<'w, 's, TAssetServer = AssetServer>
 where
 	TAssetServer: Resource + LoadAsset,
 {
 	commands: ZyheedaCommands<'w, 's>,
 	slots: Query<'w, 's, &'static mut Slots>,
 	inventories: Query<'w, 's, &'static mut Inventory>,
-	combos: Query<'w, 's, &'static mut Combos>,
-	skills: Res<'w, Assets<Skill>>,
 	asset_server: ResMut<'w, TAssetServer>,
 }

--- a/src/plugins/skills/src/system_parameters/loadout/write/insert_default_loadout.rs
+++ b/src/plugins/skills/src/system_parameters/loadout/write/insert_default_loadout.rs
@@ -1,6 +1,6 @@
 use crate::{
 	components::{inventory::Inventory, loadout::Loadout, slots::Slots},
-	system_parameters::loadout::LoadoutWriter,
+	system_parameters::loadout::LoadoutPrep,
 };
 use bevy::prelude::*;
 use common::{
@@ -58,14 +58,14 @@ where
 	server: &'ctx mut TAssetServer,
 }
 
-impl<TAssetServer> GetContextMut<NotLoadedOut> for LoadoutWriter<'_, '_, TAssetServer>
+impl<TAssetServer> GetContextMut<NotLoadedOut> for LoadoutPrep<'_, '_, TAssetServer>
 where
 	TAssetServer: Resource + LoadAsset,
 {
 	type TContext<'ctx> = PrepareLoadout<'ctx, TAssetServer>;
 
 	fn get_context_mut<'ctx>(
-		param: &'ctx mut LoadoutWriter<TAssetServer>,
+		param: &'ctx mut LoadoutPrep<TAssetServer>,
 		NotLoadedOut { entity }: NotLoadedOut,
 	) -> Option<Self::TContext<'ctx>> {
 		if param.inventories.contains(entity) && param.slots.contains(entity) {
@@ -124,9 +124,9 @@ mod tests {
 		let entity = app.world_mut().spawn_empty().id();
 
 		app.world_mut()
-			.run_system_once(move |mut loadout: LoadoutWriter<MockAssetServer>| {
+			.run_system_once(move |mut loadout: LoadoutPrep<MockAssetServer>| {
 				let key = NotLoadedOut { entity };
-				let mut ctx = LoadoutWriter::get_context_mut(&mut loadout, key).unwrap();
+				let mut ctx = LoadoutPrep::get_context_mut(&mut loadout, key).unwrap();
 				ctx.insert_default_loadout([
 					(LoadoutKey::from(InventoryKey(0)), ItemName::from("item_0")),
 					(LoadoutKey::from(InventoryKey(1)), ItemName::from("item_1")),
@@ -167,9 +167,9 @@ mod tests {
 		let entity = app.world_mut().spawn_empty().id();
 
 		app.world_mut()
-			.run_system_once(move |mut loadout: LoadoutWriter<MockAssetServer>| {
+			.run_system_once(move |mut loadout: LoadoutPrep<MockAssetServer>| {
 				let key = NotLoadedOut { entity };
-				let mut ctx = LoadoutWriter::get_context_mut(&mut loadout, key).unwrap();
+				let mut ctx = LoadoutPrep::get_context_mut(&mut loadout, key).unwrap();
 				ctx.insert_default_loadout([
 					(LoadoutKey::from(InventoryKey(3)), ItemName::from("item_0")),
 					(LoadoutKey::from(InventoryKey(1)), ItemName::from("item_1")),
@@ -196,11 +196,11 @@ mod tests {
 			.spawn((Slots::default(), Inventory::default()))
 			.id();
 
-		let ctx_is_none = app.world_mut().run_system_once(
-			move |mut loadout: LoadoutWriter<MockAssetServer>| {
-				LoadoutWriter::get_context_mut(&mut loadout, NotLoadedOut { entity }).is_none()
-			},
-		)?;
+		let ctx_is_none =
+			app.world_mut()
+				.run_system_once(move |mut loadout: LoadoutPrep<MockAssetServer>| {
+					LoadoutPrep::get_context_mut(&mut loadout, NotLoadedOut { entity }).is_none()
+				})?;
 
 		assert!(ctx_is_none);
 		Ok(())
@@ -237,9 +237,9 @@ mod tests {
 			.id();
 
 		app.world_mut()
-			.run_system_once(move |mut loadout: LoadoutWriter<MockAssetServer>| {
+			.run_system_once(move |mut loadout: LoadoutPrep<MockAssetServer>| {
 				let key = NotLoadedOut { entity };
-				let mut ctx = LoadoutWriter::get_context_mut(&mut loadout, key).unwrap();
+				let mut ctx = LoadoutPrep::get_context_mut(&mut loadout, key).unwrap();
 				ctx.insert_default_loadout([
 					(LoadoutKey::from(SlotKey(2)), ItemName::from("item_2")),
 					(LoadoutKey::from(SlotKey(3)), ItemName::from("item_3")),
@@ -294,9 +294,9 @@ mod tests {
 			.id();
 
 		app.world_mut()
-			.run_system_once(move |mut loadout: LoadoutWriter<MockAssetServer>| {
+			.run_system_once(move |mut loadout: LoadoutPrep<MockAssetServer>| {
 				let key = NotLoadedOut { entity };
-				let mut ctx = LoadoutWriter::get_context_mut(&mut loadout, key).unwrap();
+				let mut ctx = LoadoutPrep::get_context_mut(&mut loadout, key).unwrap();
 				ctx.insert_default_loadout([
 					(LoadoutKey::from(InventoryKey(2)), ItemName::from("item_2")),
 					(LoadoutKey::from(InventoryKey(3)), ItemName::from("item_3")),
@@ -326,9 +326,9 @@ mod tests {
 		let entity = app.world_mut().spawn_empty().id();
 
 		app.world_mut()
-			.run_system_once(move |mut loadout: LoadoutWriter<MockAssetServer>| {
+			.run_system_once(move |mut loadout: LoadoutPrep<MockAssetServer>| {
 				let key = NotLoadedOut { entity };
-				let mut ctx = LoadoutWriter::get_context_mut(&mut loadout, key).unwrap();
+				let mut ctx = LoadoutPrep::get_context_mut(&mut loadout, key).unwrap();
 				ctx.insert_default_loadout([]);
 			})?;
 

--- a/src/plugins/skills/src/system_parameters/loadout/write/items.rs
+++ b/src/plugins/skills/src/system_parameters/loadout/write/items.rs
@@ -11,18 +11,14 @@ use common::{
 			LoadoutKey,
 			items::{Items, SwapItems},
 		},
-		load_asset::LoadAsset,
 	},
 };
 
-impl<TAssetServer> GetContextMut<Items> for LoadoutWriter<'_, '_, TAssetServer>
-where
-	TAssetServer: Resource + LoadAsset,
-{
+impl GetContextMut<Items> for LoadoutWriter<'_, '_> {
 	type TContext<'ctx> = ItemsMut<'ctx>;
 
 	fn get_context_mut<'ctx>(
-		param: &'ctx mut LoadoutWriter<TAssetServer>,
+		param: &'ctx mut LoadoutWriter,
 		Items { entity }: Items,
 	) -> Option<Self::TContext<'ctx>> {
 		let slots = param.slots.get_mut(entity).ok()?;
@@ -89,7 +85,7 @@ mod tests {
 		skills::Skill,
 	};
 	use bevy::ecs::system::{RunSystemError, RunSystemOnce};
-	use common::{tools::action_key::slot::SlotKey, traits::load_asset::mock::MockAssetServer};
+	use common::tools::action_key::slot::SlotKey;
 	use std::ops::Deref;
 	use testing::{IsChanged, SingleThreadedApp, new_handle};
 
@@ -100,7 +96,6 @@ mod tests {
 		let mut app = App::new().single_threaded(Update);
 
 		app.init_resource::<Assets<Skill>>();
-		app.init_resource::<MockAssetServer>();
 		app.add_systems(
 			Update,
 			(IsChanged::<Slots>::detect, IsChanged::<Inventory>::detect).in_set(_ChangeDetection),
@@ -128,7 +123,7 @@ mod tests {
 				.id();
 
 			app.world_mut()
-				.run_system_once(move |mut loadout: LoadoutWriter<MockAssetServer>| {
+				.run_system_once(move |mut loadout: LoadoutWriter| {
 					let ctx =
 						LoadoutWriter::get_context_mut(&mut loadout, Items { entity }).unwrap();
 
@@ -163,7 +158,7 @@ mod tests {
 				.id();
 
 			app.world_mut()
-				.run_system_once(move |mut p: LoadoutWriter<MockAssetServer>| {
+				.run_system_once(move |mut p: LoadoutWriter| {
 					let mut ctx = LoadoutWriter::get_context_mut(&mut p, Items { entity }).unwrap();
 					ctx.swap_items(InventoryKey(0), InventoryKey(1));
 				})?;
@@ -194,7 +189,7 @@ mod tests {
 				.id();
 
 			app.world_mut()
-				.run_system_once(move |mut p: LoadoutWriter<MockAssetServer>| {
+				.run_system_once(move |mut p: LoadoutWriter| {
 					let mut ctx = LoadoutWriter::get_context_mut(&mut p, Items { entity }).unwrap();
 					ctx.swap_items(key_a, key_b);
 				})?;
@@ -225,7 +220,7 @@ mod tests {
 				.id();
 
 			app.world_mut()
-				.run_system_once(move |mut p: LoadoutWriter<MockAssetServer>| {
+				.run_system_once(move |mut p: LoadoutWriter| {
 					let mut ctx = LoadoutWriter::get_context_mut(&mut p, Items { entity }).unwrap();
 					ctx.swap_items(key_a, key_b);
 				})?;
@@ -256,7 +251,7 @@ mod tests {
 				.id();
 
 			app.world_mut()
-				.run_system_once(move |mut p: LoadoutWriter<MockAssetServer>| {
+				.run_system_once(move |mut p: LoadoutWriter| {
 					let mut ctx = LoadoutWriter::get_context_mut(&mut p, Items { entity }).unwrap();
 					ctx.swap_items(key_a, key_b);
 				})?;
@@ -286,7 +281,7 @@ mod tests {
 				.id();
 
 			app.world_mut()
-				.run_system_once(move |mut p: LoadoutWriter<MockAssetServer>| {
+				.run_system_once(move |mut p: LoadoutWriter| {
 					let mut ctx = LoadoutWriter::get_context_mut(&mut p, Items { entity }).unwrap();
 					ctx.swap_items(SlotKey(11), SlotKey(42));
 				})?;
@@ -316,7 +311,7 @@ mod tests {
 				.id();
 
 			app.world_mut()
-				.run_system_once(move |mut p: LoadoutWriter<MockAssetServer>| {
+				.run_system_once(move |mut p: LoadoutWriter| {
 					let mut ctx = LoadoutWriter::get_context_mut(&mut p, Items { entity }).unwrap();
 					ctx.swap_items(key_a, key_b);
 				})?;
@@ -350,7 +345,7 @@ mod tests {
 				.id();
 
 			app.world_mut()
-				.run_system_once(move |mut p: LoadoutWriter<MockAssetServer>| {
+				.run_system_once(move |mut p: LoadoutWriter| {
 					let mut ctx = LoadoutWriter::get_context_mut(&mut p, Items { entity }).unwrap();
 					ctx.swap_items(key_a, key_b);
 				})?;
@@ -386,7 +381,7 @@ mod tests {
 				.id();
 
 			app.world_mut()
-				.run_system_once(move |mut p: LoadoutWriter<MockAssetServer>| {
+				.run_system_once(move |mut p: LoadoutWriter| {
 					let mut ctx = LoadoutWriter::get_context_mut(&mut p, Items { entity }).unwrap();
 					ctx.swap_items(key_a, key_b);
 				})?;
@@ -422,7 +417,7 @@ mod tests {
 				.id();
 
 			app.world_mut()
-				.run_system_once(move |mut p: LoadoutWriter<MockAssetServer>| {
+				.run_system_once(move |mut p: LoadoutWriter| {
 					let mut ctx = LoadoutWriter::get_context_mut(&mut p, Items { entity }).unwrap();
 					ctx.swap_items(key_a, key_b);
 				})?;
@@ -458,7 +453,7 @@ mod tests {
 				.id();
 
 			app.world_mut()
-				.run_system_once(move |mut p: LoadoutWriter<MockAssetServer>| {
+				.run_system_once(move |mut p: LoadoutWriter| {
 					let mut ctx = LoadoutWriter::get_context_mut(&mut p, Items { entity }).unwrap();
 					ctx.swap_items(key_a, key_b);
 				})?;
@@ -494,7 +489,7 @@ mod tests {
 				.id();
 
 			app.world_mut()
-				.run_system_once(move |mut p: LoadoutWriter<MockAssetServer>| {
+				.run_system_once(move |mut p: LoadoutWriter| {
 					let mut ctx = LoadoutWriter::get_context_mut(&mut p, Items { entity }).unwrap();
 					ctx.swap_items(key_a, key_b);
 				})?;
@@ -529,7 +524,7 @@ mod tests {
 				.id();
 			app.add_systems(
 				Update,
-				(move |mut p: LoadoutWriter<MockAssetServer>| {
+				(move |mut p: LoadoutWriter| {
 					let mut ctx = LoadoutWriter::get_context_mut(&mut p, Items { entity }).unwrap();
 					ctx.swap_items(key_a, key_b);
 				})


### PR DESCRIPTION
Introduce a loadout preparation system param in order to keep individual system params smaller/thinner.