### PR TITLE
Add reborrow for `Zyheeda(Entity)Commands`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -85,6 +85,7 @@
 		"nanos",
 		"Numpad",
 		"quickbar",
+		"reborrow",
 		"savegame",
 		"serde",
 		"srgb",

--- a/src/plugins/common/src/zyheeda_commands.rs
+++ b/src/plugins/common/src/zyheeda_commands.rs
@@ -32,6 +32,13 @@ impl<'w, 's> ZyheedaCommands<'w, 's> {
 	{
 		self.commands.trigger(event);
 	}
+
+	pub fn reborrow(&mut self) -> ZyheedaCommands<'w, '_> {
+		ZyheedaCommands {
+			commands: self.commands.reborrow(),
+			persistent_entities: self.persistent_entities.as_ref().map(Res::clone),
+		}
+	}
 }
 
 impl GetMut<Entity> for ZyheedaCommands<'_, '_> {
@@ -121,6 +128,12 @@ impl ZyheedaEntityCommands<'_> {
 		TEvent: Event,
 	{
 		self.entity.commands_mut().trigger(event);
+	}
+
+	pub fn reborrow(&mut self) -> ZyheedaEntityCommands<'_> {
+		ZyheedaEntityCommands {
+			entity: self.entity.reborrow(),
+		}
 	}
 }
 


### PR DESCRIPTION
Allow re-borrow of `ZyheedaCommands` and `ZyheedaEntityCommands` like the corresponding structs in `bevy`.