### PR TITLE
Change `FollowWithOffset` to `FollowTransform`

### DIFF
--- a/src/plugins/physics/src/components/followers.rs
+++ b/src/plugins/physics/src/components/followers.rs
@@ -23,5 +23,8 @@ impl GetProperty<LifetimeRoot> for Follow {
 	}
 }
 
-#[derive(Component, Debug, PartialEq)]
-pub(crate) struct FollowWithOffset(pub(crate) Vec3);
+#[derive(Component, Debug, PartialEq, Default)]
+pub(crate) struct FollowTransform {
+	pub(crate) translation: Vec3,
+	pub(crate) rotation: Quat,
+}


### PR DESCRIPTION
`Follower`s can not specify through `FollowTransform`:
- `translation`, which serves as an offset from the followed entity relative to the followed entity's rotation
- `rotation`, which is applied together with the followed rotation

We are deliberately not setting a scale, because scales should work independently.