### PR TITLE
Remove outdated skill spawn method

### DIFF
--- a/src/plugins/common/src/traits/handles_skill_physics.rs
+++ b/src/plugins/common/src/traits/handles_skill_physics.rs
@@ -6,7 +6,6 @@ use crate::{
 		accessors::get::GetContextMut,
 		handles_physics::colliders::{Blocker, Shape},
 	},
-	zyheeda_commands::ZyheedaCommands,
 };
 use bevy::{
 	ecs::{entity::Entity, system::SystemParam},
@@ -39,15 +38,6 @@ pub trait HandlesNewPhysicalSkill {
 	/// Implementations of this are likely to use [`Commands`]. Insertion of skill components/effects
 	/// and despawning should be handled through this [`SystemParam`].
 	type TSkillSpawnerMut<'world, 'state>: for<'w, 's> SystemParam<Item<'w, 's>: Spawn + Despawn>;
-
-	/// Skills always have a contact and a projection shape.
-	///
-	/// Activity of those shapes should be controlled by their attached effects.
-	fn spawn_skill(
-		commands: &mut ZyheedaCommands,
-		contact: Contact,
-		projection: Projection,
-	) -> SkillEntities;
 }
 
 pub type SkillSpawnerMut<'w, 's, T> = <T as HandlesNewPhysicalSkill>::TSkillSpawnerMut<'w, 's>;
@@ -157,17 +147,6 @@ pub trait Skill {
 		T: Bundle;
 	fn insert_on_contact(&mut self, effect: Effect);
 	fn insert_on_projection(&mut self, effect: Effect);
-}
-
-/// The entities of a spawned skill.
-/// - `root`: The skill's top level entity (can be used to despawn the skill)
-/// - `contact`: add/remove contact effect components (projectiles, force fields, ..)
-/// - `projection`: add/remove projection/AoE effect components (gravity fields, explosions, ..)
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
-pub struct SkillEntities {
-	pub root: SkillRoot,
-	pub contact: Entity,
-	pub projection: Entity,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]

--- a/src/plugins/physics/src/lib.rs
+++ b/src/plugins/physics/src/lib.rs
@@ -38,7 +38,6 @@ use crate::{
 use bevy::prelude::*;
 use bevy_rapier3d::prelude::*;
 use common::{
-	components::{child_of_persistent::ChildOfPersistent, persistent_entity::PersistentEntity},
 	systems::log::OnError,
 	traits::{
 		delta::Delta,
@@ -52,19 +51,14 @@ use common::{
 		},
 		handles_saving::HandlesSaving,
 		handles_skill_physics::{
-			Contact,
 			HandlesNewPhysicalSkill,
 			HandlesPhysicalSkillComponents,
 			HandlesPhysicalSkillSpawnPoints,
-			Projection,
-			SkillEntities,
-			SkillRoot,
 		},
 		prefab::AddPrefabObserver,
 		register_derived_component::RegisterDerivedComponent,
 		thread_safe::ThreadSafe,
 	},
-	zyheeda_commands::ZyheedaCommands,
 };
 use components::{
 	active_beam::ActiveBeam,
@@ -286,32 +280,6 @@ impl<TDependencies> HandlesPhysicalSkillSpawnPoints for PhysicsPlugin<TDependenc
 
 impl<TDependencies> HandlesNewPhysicalSkill for PhysicsPlugin<TDependencies> {
 	type TSkillSpawnerMut<'w, 's> = SkillSpawnerMut<'w, 's>;
-
-	fn spawn_skill(
-		commands: &mut ZyheedaCommands,
-		contact: Contact,
-		projection: Projection,
-	) -> SkillEntities {
-		let persistent_contact = PersistentEntity::default();
-		let contact = commands
-			.spawn((SkillContact::from(contact), persistent_contact))
-			.id();
-		let projection = commands
-			.spawn((
-				SkillProjection::from(projection),
-				ChildOfPersistent(persistent_contact),
-			))
-			.id();
-
-		SkillEntities {
-			root: SkillRoot {
-				persistent_entity: persistent_contact,
-				entity: contact,
-			},
-			contact,
-			projection,
-		}
-	}
 }
 
 impl<TDependencies> HandlesPhysicalSkillComponents for PhysicsPlugin<TDependencies> {

--- a/src/plugins/physics/src/system_params/skill_spawner/spawn_new_skill.rs
+++ b/src/plugins/physics/src/system_params/skill_spawner/spawn_new_skill.rs
@@ -16,7 +16,6 @@ use common::{
 			Effect,
 			Projection,
 			Skill as SkillTrait,
-			SkillEntities,
 			SkillRoot,
 			Spawn,
 		},
@@ -63,6 +62,13 @@ impl Spawn for SkillSpawnerMut<'_, '_> {
 pub struct SkillCommands<'c> {
 	commands: ZyheedaCommands<'c, 'c>,
 	entities: SkillEntities,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+struct SkillEntities {
+	root: SkillRoot,
+	contact: Entity,
+	projection: Entity,
 }
 
 impl SkillTrait for SkillCommands<'_> {


### PR DESCRIPTION
The old interface method for spawning skills is unused, thus should have been removed already. This PR fixes this.