### PR TITLE
Fix lifetimes for physics skill spawning

### DIFF
--- a/src/plugins/common/src/traits/handles_skill_physics.rs
+++ b/src/plugins/common/src/traits/handles_skill_physics.rs
@@ -34,7 +34,7 @@ pub trait HandlesPhysicalSkillComponents {
 }
 
 pub trait HandlesNewPhysicalSkill {
-	type TSkillSpawnerMut<'w, 's>: SystemParam<Item<'w, 's>: Spawn>;
+	type TSkillSpawnerMut<'world, 'state>: for<'w, 's> SystemParam<Item<'w, 's>: Spawn>;
 
 	/// Skills always have a contact and a projection shape.
 	///


### PR DESCRIPTION
Make lifetimes of `HandlesNewPhysicalSkill::TSkillSpawnerMut` and related item independent from each other to enable usage for generic system type injection via `StaticSystemParam`