### PR TITLE
Allow abstract effect insertion on spawned skills

### DIFF
--- a/src/plugins/common/src/traits/handles_skill_physics.rs
+++ b/src/plugins/common/src/traits/handles_skill_physics.rs
@@ -1,5 +1,6 @@
 use crate::{
 	components::{asset_model::AssetModel, persistent_entity::PersistentEntity},
+	effects::{force::Force, gravity::Gravity, health_damage::HealthDamage},
 	tools::{Index, Units, UnitsPerSecond, action_key::slot::SlotKey, bone_name::BoneName},
 	traits::{
 		accessors::get::GetContextMut,
@@ -89,6 +90,13 @@ where
 
 pub struct NewSkill;
 
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum Effect {
+	Force(Force),
+	Gravity(Gravity),
+	HealthDamage(HealthDamage),
+}
+
 /// Describes the contact shape of a skill
 ///
 /// These should be used for physical effects like projectile bodies, barriers or beam cores.
@@ -116,12 +124,8 @@ pub trait Skill {
 	fn insert_on_root<T>(&mut self, bundle: T)
 	where
 		T: Bundle;
-	fn insert_on_contact<T>(&mut self, bundle: T)
-	where
-		T: Bundle;
-	fn insert_on_projection<T>(&mut self, bundle: T)
-	where
-		T: Bundle;
+	fn insert_on_contact(&mut self, effect: Effect);
+	fn insert_on_projection(&mut self, effect: Effect);
 }
 
 /// The entities of a spawned skill.

--- a/src/plugins/skills/src/components/skill_executer.rs
+++ b/src/plugins/skills/src/components/skill_executer.rs
@@ -107,9 +107,10 @@ mod tests {
 		tools::action_key::slot::{PlayerSlot, Side},
 		traits::{
 			accessors::get::{GetContextMut, GetProperty},
-			handles_physics::{Effect, HandlesPhysicalEffect},
+			handles_physics::{Effect as EffectTrait, HandlesPhysicalEffect},
 			handles_skill_physics::{
 				Contact,
+				Effect,
 				HandlesNewPhysicalSkill,
 				NewSkill,
 				Projection,
@@ -131,7 +132,7 @@ mod tests {
 
 	impl<T> HandlesPhysicalEffect<T> for _HandlesPhysics
 	where
-		T: Effect + ThreadSafe,
+		T: EffectTrait + ThreadSafe,
 	{
 		type TEffectComponent = _Effect;
 		type TAffectedComponent = _Affected;
@@ -215,17 +216,11 @@ mod tests {
 			panic!("SHOULD NOT BE CALLED")
 		}
 
-		fn insert_on_contact<T>(&mut self, _: T)
-		where
-			T: Bundle,
-		{
+		fn insert_on_contact(&mut self, _: Effect) {
 			panic!("SHOULD NOT BE CALLED")
 		}
 
-		fn insert_on_projection<T>(&mut self, _: T)
-		where
-			T: Bundle,
-		{
+		fn insert_on_projection(&mut self, _: Effect) {
 			panic!("SHOULD NOT BE CALLED")
 		}
 	}

--- a/src/plugins/skills/src/skills.rs
+++ b/src/plugins/skills/src/skills.rs
@@ -247,9 +247,10 @@ mod tests {
 		components::persistent_entity::PersistentEntity,
 		traits::{
 			accessors::get::GetContextMut,
-			handles_physics::{Effect, HandlesPhysicalEffect},
+			handles_physics::{Effect as EffectTrait, HandlesPhysicalEffect},
 			handles_skill_physics::{
 				Contact,
+				Effect,
 				HandlesNewPhysicalSkill,
 				NewSkill,
 				Projection,
@@ -317,17 +318,11 @@ mod tests {
 			panic!("SHOULD NOT BE CALLED")
 		}
 
-		fn insert_on_contact<T>(&mut self, _: T)
-		where
-			T: Bundle,
-		{
+		fn insert_on_contact(&mut self, _: Effect) {
 			panic!("SHOULD NOT BE CALLED")
 		}
 
-		fn insert_on_projection<T>(&mut self, _: T)
-		where
-			T: Bundle,
-		{
+		fn insert_on_projection(&mut self, _: Effect) {
 			panic!("SHOULD NOT BE CALLED")
 		}
 	}
@@ -336,7 +331,7 @@ mod tests {
 
 	impl<T> HandlesPhysicalEffect<T> for _HandlesPhysics
 	where
-		T: Effect + ThreadSafe,
+		T: EffectTrait + ThreadSafe,
 	{
 		type TEffectComponent = _Effect;
 		type TAffectedComponent = _Affected;

--- a/src/plugins/skills/src/traits/skill_builder.rs
+++ b/src/plugins/skills/src/traits/skill_builder.rs
@@ -109,6 +109,7 @@ mod tests {
 			accessors::get::GetContextMut,
 			handles_skill_physics::{
 				Contact,
+				Effect,
 				NewSkill,
 				Projection,
 				Skill,
@@ -171,17 +172,11 @@ mod tests {
 			panic!("SHOULD NOT BE CALLED")
 		}
 
-		fn insert_on_contact<T>(&mut self, _: T)
-		where
-			T: Bundle,
-		{
+		fn insert_on_contact(&mut self, _: Effect) {
 			panic!("SHOULD NOT BE CALLED")
 		}
 
-		fn insert_on_projection<T>(&mut self, _: T)
-		where
-			T: Bundle,
-		{
+		fn insert_on_projection(&mut self, _: Effect) {
 			panic!("SHOULD NOT BE CALLED")
 		}
 	}


### PR DESCRIPTION
This should make it simpler to insert effects on a newly spawned skills. Consumer's now won't need to specify a conversion method when using the new skill spawn system parameter.