### PR TITLE
Address `LineWide` overflow risk

### DIFF
--- a/src/plugins/map_generation/src/grid_graph.rs
+++ b/src/plugins/map_generation/src/grid_graph.rs
@@ -121,7 +121,11 @@ where
 	type TLNode = GridGraphNode;
 
 	fn line_of_sight(&self, a: &Self::TLNode, b: &Self::TLNode) -> bool {
-		LineWide::new(a, b).all(|LineNode { x, z }| !self.extra.obstacles.contains(&(x, z)))
+		let Ok(mut line) = LineWide::new(*a, *b) else {
+			return false;
+		};
+
+		line.all(|LineNode { x, z }| !self.extra.obstacles.contains(&(x, z)))
 	}
 }
 


### PR DESCRIPTION
fixes: #513

Limiting possible length of `LineWide` end points to `10_000` in each dimension to prevent memory overflow when building line.

Originally I just wanted to increase the size of the involved buffer types in the calculation to prevent possible buffer overflows, but during testing I realized calculation of a line from (0, 0) to (u32::MAX, u32::MAX) takes forever, which wouldn't be useful in a pathing algorithm. So we opt to claim no LoS when those points are many nodes apart. Realistically this shouldn't change any of the established behaviors.

Also cleaned the involved layout up a bit and added tests for a bit of regression safety.