### PR TITLE
Refine follow transform propagation

### DIFF
--- a/src/plugins/physics/src/components/followers.rs
+++ b/src/plugins/physics/src/components/followers.rs
@@ -15,7 +15,7 @@ pub(crate) struct Followers(EntityHashSet);
 /// Must not be used nested or in [`ChildOf`] relationships
 #[derive(Component, Debug, PartialEq)]
 #[relationship(relationship_target = Followers)]
-#[require(Transform)]
+#[require(Transform, FollowTransform)]
 pub(crate) struct Follow(pub(crate) Entity);
 
 impl GetProperty<LifetimeRoot> for Follow {

--- a/src/plugins/physics/src/lib.rs
+++ b/src/plugins/physics/src/lib.rs
@@ -200,6 +200,7 @@ where
 						.chain(),
 					// Physical effects
 					(
+						Followers::mark_dirty,
 						Followers::follow.pipe(OnError::log),
 						Blockable::beam_interactions.pipe(OnError::log),
 						OngoingInteractions::clear,

--- a/src/plugins/physics/src/systems.rs
+++ b/src/plugins/physics/src/systems.rs
@@ -2,7 +2,7 @@ pub(crate) mod apply_pull;
 pub(crate) mod blockable;
 pub(crate) mod body;
 pub(crate) mod fix_points;
-pub(crate) mod follow;
+pub(crate) mod followers;
 pub(crate) mod ground_target;
 pub(crate) mod insert_affected;
 pub(crate) mod interactions;

--- a/src/plugins/physics/src/systems/followers.rs
+++ b/src/plugins/physics/src/systems/followers.rs
@@ -1,0 +1,2 @@
+pub(crate) mod follow;
+pub(crate) mod mark_dirty;

--- a/src/plugins/physics/src/systems/followers/mark_dirty.rs
+++ b/src/plugins/physics/src/systems/followers/mark_dirty.rs
@@ -1,0 +1,130 @@
+use crate::components::followers::{FollowStateDirty, FollowTransform, Followers};
+use bevy::prelude::*;
+
+impl Followers {
+	pub(crate) fn mark_dirty(
+		mut followed: Query<(Ref<Self>, Ref<Transform>, &mut FollowStateDirty)>,
+		changed_follow_transforms: Query<(), Changed<FollowTransform>>,
+	) {
+		for (followed, transform, mut state_dirty) in &mut followed {
+			if !Self::is_dirty(followed, transform, &changed_follow_transforms) {
+				continue;
+			}
+
+			state_dirty.set_changed();
+		}
+	}
+
+	fn is_dirty(
+		followed: Ref<Followers>,
+		transform: Ref<Transform>,
+		changed_follow_transforms: &Query<(), Changed<FollowTransform>>,
+	) -> bool {
+		if followed.is_changed() || transform.is_changed() {
+			return true;
+		}
+
+		for entity in followed.iter() {
+			if changed_follow_transforms.contains(entity) {
+				return true;
+			}
+		}
+
+		false
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::components::followers::{Follow, FollowTransform};
+	use testing::{IsChanged, SingleThreadedApp};
+
+	fn setup() -> App {
+		let mut app = App::new().single_threaded(Update);
+
+		app.add_systems(
+			Update,
+			(Followers::mark_dirty, IsChanged::<FollowStateDirty>::detect).chain(),
+		);
+
+		app
+	}
+
+	#[test]
+	fn mark_dirty_if_followed_changed() {
+		let mut app = setup();
+		let entity = app.world_mut().spawn(related!(Followers[()])).id();
+
+		app.update();
+		app.world_mut()
+			.entity_mut(entity)
+			.get_mut::<Followers>()
+			.as_deref_mut();
+		app.update();
+
+		assert_eq!(
+			Some(&IsChanged::TRUE),
+			app.world()
+				.entity(entity)
+				.get::<IsChanged::<FollowStateDirty>>(),
+		);
+	}
+
+	#[test]
+	fn do_not_mark_dirty_if_followed_did_not_change() {
+		let mut app = setup();
+		let entity = app.world_mut().spawn(related!(Followers[()])).id();
+
+		app.update();
+		app.update();
+
+		assert_eq!(
+			Some(&IsChanged::FALSE),
+			app.world()
+				.entity(entity)
+				.get::<IsChanged::<FollowStateDirty>>(),
+		);
+	}
+
+	#[test]
+	fn mark_dirty_if_followed_transform_changed() {
+		let mut app = setup();
+		let entity = app.world_mut().spawn(related!(Followers[()])).id();
+
+		app.update();
+		app.world_mut()
+			.entity_mut(entity)
+			.get_mut::<Transform>()
+			.as_deref_mut();
+		app.update();
+
+		assert_eq!(
+			Some(&IsChanged::TRUE),
+			app.world()
+				.entity(entity)
+				.get::<IsChanged::<FollowStateDirty>>(),
+		);
+	}
+
+	#[test]
+	fn mark_dirty_if_follower_transform_changed() {
+		let mut app = setup();
+		let entity = app.world_mut().spawn_empty().id();
+		let follower = app.world_mut().spawn(Follow(entity)).id();
+
+		app.update();
+		app.world_mut()
+			.entity_mut(follower)
+			.get_mut::<FollowTransform>()
+			.as_deref_mut();
+		app.update();
+
+		assert_eq!(
+			Some(&IsChanged::TRUE),
+			app.world()
+				.entity(entity)
+				.get::<IsChanged::<FollowStateDirty>>(),
+		);
+	}
+}


### PR DESCRIPTION
- `Follower`'s `Transform` and `GlobalTransform` components are now immediately synced
- Also propagate transforms when `FollowerTransform` component changed (addresses discussion in previous PR about not propagating transforms when the follower offset changes)