### PR TITLE
Simplify physic's skill spawner

### DIFF
--- a/src/plugins/common/src/traits/handles_skill_physics.rs
+++ b/src/plugins/common/src/traits/handles_skill_physics.rs
@@ -34,8 +34,7 @@ pub trait HandlesPhysicalSkillComponents {
 }
 
 pub trait HandlesNewPhysicalSkill {
-	type TSkillSpawnerMut<'w, 's>: SystemParam
-		+ for<'c> GetContextMut<NewSkill, TContext<'c>: Spawn>;
+	type TSkillSpawnerMut<'w, 's>: SystemParam<Item<'w, 's>: Spawn>;
 
 	/// Skills always have a contact and a projection shape.
 	///
@@ -87,8 +86,6 @@ where
 		self.deref_mut().register_definition(definition);
 	}
 }
-
-pub struct NewSkill;
 
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum Effect {

--- a/src/plugins/physics/src/system_params/skill_spawner.rs
+++ b/src/plugins/physics/src/system_params/skill_spawner.rs
@@ -5,7 +5,7 @@ use bevy::{ecs::system::SystemParam, prelude::*};
 use common::{
 	traits::{
 		accessors::get::{GetContextMut, GetMut},
-		handles_skill_physics::{NewSkill, SkillSpawnPoints},
+		handles_skill_physics::SkillSpawnPoints,
 	},
 	zyheeda_commands::{ZyheedaCommands, ZyheedaEntityCommands},
 };
@@ -30,21 +30,4 @@ impl GetContextMut<SkillSpawnPoints> for SkillSpawnerMut<'_, '_> {
 
 pub struct SpawnPointContextMut<'ctx> {
 	entity: ZyheedaEntityCommands<'ctx>,
-}
-
-impl<'w, 's> GetContextMut<NewSkill> for SkillSpawnerMut<'w, 's> {
-	type TContext<'ctx> = SpawnNewSkillContextMut<'ctx>;
-
-	fn get_context_mut<'ctx>(
-		param: &'ctx mut SkillSpawnerMut,
-		_: NewSkill,
-	) -> Option<Self::TContext<'ctx>> {
-		Some(SpawnNewSkillContextMut {
-			commands: param.commands.reborrow(),
-		})
-	}
-}
-
-pub struct SpawnNewSkillContextMut<'ctx> {
-	commands: ZyheedaCommands<'ctx, 'ctx>,
 }

--- a/src/plugins/physics/src/system_params/skill_spawner/spawn_new_skill.rs
+++ b/src/plugins/physics/src/system_params/skill_spawner/spawn_new_skill.rs
@@ -3,7 +3,7 @@ use crate::{
 		effect::{force::ForceEffect, gravity::GravityEffect, health_damage::HealthDamageEffect},
 		skill_prefabs::{skill_contact::SkillContact, skill_projection::SkillProjection},
 	},
-	system_params::skill_spawner::SpawnNewSkillContextMut,
+	system_params::skill_spawner::SkillSpawnerMut,
 };
 use bevy::prelude::*;
 use common::{
@@ -23,7 +23,7 @@ use common::{
 	zyheeda_commands::{ZyheedaCommands, ZyheedaEntityCommands},
 };
 
-impl Spawn for SpawnNewSkillContextMut<'_> {
+impl Spawn for SkillSpawnerMut<'_, '_> {
 	type TSkill<'c>
 		= Skill<'c>
 	where
@@ -112,16 +112,12 @@ mod tests {
 	use common::{
 		CommonPlugin,
 		tools::Units,
-		traits::{
-			accessors::get::GetContextMut,
-			handles_skill_physics::{
-				ContactShape,
-				Motion,
-				NewSkill,
-				ProjectionShape,
-				SkillCaster,
-				SkillSpawner,
-			},
+		traits::handles_skill_physics::{
+			ContactShape,
+			Motion,
+			ProjectionShape,
+			SkillCaster,
+			SkillSpawner,
 		},
 	};
 	use std::{collections::HashSet, sync::LazyLock};
@@ -163,8 +159,7 @@ mod tests {
 
 			app.world_mut()
 				.run_system_once(move |mut p: SkillSpawnerMut| {
-					let mut ctx = SkillSpawnerMut::get_context_mut(&mut p, NewSkill).unwrap();
-					ctx.spawn(CONTACT.clone(), PROJECTION.clone());
+					p.spawn(CONTACT.clone(), PROJECTION.clone());
 				})?;
 
 			let skills = app
@@ -181,8 +176,7 @@ mod tests {
 
 			app.world_mut()
 				.run_system_once(move |mut p: SkillSpawnerMut| {
-					let mut ctx = SkillSpawnerMut::get_context_mut(&mut p, NewSkill).unwrap();
-					ctx.spawn(CONTACT.clone(), PROJECTION.clone());
+					p.spawn(CONTACT.clone(), PROJECTION.clone());
 				})?;
 
 			let skills = app
@@ -203,8 +197,7 @@ mod tests {
 
 			app.world_mut()
 				.run_system_once(move |mut p: SkillSpawnerMut| {
-					let mut ctx = SkillSpawnerMut::get_context_mut(&mut p, NewSkill).unwrap();
-					ctx.spawn(CONTACT.clone(), PROJECTION.clone());
+					p.spawn(CONTACT.clone(), PROJECTION.clone());
 				})?;
 
 			let skills = app
@@ -241,8 +234,7 @@ mod tests {
 			let root = app
 				.world_mut()
 				.run_system_once(move |mut p: SkillSpawnerMut| {
-					let mut ctx = SkillSpawnerMut::get_context_mut(&mut p, NewSkill).unwrap();
-					let skill = ctx.spawn(CONTACT.clone(), PROJECTION.clone());
+					let skill = p.spawn(CONTACT.clone(), PROJECTION.clone());
 					skill.root()
 				})?;
 
@@ -261,8 +253,7 @@ mod tests {
 
 			app.world_mut()
 				.run_system_once(move |mut p: SkillSpawnerMut| {
-					let mut ctx = SkillSpawnerMut::get_context_mut(&mut p, NewSkill).unwrap();
-					let mut skill = ctx.spawn(CONTACT.clone(), PROJECTION.clone());
+					let mut skill = p.spawn(CONTACT.clone(), PROJECTION.clone());
 					skill.insert_on_root(_Marker);
 				})?;
 
@@ -292,8 +283,7 @@ mod tests {
 
 			app.world_mut()
 				.run_system_once(move |mut p: SkillSpawnerMut| {
-					let mut ctx = SkillSpawnerMut::get_context_mut(&mut p, NewSkill).unwrap();
-					let mut skill = ctx.spawn(CONTACT.clone(), PROJECTION.clone());
+					let mut skill = p.spawn(CONTACT.clone(), PROJECTION.clone());
 					skill.insert_on_contact(effect);
 				})?;
 
@@ -317,8 +307,7 @@ mod tests {
 
 			app.world_mut()
 				.run_system_once(move |mut p: SkillSpawnerMut| {
-					let mut ctx = SkillSpawnerMut::get_context_mut(&mut p, NewSkill).unwrap();
-					let mut skill = ctx.spawn(CONTACT.clone(), PROJECTION.clone());
+					let mut skill = p.spawn(CONTACT.clone(), PROJECTION.clone());
 					skill.insert_on_projection(effect);
 				})?;
 

--- a/src/plugins/skills/src/components/skill_executer.rs
+++ b/src/plugins/skills/src/components/skill_executer.rs
@@ -106,13 +106,12 @@ mod tests {
 		components::persistent_entity::PersistentEntity,
 		tools::action_key::slot::{PlayerSlot, Side},
 		traits::{
-			accessors::get::{GetContextMut, GetProperty},
+			accessors::get::GetProperty,
 			handles_physics::{Effect as EffectTrait, HandlesPhysicalEffect},
 			handles_skill_physics::{
 				Contact,
 				Effect,
 				HandlesNewPhysicalSkill,
-				NewSkill,
 				Projection,
 				Skill,
 				SkillEntities,
@@ -178,20 +177,7 @@ mod tests {
 	#[derive(SystemParam)]
 	struct _SkillSpawner;
 
-	impl GetContextMut<NewSkill> for _SkillSpawner {
-		type TContext<'ctx> = _Context;
-
-		fn get_context_mut<'ctx>(
-			_: &'ctx mut _SkillSpawner,
-			_: NewSkill,
-		) -> Option<Self::TContext<'ctx>> {
-			None
-		}
-	}
-
-	struct _Context;
-
-	impl Spawn for _Context {
+	impl Spawn for _SkillSpawner {
 		type TSkill<'c>
 			= _SpawnedSkill
 		where

--- a/src/plugins/skills/src/skills.rs
+++ b/src/plugins/skills/src/skills.rs
@@ -246,13 +246,11 @@ mod tests {
 		attributes::health::Health,
 		components::persistent_entity::PersistentEntity,
 		traits::{
-			accessors::get::GetContextMut,
 			handles_physics::{Effect as EffectTrait, HandlesPhysicalEffect},
 			handles_skill_physics::{
 				Contact,
 				Effect,
 				HandlesNewPhysicalSkill,
-				NewSkill,
 				Projection,
 				Skill,
 				SkillEntities,
@@ -280,20 +278,7 @@ mod tests {
 	#[derive(SystemParam)]
 	struct _SkillSpawner;
 
-	impl GetContextMut<NewSkill> for _SkillSpawner {
-		type TContext<'ctx> = _Context;
-
-		fn get_context_mut<'ctx>(
-			_: &'ctx mut _SkillSpawner,
-			_: NewSkill,
-		) -> Option<Self::TContext<'ctx>> {
-			None
-		}
-	}
-
-	struct _Context;
-
-	impl Spawn for _Context {
+	impl Spawn for _SkillSpawner {
 		type TSkill<'c>
 			= _SpawnedSkill
 		where

--- a/src/plugins/skills/src/traits/skill_builder.rs
+++ b/src/plugins/skills/src/traits/skill_builder.rs
@@ -105,18 +105,14 @@ mod tests {
 	use bevy::ecs::system::{RunSystemError, RunSystemOnce, SystemParam};
 	use common::{
 		components::persistent_entity::PersistentEntity,
-		traits::{
-			accessors::get::GetContextMut,
-			handles_skill_physics::{
-				Contact,
-				Effect,
-				NewSkill,
-				Projection,
-				Skill,
-				SkillEntities,
-				SkillRoot,
-				Spawn,
-			},
+		traits::handles_skill_physics::{
+			Contact,
+			Effect,
+			Projection,
+			Skill,
+			SkillEntities,
+			SkillRoot,
+			Spawn,
 		},
 	};
 	use std::{any::type_name, sync::LazyLock, time::Duration};
@@ -134,20 +130,7 @@ mod tests {
 	#[derive(SystemParam)]
 	struct _SkillSpawner;
 
-	impl GetContextMut<NewSkill> for _SkillSpawner {
-		type TContext<'ctx> = _Context;
-
-		fn get_context_mut<'ctx>(
-			_: &'ctx mut _SkillSpawner,
-			_: NewSkill,
-		) -> Option<Self::TContext<'ctx>> {
-			None
-		}
-	}
-
-	struct _Context;
-
-	impl Spawn for _Context {
+	impl Spawn for _SkillSpawner {
 		type TSkill<'c>
 			= _SpawnedSkill
 		where


### PR DESCRIPTION
Because the skill spawning isn't entity specific, we can use the related system parameter directly without going through context. 