### PR TITLE
Allow `Prefab` reapplications

### DIFF
--- a/src/plugins/common/src/traits/prefab.rs
+++ b/src/plugins/common/src/traits/prefab.rs
@@ -4,14 +4,34 @@ mod entity_commands;
 use crate::{errors::ErrorData, traits::load_asset::LoadAsset};
 use bevy::{ecs::relationship::RelatedSpawnerCommands, prelude::*};
 
-pub trait Prefab<TDependency> {
+pub trait Prefab<TDependency>: Component {
 	type TError: ErrorData;
+
+	const REAPPLY: Reapply = Reapply::Never;
 
 	fn insert_prefab_components(
 		&self,
 		entity: &mut impl PrefabEntityCommands,
 		assets: &mut impl LoadAsset,
 	) -> Result<(), Self::TError>;
+}
+
+/// Prefab application strategy:
+///
+/// - [`Reapply::Never`]: [`Prefab`] is not re-applied when it is re-inserted
+/// - [`Reapply::Always`]: [`Prefab`] is re-applied each time it is inserted
+///
+/// The default for [`Prefab`] is [`Reapply::Never`].
+///
+/// <div class="warning">
+///   Using `Reapply::Always` is dangerous when the prefab may insert different component types
+///   and/or adds children. In this case a scheme to cleanup outdated components/children is
+///   required.
+/// </div>
+#[derive(Debug, PartialEq)]
+pub enum Reapply {
+	Never,
+	Always,
 }
 
 pub trait AddPrefabObserver {


### PR DESCRIPTION
Adds the option to reapply a `Prefab` when the component is re-inserted. Useful for simple prefabs that insert always the same component types and do not add children. Related dangers are documented.