### PR TITLE
Account for height differences in targeted anchored skills

### DIFF
--- a/src/plugins/common/src/traits/handles_skill_physics.rs
+++ b/src/plugins/common/src/traits/handles_skill_physics.rs
@@ -43,10 +43,6 @@ pub trait HandlesPhysicalSkillComponents {
 }
 
 pub trait HandlesNewPhysicalSkill {
-	/// Skill spawner
-	///
-	/// Implementations of this are likely to use [`Commands`]. Insertion of skill components/effects
-	/// and despawning should be handled through this [`SystemParam`].
 	type TSkillSpawnerMut<'world, 'state>: for<'w, 's> SystemParam<Item<'w, 's>: Spawn + Despawn>;
 }
 

--- a/src/plugins/physics/src/components/anchor.rs
+++ b/src/plugins/physics/src/components/anchor.rs
@@ -7,24 +7,24 @@ use common::{
 #[derive(Component, Debug, PartialEq)]
 #[require(Transform, AnchorDirty)]
 pub(crate) struct Anchor {
-	pub(crate) target: PersistentEntity,
-	pub(crate) skill_spawner: SkillSpawner,
-	pub(crate) use_target_rotation: bool,
+	pub(crate) attached_to: PersistentEntity,
+	pub(crate) attach_point: SkillSpawner,
+	pub(crate) use_attached_rotation: bool,
 	pub(crate) persistent: bool,
 }
 
 impl Anchor {
-	pub(crate) fn to_target<TEntity>(target: TEntity) -> AnchorTarget
+	pub(crate) fn attach_to<TEntity>(entity: TEntity) -> AnchorAttachment
 	where
 		TEntity: Into<PersistentEntity>,
 	{
-		AnchorTarget {
-			target: target.into(),
+		AnchorAttachment {
+			attached_to: entity.into(),
 		}
 	}
 
-	pub(crate) fn with_target_rotation(mut self) -> Self {
-		self.use_target_rotation = true;
+	pub(crate) fn with_attached_rotation(mut self) -> Self {
+		self.use_attached_rotation = true;
 		self
 	}
 
@@ -41,7 +41,7 @@ impl Anchor {
 
 impl View<PersistentEntity> for Anchor {
 	fn view(&self) -> PersistentEntity {
-		self.target
+		self.attached_to
 	}
 }
 
@@ -49,16 +49,16 @@ impl View<PersistentEntity> for Anchor {
 #[component(immutable)]
 pub(crate) struct AnchorDirty;
 
-pub(crate) struct AnchorTarget {
-	target: PersistentEntity,
+pub(crate) struct AnchorAttachment {
+	attached_to: PersistentEntity,
 }
 
-impl AnchorTarget {
-	pub(crate) fn on_spawner(self, spawner: SkillSpawner) -> Anchor {
+impl AnchorAttachment {
+	pub(crate) fn on(self, attach_point: SkillSpawner) -> Anchor {
 		Anchor {
-			target: self.target,
-			skill_spawner: spawner,
-			use_target_rotation: false,
+			attached_to: self.attached_to,
+			attach_point,
+			use_attached_rotation: false,
 			persistent: false,
 		}
 	}

--- a/src/plugins/physics/src/components/anchor.rs
+++ b/src/plugins/physics/src/components/anchor.rs
@@ -1,7 +1,10 @@
 use bevy::prelude::*;
 use common::{
 	components::persistent_entity::PersistentEntity,
-	traits::{accessors::get::View, handles_skill_physics::SkillSpawner},
+	traits::{
+		accessors::get::View,
+		handles_skill_physics::{SkillSpawner, SkillTarget},
+	},
 };
 
 #[derive(Component, Debug, PartialEq)]
@@ -9,7 +12,7 @@ use common::{
 pub(crate) struct Anchor {
 	pub(crate) attached_to: PersistentEntity,
 	pub(crate) attach_point: SkillSpawner,
-	pub(crate) use_attached_rotation: bool,
+	pub(crate) rotation: AnchorRotation,
 	pub(crate) persistent: bool,
 }
 
@@ -24,7 +27,12 @@ impl Anchor {
 	}
 
 	pub(crate) fn with_attached_rotation(mut self) -> Self {
-		self.use_attached_rotation = true;
+		self.rotation = AnchorRotation::OfAttachedTo;
+		self
+	}
+
+	pub(crate) fn looking_at(mut self, target: SkillTarget) -> Self {
+		self.rotation = AnchorRotation::LookingAt(target);
 		self
 	}
 
@@ -58,8 +66,15 @@ impl AnchorAttachment {
 		Anchor {
 			attached_to: self.attached_to,
 			attach_point,
-			use_attached_rotation: false,
+			rotation: AnchorRotation::OfMount,
 			persistent: false,
 		}
 	}
+}
+
+#[derive(Debug, PartialEq)]
+pub(crate) enum AnchorRotation {
+	OfMount,
+	OfAttachedTo,
+	LookingAt(SkillTarget),
 }

--- a/src/plugins/physics/src/components/skill/motion.rs
+++ b/src/plugins/physics/src/components/skill/motion.rs
@@ -46,9 +46,9 @@ impl ApplyMotionPrefab for Skill {
 
 				if self.created_from == CreatedFrom::Spawn {
 					entity.try_insert((
-						Anchor::to_target(self.caster.0)
-							.on_spawner(self.spawner)
-							.with_target_rotation()
+						Anchor::attach_to(self.caster.0)
+							.on(self.spawner)
+							.with_attached_rotation()
 							.once(),
 						SetVelocityForward(PROJECTILE_SPEED),
 					));
@@ -58,9 +58,9 @@ impl ApplyMotionPrefab for Skill {
 			}
 			SkillShape::Beam(..) | SkillShape::Shield(..) => {
 				entity.try_insert(
-					Anchor::to_target(self.caster.0)
-						.on_spawner(self.spawner)
-						.with_target_rotation()
+					Anchor::attach_to(self.caster.0)
+						.on(self.spawner)
+						.with_attached_rotation()
 						.always(),
 				);
 

--- a/src/plugins/physics/src/components/skill/motion.rs
+++ b/src/plugins/physics/src/components/skill/motion.rs
@@ -48,7 +48,7 @@ impl ApplyMotionPrefab for Skill {
 					entity.try_insert((
 						Anchor::attach_to(self.caster.0)
 							.on(self.spawner)
-							.with_attached_rotation()
+							.looking_at(self.target)
 							.once(),
 						SetVelocityForward(PROJECTILE_SPEED),
 					));
@@ -56,7 +56,17 @@ impl ApplyMotionPrefab for Skill {
 
 				RigidBody::Dynamic
 			}
-			SkillShape::Beam(..) | SkillShape::Shield(..) => {
+			SkillShape::Beam(..) => {
+				entity.try_insert(
+					Anchor::attach_to(self.caster.0)
+						.on(self.spawner)
+						.looking_at(self.target)
+						.always(),
+				);
+
+				RigidBody::Fixed
+			}
+			SkillShape::Shield(..) => {
 				entity.try_insert(
 					Anchor::attach_to(self.caster.0)
 						.on(self.spawner)

--- a/src/plugins/physics/src/lib.rs
+++ b/src/plugins/physics/src/lib.rs
@@ -188,7 +188,7 @@ where
 			.add_message::<BeamInteraction>()
 			.init_resource::<OngoingInteractions>()
 			// Anchor
-			.add_observer(AnchorDirty::process.pipe(OnError::log))
+			.add_observer(AnchorDirty::process::<RayCaster>.pipe(OnError::log))
 			.add_systems(Update, Anchor::mark_dirty.in_set(PhysicsSystems))
 			.add_systems(
 				Update,

--- a/src/plugins/physics/src/observers/process_dirty_anchor.rs
+++ b/src/plugins/physics/src/observers/process_dirty_anchor.rs
@@ -1,5 +1,5 @@
 use crate::{
-	components::anchor::{Anchor, AnchorDirty},
+	components::anchor::{Anchor, AnchorDirty, AnchorRotation},
 	system_params::mount_points_lookup::{MountPointsLookup, get_mount_point::MountPointError},
 	traits::get_mount_point::GetMountPoint,
 };
@@ -12,27 +12,33 @@ use common::{
 	errors::{ErrorData, Level},
 	traits::{
 		accessors::get::{Get, TryApplyOn},
-		handles_skill_physics::SkillSpawner,
+		handles_physics::{MouseHover, MouseHoversOver, Raycast},
+		handles_skill_physics::{SkillSpawner, SkillTarget},
 	},
 	zyheeda_commands::ZyheedaCommands,
 };
 use std::fmt::Display;
 
 impl AnchorDirty {
-	pub(crate) fn process(
+	pub(crate) fn process<TRayCaster>(
 		on_add: On<Add, Self>,
 		commands: ZyheedaCommands,
 		lookup: StaticSystemParam<MountPointsLookup<SkillSpawner>>,
+		ray_caster: StaticSystemParam<TRayCaster>,
 		agents: Query<(&Anchor, &mut Transform)>,
 		transforms: Query<&GlobalTransform>,
-	) -> Result<(), AnchorError<MountPointError<SkillSpawner>>> {
-		Self::system_internal(on_add, commands, lookup, agents, transforms)
+	) -> Result<(), AnchorError<MountPointError<SkillSpawner>>>
+	where
+		TRayCaster: for<'w, 's> SystemParam<Item<'w, 's>: Raycast<MouseHover>>,
+	{
+		Self::system_internal(on_add, commands, lookup, ray_caster, agents, transforms)
 	}
 
-	fn system_internal<TLookup, TMountError>(
+	fn system_internal<TLookup, TRayCaster, TMountError>(
 		on_add: On<Add, Self>,
 		mut commands: ZyheedaCommands,
 		mut lookup: StaticSystemParam<TLookup>,
+		mut ray_caster: StaticSystemParam<TRayCaster>,
 		mut agents: Query<(&Anchor, &mut Transform)>,
 		transforms: Query<&GlobalTransform>,
 	) -> Result<(), AnchorError<TMountError>>
@@ -40,6 +46,7 @@ impl AnchorDirty {
 		TLookup: for<'w, 's> SystemParam<
 			Item<'w, 's>: GetMountPoint<SkillSpawner, TError = TMountError>,
 		>,
+		TRayCaster: for<'w, 's> SystemParam<Item<'w, 's>: Raycast<MouseHover>>,
 	{
 		let Ok((anchor, mut anchor_transform)) = agents.get_mut(on_add.entity) else {
 			return Ok(());
@@ -54,7 +61,7 @@ impl AnchorDirty {
 		});
 
 		let Some(attached_to) = commands.get(&anchor.attached_to) else {
-			return Err(AnchorError::AttachedToNotFound(anchor.attached_to));
+			return Err(AnchorError::EntityNotFound(anchor.attached_to));
 		};
 
 		let mount = match lookup.get_mount_point(attached_to, anchor.attach_point) {
@@ -63,24 +70,59 @@ impl AnchorDirty {
 		};
 
 		let Ok(attached_to_transform) = transforms.get(attached_to) else {
-			return Err(AnchorError::AttachedToNoTransform(anchor.attached_to));
+			return Err(AnchorError::PersistentEntityWithoutTransform(
+				anchor.attached_to,
+			));
 		};
 
 		let Ok(mount_transform) = transforms.get(mount) else {
-			return Err(AnchorError::MountHasNoTransform(mount));
+			return Err(AnchorError::EntityWithoutTransform(mount));
 		};
 
 		let mount_translation = mount_transform.translation();
 		if mount_translation.is_nan() {
-			return Err(AnchorError::MountTranslationIsNan(mount));
+			return Err(AnchorError::TranslationNaN(mount));
 		}
 
 		anchor_transform.translation = mount_translation;
-		let rotation = match anchor.use_attached_rotation {
-			true => attached_to_transform.rotation(),
-			false => mount_transform.rotation(),
+		match anchor.rotation {
+			AnchorRotation::OfAttachedTo => {
+				anchor_transform.rotation = attached_to_transform.rotation();
+			}
+			AnchorRotation::OfMount => {
+				anchor_transform.rotation = mount_transform.rotation();
+			}
+			AnchorRotation::LookingAt(SkillTarget::Cursor) => {
+				let hover = MouseHover {
+					exclude: vec![attached_to],
+				};
+				let Some(hit) = ray_caster.raycast(hover) else {
+					return Ok(());
+				};
+				let target = match hit {
+					MouseHoversOver::Terrain { point } => point,
+					MouseHoversOver::Object { entity, .. } => {
+						let Ok(target) = transforms.get(entity) else {
+							return Err(AnchorError::EntityWithoutTransform(entity));
+						};
+
+						target.translation()
+					}
+				};
+
+				anchor_transform.look_at(target, Vec3::Y);
+			}
+			AnchorRotation::LookingAt(SkillTarget::Entity(entity)) => {
+				let Some(target) = commands.get(&entity) else {
+					return Err(AnchorError::EntityNotFound(entity));
+				};
+				let Ok(target) = transforms.get(target) else {
+					return Err(AnchorError::EntityWithoutTransform(target));
+				};
+
+				anchor_transform.look_at(target.translation(), Vec3::Y);
+			}
 		};
-		anchor_transform.rotation = rotation;
 
 		Ok(())
 	}
@@ -89,10 +131,10 @@ impl AnchorDirty {
 #[derive(Debug, PartialEq)]
 pub(crate) enum AnchorError<TMountError> {
 	MountError(TMountError),
-	AttachedToNotFound(PersistentEntity),
-	AttachedToNoTransform(PersistentEntity),
-	MountHasNoTransform(Entity),
-	MountTranslationIsNan(Entity),
+	EntityNotFound(PersistentEntity),
+	PersistentEntityWithoutTransform(PersistentEntity),
+	EntityWithoutTransform(Entity),
+	TranslationNaN(Entity),
 }
 
 impl<TMountError> Display for AnchorError<TMountError>
@@ -102,10 +144,12 @@ where
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		match self {
 			AnchorError::MountError(error) => write!(f, "{error}"),
-			AnchorError::AttachedToNotFound(e) => write!(f, "{e:?}: Anchor target not found"),
-			AnchorError::AttachedToNoTransform(e) => write!(f, "{e:?}: Has no transform"),
-			AnchorError::MountHasNoTransform(e) => write!(f, "{e}: Has no transform"),
-			AnchorError::MountTranslationIsNan(e) => write!(f, "{e}: Translation is NaN"),
+			AnchorError::EntityNotFound(e) => write!(f, "{e:?}: not found"),
+			AnchorError::PersistentEntityWithoutTransform(e) => {
+				write!(f, "{e:?}: has no transform")
+			}
+			AnchorError::EntityWithoutTransform(e) => write!(f, "{e}: has no transform"),
+			AnchorError::TranslationNaN(e) => write!(f, "{e}: translation is NaN"),
 		}
 	}
 }
@@ -134,12 +178,15 @@ mod tests {
 		components::persistent_entity::PersistentEntity,
 		tools::action_key::slot::SlotKey,
 		traits::{
+			handles_physics::MouseHoversOver,
 			handles_skill_physics::SkillSpawner,
 			register_persistent_entities::RegisterPersistentEntities,
 		},
 	};
+	use macros::NestedMocks;
+	use mockall::{automock, predicate::eq};
 	use std::{collections::HashMap, sync::LazyLock};
-	use testing::SingleThreadedApp;
+	use testing::{NestedMocks, SingleThreadedApp};
 
 	#[derive(Resource)]
 	struct _Lookup {
@@ -161,6 +208,26 @@ mod tests {
 		}
 	}
 
+	#[derive(Resource, NestedMocks)]
+	struct _RayCaster {
+		mock: Mock_RayCaster,
+	}
+
+	impl Default for _RayCaster {
+		fn default() -> Self {
+			Self::new().with_mock(|mock| {
+				mock.expect_raycast().return_const(None);
+			})
+		}
+	}
+
+	#[automock]
+	impl Raycast<MouseHover> for _RayCaster {
+		fn raycast(&mut self, args: MouseHover) -> Option<MouseHoversOver> {
+			self.mock.raycast(args)
+		}
+	}
+
 	#[derive(Debug, PartialEq)]
 	struct _Error;
 
@@ -174,12 +241,13 @@ mod tests {
 
 		app.register_persistent_entities();
 		app.add_observer(
-			AnchorDirty::system_internal::<ResMut<_Lookup>, _Error>.pipe(
+			AnchorDirty::system_internal::<ResMut<_Lookup>, ResMut<_RayCaster>, _Error>.pipe(
 				|In(result), mut commands: Commands| {
 					commands.insert_resource(_Result(result));
 				},
 			),
 		);
+		app.init_resource::<_RayCaster>();
 		app.insert_resource(_Lookup {
 			mount_points: HashMap::default(),
 		});
@@ -243,7 +311,7 @@ mod tests {
 	}
 
 	#[test]
-	fn copy_rotation_of_target() {
+	fn copy_rotation_of_anchor() {
 		let mut app = setup();
 		let spawner_key = SkillSpawner::Slot(SlotKey(22));
 		let agent = app
@@ -269,6 +337,118 @@ mod tests {
 
 		assert_eq!(
 			Some(&Transform::from_xyz(4., 11., 9.).looking_to(Dir3::NEG_Z, Dir3::Y)),
+			anchor.get::<Transform>(),
+		);
+	}
+
+	#[test]
+	fn look_at_target() {
+		let mut app = setup();
+		let spawner_key = SkillSpawner::Slot(SlotKey(22));
+		let agent = app
+			.world_mut()
+			.spawn((*AGENT, GlobalTransform::default()))
+			.id();
+		let mount_point = app
+			.world_mut()
+			.spawn(GlobalTransform::from_xyz(4., 11., 9.))
+			.id();
+		app.insert_resource(_Lookup {
+			mount_points: HashMap::from([((spawner_key, agent), mount_point)]),
+		});
+		let target = PersistentEntity::default();
+		app.world_mut()
+			.spawn((target, GlobalTransform::from_xyz(11., -20., 3.)));
+
+		let anchor = app.world_mut().spawn(
+			Anchor::attach_to(*AGENT)
+				.on(spawner_key)
+				.looking_at(SkillTarget::Entity(target)),
+		);
+
+		assert_eq!(
+			Some(&Transform::from_xyz(4., 11., 9.).looking_at(Vec3::new(11., -20., 3.), Vec3::Y)),
+			anchor.get::<Transform>(),
+		);
+	}
+
+	#[test]
+	fn look_at_cursor_over_terrain() {
+		let mut app = setup();
+		let spawner_key = SkillSpawner::Slot(SlotKey(22));
+		let agent = app
+			.world_mut()
+			.spawn((*AGENT, GlobalTransform::default()))
+			.id();
+		let mount_point = app
+			.world_mut()
+			.spawn(GlobalTransform::from_xyz(4., 11., 9.))
+			.id();
+		app.insert_resource(_Lookup {
+			mount_points: HashMap::from([((spawner_key, agent), mount_point)]),
+		});
+		app.insert_resource(_RayCaster::new().with_mock(|mock| {
+			mock.expect_raycast()
+				.once()
+				.with(eq(MouseHover {
+					exclude: vec![agent],
+				}))
+				.return_const(MouseHoversOver::Terrain {
+					point: Vec3::new(11., 22., 33.),
+				});
+		}));
+
+		let anchor = app.world_mut().spawn(
+			Anchor::attach_to(*AGENT)
+				.on(spawner_key)
+				.looking_at(SkillTarget::Cursor),
+		);
+
+		assert_eq!(
+			Some(&Transform::from_xyz(4., 11., 9.).looking_at(Vec3::new(11., 22., 33.), Vec3::Y)),
+			anchor.get::<Transform>(),
+		);
+	}
+
+	#[test]
+	fn look_at_cursor_over_object() {
+		let mut app = setup();
+		let spawner_key = SkillSpawner::Slot(SlotKey(22));
+		let agent = app
+			.world_mut()
+			.spawn((*AGENT, GlobalTransform::default()))
+			.id();
+		let mount_point = app
+			.world_mut()
+			.spawn(GlobalTransform::from_xyz(4., 11., 9.))
+			.id();
+		app.insert_resource(_Lookup {
+			mount_points: HashMap::from([((spawner_key, agent), mount_point)]),
+		});
+		let target = app
+			.world_mut()
+			.spawn(GlobalTransform::from_xyz(11., 22., 33.))
+			.id();
+		app.insert_resource(_RayCaster::new().with_mock(|mock| {
+			mock.expect_raycast()
+				.once()
+				.with(eq(MouseHover {
+					exclude: vec![agent],
+				}))
+				.return_const(MouseHoversOver::Object {
+					entity: target,
+					point: Vec3::ZERO,
+				});
+		}));
+
+		let anchor = app.world_mut().spawn(
+			Anchor::attach_to(*AGENT)
+				.on(spawner_key)
+				.looking_at(SkillTarget::Cursor),
+		);
+
+		assert_eq!(
+			Some(&Transform::from_xyz(4., 11., 9.).looking_at(Vec3::new(11., 22., 33.), Vec3::Y)),
 			anchor.get::<Transform>(),
 		);
 	}
@@ -423,7 +603,7 @@ mod tests {
 			.spawn(Anchor::attach_to(*AGENT).on(spawner_key));
 
 		assert_eq!(
-			&_Result(Err(AnchorError::AttachedToNotFound(*AGENT))),
+			&_Result(Err(AnchorError::EntityNotFound(*AGENT))),
 			app.world().resource::<_Result>(),
 		);
 	}
@@ -457,7 +637,7 @@ mod tests {
 			.spawn(Anchor::attach_to(*AGENT).on(spawner_key));
 
 		assert_eq!(
-			&_Result(Err(AnchorError::AttachedToNoTransform(*AGENT))),
+			&_Result(Err(AnchorError::PersistentEntityWithoutTransform(*AGENT))),
 			app.world().resource::<_Result>(),
 		);
 	}
@@ -479,7 +659,7 @@ mod tests {
 			.spawn(Anchor::attach_to(*AGENT).on(spawner_key));
 
 		assert_eq!(
-			&_Result(Err(AnchorError::MountHasNoTransform(mount_point))),
+			&_Result(Err(AnchorError::EntityWithoutTransform(mount_point))),
 			app.world().resource::<_Result>(),
 		);
 	}
@@ -504,7 +684,7 @@ mod tests {
 			.spawn(Anchor::attach_to(*AGENT).on(spawner_key));
 
 		assert_eq!(
-			&_Result(Err(AnchorError::MountTranslationIsNan(mount_point))),
+			&_Result(Err(AnchorError::TranslationNaN(mount_point))),
 			app.world().resource::<_Result>(),
 		);
 	}

--- a/src/plugins/physics/src/observers/process_dirty_anchor.rs
+++ b/src/plugins/physics/src/observers/process_dirty_anchor.rs
@@ -53,32 +53,32 @@ impl AnchorDirty {
 			}
 		});
 
-		let Some(target) = commands.get(&anchor.target) else {
-			return Err(AnchorError::TargetNotFound(anchor.target));
+		let Some(attached_to) = commands.get(&anchor.attached_to) else {
+			return Err(AnchorError::AttachedToNotFound(anchor.attached_to));
 		};
 
-		let mount_point = match lookup.get_mount_point(target, anchor.skill_spawner) {
-			Ok(mount_point) => mount_point,
+		let mount = match lookup.get_mount_point(attached_to, anchor.attach_point) {
+			Ok(mount) => mount,
 			Err(error) => return Err(AnchorError::MountError(error)),
 		};
 
-		let Ok(target_transform) = transforms.get(target) else {
-			return Err(AnchorError::RootHasNoTransform(anchor.target));
+		let Ok(attached_to_transform) = transforms.get(attached_to) else {
+			return Err(AnchorError::AttachedToNoTransform(anchor.attached_to));
 		};
 
-		let Ok(mount_point_transform) = transforms.get(mount_point) else {
-			return Err(AnchorError::MountHasNoTransform(mount_point));
+		let Ok(mount_transform) = transforms.get(mount) else {
+			return Err(AnchorError::MountHasNoTransform(mount));
 		};
 
-		let mount_point_translation = mount_point_transform.translation();
-		if mount_point_translation.is_nan() {
-			return Err(AnchorError::MountTranslationIsNan(mount_point));
+		let mount_translation = mount_transform.translation();
+		if mount_translation.is_nan() {
+			return Err(AnchorError::MountTranslationIsNan(mount));
 		}
 
-		anchor_transform.translation = mount_point_translation;
-		let rotation = match anchor.use_target_rotation {
-			true => target_transform.rotation(),
-			false => mount_point_transform.rotation(),
+		anchor_transform.translation = mount_translation;
+		let rotation = match anchor.use_attached_rotation {
+			true => attached_to_transform.rotation(),
+			false => mount_transform.rotation(),
 		};
 		anchor_transform.rotation = rotation;
 
@@ -89,8 +89,8 @@ impl AnchorDirty {
 #[derive(Debug, PartialEq)]
 pub(crate) enum AnchorError<TMountError> {
 	MountError(TMountError),
-	TargetNotFound(PersistentEntity),
-	RootHasNoTransform(PersistentEntity),
+	AttachedToNotFound(PersistentEntity),
+	AttachedToNoTransform(PersistentEntity),
 	MountHasNoTransform(Entity),
 	MountTranslationIsNan(Entity),
 }
@@ -102,8 +102,8 @@ where
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		match self {
 			AnchorError::MountError(error) => write!(f, "{error}"),
-			AnchorError::TargetNotFound(e) => write!(f, "{e:?}: Anchor target not found"),
-			AnchorError::RootHasNoTransform(e) => write!(f, "{e:?}: Has no transform"),
+			AnchorError::AttachedToNotFound(e) => write!(f, "{e:?}: Anchor target not found"),
+			AnchorError::AttachedToNoTransform(e) => write!(f, "{e:?}: Has no transform"),
 			AnchorError::MountHasNoTransform(e) => write!(f, "{e}: Has no transform"),
 			AnchorError::MountTranslationIsNan(e) => write!(f, "{e}: Translation is NaN"),
 		}
@@ -205,7 +205,7 @@ mod tests {
 
 		let anchor = app
 			.world_mut()
-			.spawn(Anchor::to_target(*AGENT).on_spawner(spawner_key))
+			.spawn(Anchor::attach_to(*AGENT).on(spawner_key))
 			.id();
 
 		assert_eq!(
@@ -234,7 +234,7 @@ mod tests {
 
 		let anchor = app
 			.world_mut()
-			.spawn(Anchor::to_target(*AGENT).on_spawner(spawner_key));
+			.spawn(Anchor::attach_to(*AGENT).on(spawner_key));
 
 		assert_eq!(
 			Some(&Transform::from_xyz(4., 11., 9.).looking_to(Dir3::NEG_Z, Dir3::Y)),
@@ -262,9 +262,9 @@ mod tests {
 		});
 
 		let anchor = app.world_mut().spawn(
-			Anchor::to_target(*AGENT)
-				.on_spawner(spawner_key)
-				.with_target_rotation(),
+			Anchor::attach_to(*AGENT)
+				.on(spawner_key)
+				.with_attached_rotation(),
 		);
 
 		assert_eq!(
@@ -296,7 +296,7 @@ mod tests {
 
 		let anchor = app
 			.world_mut()
-			.spawn(Anchor::to_target(*AGENT).on_spawner(spawner_key));
+			.spawn(Anchor::attach_to(*AGENT).on(spawner_key));
 
 		assert_eq!(
 			Some(&Transform::from_xyz(4., 11., 9.)),
@@ -322,7 +322,7 @@ mod tests {
 
 		let anchor = app
 			.world_mut()
-			.spawn(Anchor::to_target(*AGENT).on_spawner(spawner_key).once());
+			.spawn(Anchor::attach_to(*AGENT).on(spawner_key).once());
 
 		assert!(!anchor.contains::<AnchorDirty>());
 	}
@@ -345,7 +345,7 @@ mod tests {
 
 		let anchor = app
 			.world_mut()
-			.spawn(Anchor::to_target(*AGENT).on_spawner(spawner_key).always());
+			.spawn(Anchor::attach_to(*AGENT).on(spawner_key).always());
 
 		assert!(!anchor.contains::<AnchorDirty>());
 	}
@@ -368,7 +368,7 @@ mod tests {
 
 		let anchor = app
 			.world_mut()
-			.spawn(Anchor::to_target(*AGENT).on_spawner(spawner_key).once());
+			.spawn(Anchor::attach_to(*AGENT).on(spawner_key).once());
 
 		assert!(!anchor.contains::<Anchor>());
 	}
@@ -391,7 +391,7 @@ mod tests {
 
 		let anchor = app
 			.world_mut()
-			.spawn(Anchor::to_target(*AGENT).on_spawner(spawner_key).always());
+			.spawn(Anchor::attach_to(*AGENT).on(spawner_key).always());
 
 		assert!(anchor.contains::<Anchor>());
 	}
@@ -403,7 +403,7 @@ mod tests {
 
 		let anchor = app
 			.world_mut()
-			.spawn(Anchor::to_target(*AGENT).on_spawner(spawner_key).once());
+			.spawn(Anchor::attach_to(*AGENT).on(spawner_key).once());
 
 		assert_eq!(
 			(false, false),
@@ -420,10 +420,10 @@ mod tests {
 		let spawner_key = SkillSpawner::Slot(SlotKey(22));
 
 		app.world_mut()
-			.spawn(Anchor::to_target(*AGENT).on_spawner(spawner_key));
+			.spawn(Anchor::attach_to(*AGENT).on(spawner_key));
 
 		assert_eq!(
-			&_Result(Err(AnchorError::TargetNotFound(*AGENT))),
+			&_Result(Err(AnchorError::AttachedToNotFound(*AGENT))),
 			app.world().resource::<_Result>(),
 		);
 	}
@@ -435,7 +435,7 @@ mod tests {
 		app.world_mut().spawn(*AGENT);
 
 		app.world_mut()
-			.spawn(Anchor::to_target(*AGENT).on_spawner(spawner_key));
+			.spawn(Anchor::attach_to(*AGENT).on(spawner_key));
 
 		assert_eq!(
 			&_Result(Err(AnchorError::MountError(_Error))),
@@ -454,10 +454,10 @@ mod tests {
 		});
 
 		app.world_mut()
-			.spawn(Anchor::to_target(*AGENT).on_spawner(spawner_key));
+			.spawn(Anchor::attach_to(*AGENT).on(spawner_key));
 
 		assert_eq!(
-			&_Result(Err(AnchorError::RootHasNoTransform(*AGENT))),
+			&_Result(Err(AnchorError::AttachedToNoTransform(*AGENT))),
 			app.world().resource::<_Result>(),
 		);
 	}
@@ -476,7 +476,7 @@ mod tests {
 		});
 
 		app.world_mut()
-			.spawn(Anchor::to_target(*AGENT).on_spawner(spawner_key));
+			.spawn(Anchor::attach_to(*AGENT).on(spawner_key));
 
 		assert_eq!(
 			&_Result(Err(AnchorError::MountHasNoTransform(mount_point))),
@@ -501,7 +501,7 @@ mod tests {
 		});
 
 		app.world_mut()
-			.spawn(Anchor::to_target(*AGENT).on_spawner(spawner_key));
+			.spawn(Anchor::attach_to(*AGENT).on(spawner_key));
 
 		assert_eq!(
 			&_Result(Err(AnchorError::MountTranslationIsNan(mount_point))),

--- a/src/plugins/physics/src/systems/mark_anchor_dirty.rs
+++ b/src/plugins/physics/src/systems/mark_anchor_dirty.rs
@@ -41,7 +41,7 @@ mod tests {
 		let mut app = setup();
 		let entity = app
 			.world_mut()
-			.spawn(Anchor::to_target(PersistentEntity::default()).on_spawner(SkillSpawner::Neutral))
+			.spawn(Anchor::attach_to(PersistentEntity::default()).on(SkillSpawner::Neutral))
 			.remove::<AnchorDirty>()
 			.id();
 
@@ -68,7 +68,7 @@ mod tests {
 		let mut app = setup();
 		let entity = app
 			.world_mut()
-			.spawn(Anchor::to_target(PersistentEntity::default()).on_spawner(SkillSpawner::Neutral))
+			.spawn(Anchor::attach_to(PersistentEntity::default()).on(SkillSpawner::Neutral))
 			.remove::<AnchorDirty>()
 			.id();
 
@@ -86,7 +86,7 @@ mod tests {
 		let mut app = setup();
 		let entity = app
 			.world_mut()
-			.spawn(Anchor::to_target(PersistentEntity::default()).on_spawner(SkillSpawner::Neutral))
+			.spawn(Anchor::attach_to(PersistentEntity::default()).on(SkillSpawner::Neutral))
 			.remove::<AnchorDirty>()
 			.id();
 


### PR DESCRIPTION
Anchored targeted skills (beam, projectile) now have their forward direction set towards the skill's target.

We currently employ a naive approach for cursor targets and set the target to the exact cursor intersection point when hitting terrain. We will need to adopt a more sophisticated approach (custom ray-cast?) to make the targeting experience more natural.