### PR TITLE
Immediate beam collider scaling

### DIFF
--- a/src/plugins/physics/src/components/hollow.rs
+++ b/src/plugins/physics/src/components/hollow.rs
@@ -7,3 +7,9 @@ use common::tools::Units;
 pub(crate) struct Hollow {
 	pub(crate) radius: Units,
 }
+
+impl Hollow {
+	pub(crate) fn with_radius(radius: Units) -> Self {
+		Self { radius }
+	}
+}


### PR DESCRIPTION
We replace beam colliders when beam length changes so that rapier does not work with one frame delay through transform changes.