### PR TITLE
Anchors filter out nan translations

### DIFF
--- a/src/plugins/physics/src/components/fix_points.rs
+++ b/src/plugins/physics/src/components/fix_points.rs
@@ -100,6 +100,7 @@ pub enum AnchorError {
 	NoFixPointEntityFor(SkillSpawner),
 	FixPointsMissingOn(PersistentEntity),
 	GlobalTransformMissingOn(Entity),
+	FixPointTranslationNaN(Entity),
 }
 
 impl Display for AnchorError {
@@ -115,6 +116,9 @@ impl Display for AnchorError {
 			}
 			AnchorError::NoFixPointEntityFor(entity) => {
 				write!(f, "{entity:?} missing")
+			}
+			AnchorError::FixPointTranslationNaN(entity) => {
+				write!(f, "{entity:?} translation is NaN")
 			}
 		}
 	}


### PR DESCRIPTION
Game crashed in debug mode sometimes. This was caused by:
- beams anchored to fix point with `NaN` translation
- raycast ray origin used that `NaN` translation
- `rapier` aabb ray intersection computation panicked  due to invalid translation

The cause for the faulty translation is unclear. The fixpoint is part of the agent model's scene and should be moved by bevy's animation systems. So for now we skip anchoring when the translation is faulty and log it. We should investigate, if it occurs multiple times. During testing it occurred - if it occurred - only once per session.