### PR TITLE
Move all remaining `rapier` dependencies into `physics`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,7 +204,6 @@ name = "animations"
 version = "0.1.0"
 dependencies = [
  "bevy",
- "bevy_rapier3d",
  "common",
  "macros",
  "mockall",
@@ -433,7 +432,6 @@ name = "bars"
 version = "0.1.0"
 dependencies = [
  "bevy",
- "bevy_rapier3d",
  "common",
  "macros",
  "mockall",
@@ -458,7 +456,6 @@ name = "behaviors"
 version = "0.1.0"
 dependencies = [
  "bevy",
- "bevy_rapier3d",
  "common",
  "macros",
  "mockall",
@@ -1198,7 +1195,6 @@ dependencies = [
  "log",
  "nalgebra",
  "rapier3d",
- "serde",
 ]
 
 [[package]]
@@ -1620,9 +1616,6 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bit_field"
@@ -1773,7 +1766,6 @@ name = "camera_control"
 version = "0.1.0"
 dependencies = [
  "bevy",
- "bevy_rapier3d",
  "common",
  "macros",
  "mockall",
@@ -2614,7 +2606,6 @@ name = "frame_limiter"
 version = "0.1.0"
 dependencies = [
  "bevy",
- "bevy_rapier3d",
  "common",
 ]
 
@@ -3304,7 +3295,6 @@ name = "light"
 version = "0.1.0"
 dependencies = [
  "bevy",
- "bevy_rapier3d",
  "common",
  "macros",
  "mockall",
@@ -3471,7 +3461,6 @@ name = "menu"
 version = "0.1.0"
 dependencies = [
  "bevy",
- "bevy_rapier3d",
  "common",
  "macros",
  "mockall",
@@ -3594,7 +3583,6 @@ dependencies = [
  "num-complex",
  "num-rational",
  "num-traits",
- "serde",
  "simba",
  "typenum",
 ]
@@ -3757,7 +3745,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -4239,7 +4226,6 @@ dependencies = [
  "num-traits",
  "ordered-float 5.0.0",
  "rstar",
- "serde",
  "simba",
  "slab",
  "spade",
@@ -4495,7 +4481,6 @@ dependencies = [
  "behaviors",
  "bevy",
  "bevy-inspector-egui",
- "bevy_rapier3d",
  "camera_control",
  "common",
  "fluent",
@@ -4641,7 +4626,6 @@ dependencies = [
  "parry3d",
  "profiling",
  "rustc-hash 2.1.1",
- "serde",
  "simba",
  "thiserror 2.0.12",
 ]
@@ -5095,7 +5079,6 @@ name = "skills"
 version = "0.1.0"
 dependencies = [
  "bevy",
- "bevy_rapier3d",
  "common",
  "macros",
  "mockall",
@@ -5186,7 +5169,6 @@ dependencies = [
  "hashbrown",
  "num-traits",
  "robust",
- "serde",
  "smallvec",
 ]
 
@@ -5388,7 +5370,6 @@ name = "testing"
 version = "0.1.0"
 dependencies = [
  "bevy",
- "bevy_rapier3d",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2024"
 # external
 bevy = { version = "0.16.0", features = ["serialize"] }
 bevy-inspector-egui = "0.31.0"
-bevy_rapier3d = { version = "0.30.0", features = ["serde-serialize"] }
 fluent = "0.16.1"
 fluent-syntax = "0.11.1"
 mockall = "=0.13.1"
@@ -47,7 +46,6 @@ edition.workspace = true
 # external
 bevy.workspace = true
 bevy-inspector-egui.workspace = true
-bevy_rapier3d.workspace = true
 fluent.workspace = true
 fluent-syntax.workspace = true
 serde.workspace = true

--- a/src/plugins/animations/Cargo.toml
+++ b/src/plugins/animations/Cargo.toml
@@ -6,7 +6,6 @@ edition.workspace = true
 [dependencies]
 # external
 bevy.workspace = true
-bevy_rapier3d.workspace = true
 tracing.workspace = true
 uuid.workspace = true
 serde.workspace = true

--- a/src/plugins/bars/Cargo.toml
+++ b/src/plugins/bars/Cargo.toml
@@ -6,7 +6,6 @@ edition.workspace = true
 [dependencies]
 # external
 bevy.workspace = true
-bevy_rapier3d.workspace = true
 tracing.workspace = true
 
 # internal

--- a/src/plugins/behaviors/Cargo.toml
+++ b/src/plugins/behaviors/Cargo.toml
@@ -6,7 +6,6 @@ edition.workspace = true
 [dependencies]
 # external
 bevy.workspace = true
-bevy_rapier3d.workspace = true
 serde.workspace = true
 tracing.workspace = true
 

--- a/src/plugins/camera_control/Cargo.toml
+++ b/src/plugins/camera_control/Cargo.toml
@@ -6,7 +6,6 @@ edition.workspace = true
 [dependencies]
 # external
 bevy.workspace = true
-bevy_rapier3d.workspace = true
 serde.workspace = true
 tracing.workspace = true
 uuid.workspace = true

--- a/src/plugins/frame_limiter/Cargo.toml
+++ b/src/plugins/frame_limiter/Cargo.toml
@@ -6,7 +6,6 @@ edition.workspace = true
 [dependencies]
 # external
 bevy.workspace = true
-bevy_rapier3d.workspace = true
 
 #internal
 common.workspace = true

--- a/src/plugins/frame_limiter/src/lib.rs
+++ b/src/plugins/frame_limiter/src/lib.rs
@@ -5,7 +5,6 @@ use bevy::{
 	prelude::*,
 	render::{Render, RenderApp, RenderSet},
 };
-use bevy_rapier3d::plugin::TimestepMode;
 use std::{
 	thread,
 	time::{Duration, Instant},
@@ -56,8 +55,6 @@ impl Plugin for FrameLimiterPlugin {
 			.insert_resource(Sleep(time_per_frame))
 			.insert_resource(LastSleep(Instant::now()))
 			.add_systems(Render, Sleep::system.in_set(RenderSet::Cleanup));
-
-		app.add_systems(Update, configure_rapier(time_per_frame));
 	}
 }
 
@@ -75,20 +72,5 @@ impl Sleep {
 
 		thread::sleep(sleep);
 		*last_sleep = Instant::now();
-	}
-}
-
-fn configure_rapier(time_per_frame: Duration) -> impl Fn(Option<ResMut<TimestepMode>>) {
-	move |time_step_mode: Option<ResMut<TimestepMode>>| {
-		let Some(mut time_step_mode) = time_step_mode else {
-			return;
-		};
-		let time_step_mode = time_step_mode.as_mut();
-
-		*time_step_mode = TimestepMode::Variable {
-			max_dt: time_per_frame.as_secs_f32(),
-			time_scale: 1.,
-			substeps: 1,
-		}
 	}
 }

--- a/src/plugins/light/Cargo.toml
+++ b/src/plugins/light/Cargo.toml
@@ -6,7 +6,6 @@ edition.workspace = true
 [dependencies]
 # external
 bevy.workspace = true
-bevy_rapier3d.workspace = true
 serde.workspace = true
 uuid.workspace = true
 

--- a/src/plugins/menu/Cargo.toml
+++ b/src/plugins/menu/Cargo.toml
@@ -6,7 +6,6 @@ edition.workspace = true
 [dependencies]
 # external
 bevy.workspace = true
-bevy_rapier3d.workspace = true
 tracing.workspace = true
 uuid.workspace = true
 

--- a/src/plugins/physics/Cargo.toml
+++ b/src/plugins/physics/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 [dependencies]
 # external
 bevy.workspace = true
-bevy_rapier3d.workspace = true
+bevy_rapier3d = "0.30.0"
 serde.workspace = true
 tracing.workspace = true
 

--- a/src/plugins/physics/src/debug.rs
+++ b/src/plugins/physics/src/debug.rs
@@ -1,0 +1,32 @@
+use crate::events::{InteractionEvent, Ray};
+use bevy::prelude::*;
+use bevy_rapier3d::prelude::*;
+
+pub(crate) struct Debug;
+
+impl Debug {
+	fn display_events(
+		mut collision_events: EventReader<CollisionEvent>,
+		mut contact_force_events: EventReader<ContactForceEvent>,
+		mut ray_cast_events: EventReader<InteractionEvent<Ray>>,
+	) {
+		for collision_event in collision_events.read() {
+			info!("Received collision event: {collision_event:?}");
+		}
+
+		for contact_force_event in contact_force_events.read() {
+			info!("Received contact force event: {contact_force_event:?}");
+		}
+
+		for ray_cast_event in ray_cast_events.read() {
+			info!("Received ray cast event: {ray_cast_event:?}");
+		}
+	}
+}
+
+impl Plugin for Debug {
+	fn build(&self, app: &mut App) {
+		app.add_plugins(RapierDebugRenderPlugin::default())
+			.add_systems(Update, Self::display_events);
+	}
+}

--- a/src/plugins/skills/Cargo.toml
+++ b/src/plugins/skills/Cargo.toml
@@ -6,7 +6,6 @@ edition.workspace = true
 [dependencies]
 # external
 bevy.workspace = true
-bevy_rapier3d.workspace = true
 serde.workspace = true
 tracing.workspace = true
 uuid.workspace = true

--- a/src/testing/Cargo.toml
+++ b/src/testing/Cargo.toml
@@ -6,5 +6,4 @@ edition.workspace = true
 [dependencies]
 # external
 bevy.workspace = true
-bevy_rapier3d.workspace = true
 uuid.workspace = true

--- a/src/testing/src/lib.rs
+++ b/src/testing/src/lib.rs
@@ -2,7 +2,6 @@ use bevy::{
 	ecs::schedule::{ExecutorKind, ScheduleLabel},
 	prelude::*,
 };
-use bevy_rapier3d::prelude::Velocity;
 use std::{
 	any::{Any, TypeId, type_name},
 	fmt::Debug,
@@ -45,13 +44,6 @@ impl ApproxEqual<f32> for Transform {
 		self.translation.approx_equal(&other.translation, tolerance)
 			&& self.scale.approx_equal(&other.scale, tolerance)
 			&& self.rotation.approx_equal(&other.rotation, tolerance)
-	}
-}
-
-impl ApproxEqual<f32> for Velocity {
-	fn approx_equal(&self, other: &Self, tolerance: &f32) -> bool {
-		self.linvel.approx_equal(&other.linvel, tolerance)
-			&& self.angvel.approx_equal(&other.angvel, tolerance)
 	}
 }
 


### PR DESCRIPTION
Finally all physics implementations are owned by the physics plugin and all other plugins rely on definitions/interfaces, that are implemented by the physics plugin. This enables:
- simpler bevy(_rapier) version updates
- simpler way of switching out physics simulation libraries
- cleaner control over physics interactions
- all other plugins do not need special knowledge any longer about how physics is implemented.