### PR TITLE
Require `Prefab` component to be immutable

### DIFF
--- a/src/plugins/agents/src/components/enemy/void_sphere.rs
+++ b/src/plugins/agents/src/components/enemy/void_sphere.rs
@@ -37,6 +37,7 @@ use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, f32::consts::PI, sync::LazyLock, time::Duration};
 
 #[derive(Component, Debug, PartialEq, Default, Clone, Serialize, Deserialize)]
+#[component(immutable)]
 #[require(
 	Enemy = Self::enemy(),
 	EnemyAttackConfig = Self::attack_config(),

--- a/src/plugins/agents/src/components/player.rs
+++ b/src/plugins/agents/src/components/player.rs
@@ -21,6 +21,7 @@ use common::{
 use std::sync::LazyLock;
 
 #[derive(Component, Default, Debug, PartialEq, Clone)]
+#[component(immutable)]
 #[require(
 	MovementConfig = PLAYER_RUN.clone(),
 	Name = "Player",

--- a/src/plugins/common/src/traits/prefab.rs
+++ b/src/plugins/common/src/traits/prefab.rs
@@ -2,9 +2,12 @@ mod app;
 mod entity_commands;
 
 use crate::{errors::ErrorData, traits::load_asset::LoadAsset};
-use bevy::{ecs::relationship::RelatedSpawnerCommands, prelude::*};
+use bevy::{
+	ecs::{component::Immutable, relationship::RelatedSpawnerCommands},
+	prelude::*,
+};
 
-pub trait Prefab<TDependency>: Component {
+pub trait Prefab<TDependency>: Component<Mutability = Immutable> {
 	type TError: ErrorData;
 
 	const REAPPLY: Reapply = Reapply::Never;

--- a/src/plugins/common/src/traits/prefab/app.rs
+++ b/src/plugins/common/src/traits/prefab/app.rs
@@ -61,6 +61,7 @@ mod tests {
 	struct _Asset;
 
 	#[derive(Component)]
+	#[component(immutable)]
 	struct _Component {
 		prefab: Result<_Prefab<&'static str>, _Error>,
 	}

--- a/src/plugins/graphics/src/components/effect_shaders/damage_effect_shaders.rs
+++ b/src/plugins/graphics/src/components/effect_shaders/damage_effect_shaders.rs
@@ -9,6 +9,7 @@ use common::{
 };
 
 #[derive(Component, Debug, PartialEq, Default)]
+#[component(immutable)]
 pub struct DamageEffectShaders;
 
 impl Prefab<()> for DamageEffectShaders {

--- a/src/plugins/map_generation/src/components/wall_cell.rs
+++ b/src/plugins/map_generation/src/components/wall_cell.rs
@@ -16,6 +16,7 @@ use common::{
 };
 
 #[derive(Component, Debug, PartialEq)]
+#[component(immutable)]
 #[require(Transform)]
 pub(crate) struct WallCell;
 

--- a/src/plugins/menu/src/components/start_menu_button.rs
+++ b/src/plugins/menu/src/components/start_menu_button.rs
@@ -18,6 +18,7 @@ use common::{
 };
 
 #[derive(Component, Debug, PartialEq, Default)]
+#[component(immutable)]
 #[require(Button, Node = Self::node())]
 pub(crate) struct StartMenuButton {
 	pub(crate) label: Localized,

--- a/src/plugins/physics/src/components/collider.rs
+++ b/src/plugins/physics/src/components/collider.rs
@@ -20,6 +20,7 @@ pub(crate) struct Colliders(EntityHashSet);
 pub(crate) struct ColliderOf(pub(crate) Entity);
 
 #[derive(Component, Debug, PartialEq, Clone, Copy)]
+#[component(immutable)]
 #[require(Transform)]
 pub(crate) enum ColliderShape {
 	Sphere {


### PR DESCRIPTION
Made `Prefab` components to only work with immutable components.

Prevents silent errors with prefab reapplication when changing a prefab component. Only reinsertion will trigger a prefab reapplication.