### PR TITLE
Allow skill despawning through `HandlesNewPhysicalSkill::TSkillSpawnerMut`

### DIFF
--- a/src/plugins/common/src/traits/handles_skill_physics.rs
+++ b/src/plugins/common/src/traits/handles_skill_physics.rs
@@ -34,7 +34,11 @@ pub trait HandlesPhysicalSkillComponents {
 }
 
 pub trait HandlesNewPhysicalSkill {
-	type TSkillSpawnerMut<'world, 'state>: for<'w, 's> SystemParam<Item<'w, 's>: Spawn>;
+	/// Skill spawner
+	///
+	/// Implementations of this are likely to use [`Commands`]. Insertion of skill components/effects
+	/// and despawning should be handled through this [`SystemParam`].
+	type TSkillSpawnerMut<'world, 'state>: for<'w, 's> SystemParam<Item<'w, 's>: Spawn + Despawn>;
 
 	/// Skills always have a contact and a projection shape.
 	///
@@ -54,6 +58,10 @@ pub trait Spawn {
 		Self: 'c;
 
 	fn spawn(&mut self, contact: Contact, projection: Projection) -> Self::TSkill<'_>;
+}
+
+pub trait Despawn {
+	fn despawn(&mut self, skill: SkillEntity);
 }
 
 pub trait HandlesPhysicalSkillSpawnPoints {
@@ -86,6 +94,8 @@ where
 		self.deref_mut().register_definition(definition);
 	}
 }
+
+pub struct SkillEntity(pub PersistentEntity);
 
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum Effect {

--- a/src/plugins/physics/src/components.rs
+++ b/src/plugins/physics/src/components.rs
@@ -14,6 +14,7 @@ pub(crate) mod motion;
 pub(crate) mod no_hover;
 pub(crate) mod running_interactions;
 pub(crate) mod set_motion_forward;
+pub(crate) mod skill;
 pub(crate) mod skill_prefabs;
 pub(crate) mod when_traveled;
 pub(crate) mod world_camera;

--- a/src/plugins/physics/src/components/skill.rs
+++ b/src/plugins/physics/src/components/skill.rs
@@ -1,0 +1,6 @@
+use bevy::prelude::*;
+use common::components::persistent_entity::PersistentEntity;
+
+#[derive(Component, Debug, PartialEq)]
+#[require(PersistentEntity)]
+pub struct Skill;

--- a/src/plugins/physics/src/system_params/skill_spawner.rs
+++ b/src/plugins/physics/src/system_params/skill_spawner.rs
@@ -1,6 +1,8 @@
+mod despawn_skill;
 mod spawn_new_skill;
 mod spawn_points_definition;
 
+use crate::components::skill::Skill;
 use bevy::{ecs::system::SystemParam, prelude::*};
 use common::{
 	traits::{
@@ -12,6 +14,7 @@ use common::{
 
 #[derive(SystemParam)]
 pub struct SkillSpawnerMut<'w, 's> {
+	skills: Query<'w, 's, (), With<Skill>>,
 	commands: ZyheedaCommands<'w, 's>,
 }
 

--- a/src/plugins/physics/src/system_params/skill_spawner/despawn_skill.rs
+++ b/src/plugins/physics/src/system_params/skill_spawner/despawn_skill.rs
@@ -1,0 +1,69 @@
+use crate::system_params::skill_spawner::SkillSpawnerMut;
+use common::traits::{
+	accessors::get::GetMut,
+	handles_skill_physics::{Despawn, SkillEntity},
+};
+
+impl Despawn for SkillSpawnerMut<'_, '_> {
+	fn despawn(&mut self, SkillEntity(entity): SkillEntity) {
+		let Some(entity) = self.commands.get_mut(&entity) else {
+			return;
+		};
+
+		if !self.skills.contains(entity.id()) {
+			return;
+		}
+
+		entity.try_despawn();
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::components::skill::Skill;
+	use bevy::{
+		ecs::system::{RunSystemError, RunSystemOnce},
+		prelude::*,
+	};
+	use common::{CommonPlugin, components::persistent_entity::PersistentEntity};
+	use testing::SingleThreadedApp;
+
+	fn setup() -> App {
+		let mut app = App::new().single_threaded(Update);
+
+		app.add_plugins(CommonPlugin);
+
+		app
+	}
+
+	#[test]
+	fn despawn_skill() -> Result<(), RunSystemError> {
+		let mut app = setup();
+		let persistent_entity = PersistentEntity::default();
+		let entity = app.world_mut().spawn((Skill, persistent_entity)).id();
+
+		app.world_mut()
+			.run_system_once(move |mut p: SkillSpawnerMut| {
+				p.despawn(SkillEntity(persistent_entity));
+			})?;
+
+		assert!(app.world().get_entity(entity).is_err());
+		Ok(())
+	}
+
+	#[test]
+	fn do_not_despawn_non_skill() -> Result<(), RunSystemError> {
+		let mut app = setup();
+		let persistent_entity = PersistentEntity::default();
+		let entity = app.world_mut().spawn(persistent_entity).id();
+
+		app.world_mut()
+			.run_system_once(move |mut p: SkillSpawnerMut| {
+				p.despawn(SkillEntity(persistent_entity));
+			})?;
+
+		assert!(app.world().get_entity(entity).is_ok());
+		Ok(())
+	}
+}

--- a/src/plugins/skills/src/components/skill_executer.rs
+++ b/src/plugins/skills/src/components/skill_executer.rs
@@ -110,11 +110,13 @@ mod tests {
 			handles_physics::{Effect as EffectTrait, HandlesPhysicalEffect},
 			handles_skill_physics::{
 				Contact,
+				Despawn,
 				Effect,
 				HandlesNewPhysicalSkill,
 				Projection,
 				Skill,
 				SkillEntities,
+				SkillEntity,
 				SkillRoot,
 				Spawn,
 			},
@@ -184,6 +186,12 @@ mod tests {
 			Self: 'c;
 
 		fn spawn(&mut self, _: Contact, _: Projection) -> Self::TSkill<'_> {
+			panic!("SHOULD NOT BE CALLED")
+		}
+	}
+
+	impl Despawn for _SkillSpawner {
+		fn despawn(&mut self, _: SkillEntity) {
 			panic!("SHOULD NOT BE CALLED")
 		}
 	}

--- a/src/plugins/skills/src/skills.rs
+++ b/src/plugins/skills/src/skills.rs
@@ -249,11 +249,13 @@ mod tests {
 			handles_physics::{Effect as EffectTrait, HandlesPhysicalEffect},
 			handles_skill_physics::{
 				Contact,
+				Despawn,
 				Effect,
 				HandlesNewPhysicalSkill,
 				Projection,
 				Skill,
 				SkillEntities,
+				SkillEntity,
 				SkillRoot,
 				Spawn,
 			},
@@ -285,6 +287,12 @@ mod tests {
 			Self: 'c;
 
 		fn spawn(&mut self, _: Contact, _: Projection) -> Self::TSkill<'_> {
+			panic!("SHOULD NOT BE CALLED")
+		}
+	}
+
+	impl Despawn for _SkillSpawner {
+		fn despawn(&mut self, _: SkillEntity) {
 			panic!("SHOULD NOT BE CALLED")
 		}
 	}

--- a/src/plugins/skills/src/traits/skill_builder.rs
+++ b/src/plugins/skills/src/traits/skill_builder.rs
@@ -107,10 +107,12 @@ mod tests {
 		components::persistent_entity::PersistentEntity,
 		traits::handles_skill_physics::{
 			Contact,
+			Despawn,
 			Effect,
 			Projection,
 			Skill,
 			SkillEntities,
+			SkillEntity,
 			SkillRoot,
 			Spawn,
 		},
@@ -137,6 +139,12 @@ mod tests {
 			Self: 'c;
 
 		fn spawn(&mut self, _: Contact, _: Projection) -> Self::TSkill<'_> {
+			panic!("SHOULD NOT BE CALLED")
+		}
+	}
+
+	impl Despawn for _SkillSpawner {
+		fn despawn(&mut self, _: SkillEntity) {
 			panic!("SHOULD NOT BE CALLED")
 		}
 	}


### PR DESCRIPTION
Despawning of skills can be done via `HandlesNewPhysicalSkill::TSkillSpawnerMut`, 
so consumers don't need to use `(Zyheeda)Commands`, which will conflict with the `physics` plugin implementation of the plugin.