### PR TITLE
Rework animation system param traits

### DIFF
--- a/src/plugins/agents/src/lib.rs
+++ b/src/plugins/agents/src/lib.rs
@@ -178,8 +178,7 @@ where
 					Player::animate_movement::<
 						MovementSystemParam<TMovement>,
 						AnimationsSystemParamMut<TAnimations>,
-					>
-						.pipe(OnError::log),
+					>,
 					Player::use_skills::<InputSystemParam<TInput>, LoadoutActivityMutParam<TLoadout>>,
 				)
 					.chain(),
@@ -190,8 +189,7 @@ where
 					Enemy::animate_movement::<
 						MovementSystemParam<TMovement>,
 						AnimationsSystemParamMut<TAnimations>,
-					>
-						.pipe(OnError::log),
+					>,
 					ring_rotation,
 					Enemy::begin_attack,
 					Enemy::hold_attack::<LoadoutActivityMutParam<TLoadout>>,
@@ -202,8 +200,7 @@ where
 				AgentConfig::animate_skills::<
 					LoadoutActivityParam<TLoadout>,
 					AnimationsSystemParamMut<TAnimations>,
-				>
-					.pipe(OnError::log),
+				>,
 			)
 				.chain()
 				.run_if(in_state(GameState::Play))

--- a/src/plugins/agents/src/systems/agent_config/animate_idle.rs
+++ b/src/plugins/agents/src/systems/agent_config/animate_idle.rs
@@ -22,11 +22,8 @@ impl AnimateIdle {
 			let Some(mut animations) = TAnimations::get_context_mut(&mut animations, key) else {
 				continue;
 			};
-			let Ok(movement_animations) = animations.active_animations_mut(Idle) else {
-				continue;
-			};
 
-			*movement_animations = HashSet::from([AnimationKey::Idle]);
+			*animations.active_animations_mut(Idle) = HashSet::from([AnimationKey::Idle]);
 			commands.try_apply_on(&entity, |mut e| {
 				e.try_remove::<Self>();
 			});
@@ -69,7 +66,7 @@ mod test {
 		app.update();
 
 		assert_eq!(
-			Some(&_Animations::Prepared(HashMap::from([(
+			Some(&_Animations(HashMap::from([(
 				Idle.into(),
 				HashSet::from([AnimationKey::Idle])
 			)]))),
@@ -84,7 +81,7 @@ mod test {
 			.world_mut()
 			.spawn((
 				AnimateIdle,
-				_Animations::Prepared(HashMap::from([(
+				_Animations(HashMap::from([(
 					Idle.into(),
 					HashSet::from([AnimationKey::Walk]),
 				)])),
@@ -94,7 +91,7 @@ mod test {
 		app.update();
 
 		assert_eq!(
-			Some(&_Animations::Prepared(HashMap::from([(
+			Some(&_Animations(HashMap::from([(
 				Idle.into(),
 				HashSet::from([AnimationKey::Idle])
 			)]))),
@@ -132,22 +129,6 @@ mod test {
 	fn do_not_remove_animate_idle_component_when_animations_for_entity_are_missing() {
 		let mut app = setup();
 		let entity = app.world_mut().spawn(AnimateIdle).id();
-
-		app.update();
-
-		assert_eq!(
-			Some(&AnimateIdle),
-			app.world().entity(entity).get::<AnimateIdle>(),
-		);
-	}
-
-	#[test]
-	fn do_not_remove_animate_idle_component_when_animations_unprepared() {
-		let mut app = setup();
-		let entity = app.world_mut().spawn(AnimateIdle).id();
-		app.world_mut()
-			.entity_mut(entity)
-			.insert(_Animations::Unprepared(entity));
 
 		app.update();
 

--- a/src/plugins/agents/src/systems/agent_config/animate_skills.rs
+++ b/src/plugins/agents/src/systems/agent_config/animate_skills.rs
@@ -2,13 +2,7 @@ use crate::components::agent_config::AgentConfig;
 use bevy::{ecs::system::StaticSystemParam, prelude::*};
 use common::traits::{
 	accessors::get::{GetChangedContext, GetContext, GetContextMut},
-	handles_animations::{
-		ActiveAnimationsMut,
-		AnimationKey,
-		AnimationPriority,
-		Animations,
-		AnimationsUnprepared,
-	},
+	handles_animations::{ActiveAnimationsMut, AnimationKey, AnimationPriority, Animations},
 	handles_loadout::{ActiveSkill, ActiveSkills, skills::Skills},
 };
 
@@ -17,47 +11,36 @@ impl AgentConfig {
 		loadout: StaticSystemParam<TLoadout>,
 		mut animations: StaticSystemParam<TAnimations>,
 		agents: Query<Entity, With<Self>>,
-	) -> Result<(), Vec<AnimationsUnprepared>>
-	where
+	) where
 		TLoadout: for<'c> GetContext<Skills, TContext<'c>: ActiveSkills>,
 		TAnimations: for<'c> GetContextMut<Animations, TContext<'c>: ActiveAnimationsMut>,
 	{
-		let errors = agents
-			.iter()
-			.filter_map(|entity| {
-				let key = Skills { entity };
-				let loadout = TLoadout::get_changed_context(&loadout, key)?;
+		for entity in agents {
+			let key = Skills { entity };
+			let Some(loadout) = TLoadout::get_changed_context(&loadout, key) else {
+				continue;
+			};
 
-				let key = Animations { entity };
-				let mut animations = TAnimations::get_context_mut(&mut animations, key)?;
+			let key = Animations { entity };
+			let Some(mut animations) = TAnimations::get_context_mut(&mut animations, key) else {
+				continue;
+			};
 
-				let active_animations = match animations.active_animations_mut(SkillAnimations) {
-					Ok(active_animations) => active_animations,
-					Err(error) => return Some(error),
-				};
+			let active_animations = animations.active_animations_mut(SkillAnimations);
 
-				let mut skills_to_animate = loadout.active_skills().filter(should_animate);
-				match skills_to_animate.next() {
-					Some(first) => {
-						active_animations.insert(AnimationKey::Skill(first.key));
-						for remaining in skills_to_animate {
-							active_animations.insert(AnimationKey::Skill(remaining.key));
-						}
-					}
-					None => {
-						active_animations.clear();
+			let mut skills_to_animate = loadout.active_skills().filter(should_animate);
+			match skills_to_animate.next() {
+				Some(first) => {
+					active_animations.insert(AnimationKey::Skill(first.key));
+					for remaining in skills_to_animate {
+						active_animations.insert(AnimationKey::Skill(remaining.key));
 					}
 				}
-
-				None
-			})
-			.collect::<Vec<_>>();
-
-		if !errors.is_empty() {
-			return Err(errors);
+				None => {
+					active_animations.clear();
+				}
+			}
 		}
-
-		Ok(())
 	}
 }
 
@@ -75,12 +58,11 @@ impl From<SkillAnimations> for AnimationPriority {
 
 #[cfg(test)]
 mod tests {
+	use super::*;
 	use crate::{
 		assets::agent_config::AgentConfigAsset,
 		systems::player::animate_movement::tests::_Animations,
 	};
-
-	use super::*;
 	use common::{
 		tools::action_key::slot::SlotKey,
 		traits::{
@@ -111,19 +93,12 @@ mod tests {
 		}
 	}
 
-	#[derive(Resource, Debug, PartialEq)]
-	struct _Result(Result<(), Vec<AnimationsUnprepared>>);
-
 	fn setup() -> App {
 		let mut app = App::new().single_threaded(Update);
 
 		app.add_systems(
 			Update,
-			AgentConfig::animate_skills::<Query<Ref<_Loadout>>, Query<&mut _Animations>>.pipe(
-				|In(result), mut commands: Commands| {
-					commands.insert_resource(_Result(result));
-				},
-			),
+			AgentConfig::animate_skills::<Query<Ref<_Loadout>>, Query<&mut _Animations>>,
 		);
 
 		app
@@ -157,7 +132,7 @@ mod tests {
 		app.update();
 
 		assert_eq!(
-			Some(&_Animations::Prepared(HashMap::from([(
+			Some(&_Animations(HashMap::from([(
 				AnimationPriority::High,
 				HashSet::from([
 					AnimationKey::Skill(SlotKey(42)),
@@ -196,7 +171,7 @@ mod tests {
 		app.update();
 
 		assert_eq!(
-			Some(&_Animations::Prepared(HashMap::from([(
+			Some(&_Animations(HashMap::from([(
 				AnimationPriority::High,
 				HashSet::from([AnimationKey::Skill(SlotKey(42))])
 			)]))),
@@ -214,7 +189,7 @@ mod tests {
 					config_handle: new_handle::<AgentConfigAsset>(),
 				},
 				_Loadout { active: vec![] },
-				_Animations::Prepared(HashMap::from([
+				_Animations(HashMap::from([
 					(AnimationPriority::Low, HashSet::from([AnimationKey::Idle])),
 					(
 						AnimationPriority::Medium,
@@ -234,7 +209,7 @@ mod tests {
 		app.update();
 
 		assert_eq!(
-			Some(&_Animations::Prepared(HashMap::from([
+			Some(&_Animations(HashMap::from([
 				(AnimationPriority::Low, HashSet::from([AnimationKey::Idle])),
 				(
 					AnimationPriority::Medium,
@@ -329,35 +304,11 @@ mod tests {
 		app.update();
 
 		assert_eq!(
-			Some(&_Animations::Prepared(HashMap::from([(
+			Some(&_Animations(HashMap::from([(
 				AnimationPriority::High,
 				HashSet::from([AnimationKey::Skill(SlotKey(42))])
 			)]))),
 			app.world().entity(entity).get::<_Animations>(),
-		);
-	}
-
-	#[test]
-	fn return_errors() {
-		let mut app = setup();
-		let entity = app
-			.world_mut()
-			.spawn((
-				AgentConfig {
-					config_handle: new_handle::<AgentConfigAsset>(),
-				},
-				_Loadout { active: vec![] },
-			))
-			.id();
-		app.world_mut()
-			.entity_mut(entity)
-			.insert(_Animations::Unprepared(entity));
-
-		app.update();
-
-		assert_eq!(
-			&_Result(Err(vec![AnimationsUnprepared { entity }])),
-			app.world().resource::<_Result>(),
 		);
 	}
 }

--- a/src/plugins/agents/src/systems/agent_config/apply_config_system.rs
+++ b/src/plugins/agents/src/systems/agent_config/apply_config_system.rs
@@ -14,7 +14,7 @@ use common::{
 	tools::{Units, action_key::slot::SlotKey, inventory_key::InventoryKey},
 	traits::{
 		accessors::get::{GetContextMut, TryApplyOn},
-		handles_animations::{Animations, RegisterAnimations},
+		handles_animations::{RegisterAnimations, WithoutAnimations},
 		handles_loadout::{
 			LoadoutKey,
 			insert_default_loadout::{InsertDefaultLoadout, NotLoadedOut},
@@ -60,8 +60,8 @@ impl ApplyAgentConfig {
 			+ for<'c> GetContextMut<NoBonesRegistered, TContext<'c>: RegisterLoadoutBones>,
 		TSkills:
 			SystemParam + for<'c> GetContextMut<SkillSpawnPoints, TContext<'c>: RegisterDefinition>,
-		TAnimations:
-			SystemParam + for<'c> GetContextMut<Animations, TContext<'c>: RegisterAnimations>,
+		TAnimations: SystemParam
+			+ for<'c> GetContextMut<WithoutAnimations, TContext<'c>: RegisterAnimations>,
 		TMovement: SystemParam
 			+ for<'c> GetContextMut<NotConfiguredMovement, TContext<'c>: ConfigureMovement>,
 		TPhysics: SystemParam
@@ -92,7 +92,7 @@ impl ApplyAgentConfig {
 				ctx.register_definition(config.bones.spawners.clone());
 			};
 
-			let animations = Animations { entity };
+			let animations = WithoutAnimations { entity };
 			if let Some(mut ctx) = TAnimations::get_context_mut(&mut animations_param, animations) {
 				ctx.register_animations(&config.animations, &config.animation_mask_groups);
 			}

--- a/src/plugins/agents/src/systems/enemy/animate_movement.rs
+++ b/src/plugins/agents/src/systems/enemy/animate_movement.rs
@@ -2,7 +2,7 @@ use crate::{components::enemy::Enemy, systems::player::animate_movement::Move};
 use bevy::{ecs::system::StaticSystemParam, prelude::*};
 use common::traits::{
 	accessors::get::{GetChangedContext, GetContext, GetContextMut, View},
-	handles_animations::{ActiveAnimationsMut, AnimationKey, Animations, AnimationsUnprepared},
+	handles_animations::{ActiveAnimationsMut, AnimationKey, Animations},
 	handles_movement::{Movement, MovementTarget},
 };
 use std::collections::HashSet;
@@ -12,41 +12,28 @@ impl Enemy {
 		movement: StaticSystemParam<TMovement>,
 		mut animations: StaticSystemParam<TAnimations>,
 		enemies: Query<Entity, With<Self>>,
-	) -> Result<(), Vec<AnimationsUnprepared>>
-	where
+	) where
 		TMovement: for<'c> GetContext<Movement, TContext<'c>: View<Option<MovementTarget>>>,
 		TAnimations: for<'c> GetContextMut<Animations, TContext<'c>: ActiveAnimationsMut>,
 	{
-		let animate_movement = |entity| {
+		for entity in enemies {
 			let key = Movement { entity };
-			let movement = TMovement::get_changed_context(&movement, key)?;
+			let Some(movement) = TMovement::get_changed_context(&movement, key) else {
+				continue;
+			};
 
 			let key = Animations { entity };
-			let mut animations = TAnimations::get_context_mut(&mut animations, key)?;
-
-			let movement_animations = match animations.active_animations_mut(Move) {
-				Err(error) => return Some(error),
-				Ok(movement_animations) => movement_animations,
+			let Some(mut animations) = TAnimations::get_context_mut(&mut animations, key) else {
+				continue;
 			};
+
+			let movement_animations = animations.active_animations_mut(Move);
 
 			match movement.view() {
 				Some(_) => *movement_animations = HashSet::from([AnimationKey::Run]),
 				None => movement_animations.clear(),
 			};
-
-			None
-		};
-
-		let errors = enemies
-			.iter()
-			.filter_map(animate_movement)
-			.collect::<Vec<_>>();
-
-		if !errors.is_empty() {
-			return Err(errors);
 		}
-
-		Ok(())
 	}
 }
 
@@ -54,11 +41,7 @@ impl Enemy {
 mod tests {
 	#![allow(clippy::unwrap_used)]
 	use super::*;
-	use crate::systems::player::animate_movement::tests::{
-		_AnimationErrors,
-		_Animations,
-		_Movement,
-	};
+	use crate::systems::player::animate_movement::tests::{_Animations, _Movement};
 	use common::traits::{handles_animations::AnimationKey, handles_movement::MovementTarget};
 	use std::collections::{HashMap, HashSet};
 	use testing::SingleThreadedApp;
@@ -68,15 +51,7 @@ mod tests {
 
 		app.add_systems(
 			Update,
-			Enemy::animate_movement::<Query<Ref<_Movement>>, Query<Mut<_Animations>>>.pipe(
-				|In(errors), mut commands: Commands| {
-					let Err(errors) = errors else {
-						return;
-					};
-
-					commands.insert_resource(_AnimationErrors(errors));
-				},
-			),
+			Enemy::animate_movement::<Query<Ref<_Movement>>, Query<Mut<_Animations>>>,
 		);
 
 		app
@@ -100,7 +75,7 @@ mod tests {
 		app.update();
 
 		assert_eq!(
-			Some(&_Animations::Prepared(HashMap::from([(
+			Some(&_Animations(HashMap::from([(
 				Move.into(),
 				HashSet::from([AnimationKey::Run]),
 			)]))),
@@ -119,7 +94,7 @@ mod tests {
 					target: Some(MovementTarget::Dir(Dir3::X)),
 					..default()
 				},
-				_Animations::Prepared(HashMap::from([(
+				_Animations(HashMap::from([(
 					Move.into(),
 					HashSet::from([AnimationKey::Walk]),
 				)])),
@@ -129,7 +104,7 @@ mod tests {
 		app.update();
 
 		assert_eq!(
-			Some(&_Animations::Prepared(HashMap::from([(
+			Some(&_Animations(HashMap::from([(
 				Move.into(),
 				HashSet::from([AnimationKey::Run]),
 			)]))),
@@ -176,7 +151,7 @@ mod tests {
 					target: Some(MovementTarget::Dir(Dir3::X)),
 					..default()
 				},
-				_Animations::Prepared(HashMap::from([(
+				_Animations(HashMap::from([(
 					Move.into(),
 					HashSet::from([AnimationKey::Run]),
 				)])),
@@ -190,7 +165,7 @@ mod tests {
 		app.update();
 
 		assert_eq!(
-			Some(&_Animations::Prepared(HashMap::from([(
+			Some(&_Animations(HashMap::from([(
 				Move.into(),
 				HashSet::from([])
 			)]))),
@@ -217,31 +192,6 @@ mod tests {
 		assert_eq!(
 			Some(&_Animations::default()),
 			app.world().entity(entity).get::<_Animations>(),
-		);
-	}
-
-	#[test]
-	fn return_error() {
-		let mut app = setup();
-		let entity = app
-			.world_mut()
-			.spawn((
-				Enemy::default(),
-				_Movement {
-					target: Some(MovementTarget::Dir(Dir3::X)),
-					..default()
-				},
-			))
-			.id();
-		app.world_mut()
-			.entity_mut(entity)
-			.insert(_Animations::Unprepared(entity));
-
-		app.update();
-
-		assert_eq!(
-			Some(&_AnimationErrors(vec![AnimationsUnprepared { entity }])),
-			app.world().get_resource::<_AnimationErrors>(),
 		);
 	}
 }

--- a/src/plugins/agents/src/systems/player/animate_movement.rs
+++ b/src/plugins/agents/src/systems/player/animate_movement.rs
@@ -2,13 +2,7 @@ use crate::components::player::Player;
 use bevy::{ecs::system::StaticSystemParam, prelude::*};
 use common::traits::{
 	accessors::get::{GetChangedContext, GetContext, GetContextMut, View, ViewOf},
-	handles_animations::{
-		ActiveAnimationsMut,
-		AnimationKey,
-		AnimationPriority,
-		Animations,
-		AnimationsUnprepared,
-	},
+	handles_animations::{ActiveAnimationsMut, AnimationKey, AnimationPriority, Animations},
 	handles_movement::{CurrentMovement, Movement, MovementTarget, SpeedToggle},
 };
 use std::collections::HashSet;
@@ -18,41 +12,28 @@ impl Player {
 		movement: StaticSystemParam<TMovement>,
 		mut animations: StaticSystemParam<TAnimations>,
 		players: Query<Entity, With<Self>>,
-	) -> Result<(), Vec<AnimationsUnprepared>>
-	where
+	) where
 		TMovement: for<'c> GetContext<Movement, TContext<'c>: CurrentMovement>,
 		TAnimations: for<'c> GetContextMut<Animations, TContext<'c>: ActiveAnimationsMut>,
 	{
-		let animate_movement = |entity| {
+		for entity in players {
 			let key = Movement { entity };
-			let movement = TMovement::get_changed_context(&movement, key)?;
+			let Some(movement) = TMovement::get_changed_context(&movement, key) else {
+				continue;
+			};
 
 			let key = Animations { entity };
-			let mut animations = TAnimations::get_context_mut(&mut animations, key)?;
-
-			let movement_animations = match animations.active_animations_mut(Move) {
-				Err(error) => return Some(error),
-				Ok(movement_animations) => movement_animations,
+			let Some(mut animations) = TAnimations::get_context_mut(&mut animations, key) else {
+				continue;
 			};
+
+			let movement_animations = animations.active_animations_mut(Move);
 
 			match movement.view_of::<Option<MovementTarget>>() {
 				Some(_) => Self::start_run_or_walk_animation(movement_animations, movement),
 				None => Self::stop_move_animations(movement_animations),
 			}
-
-			None
-		};
-
-		let errors = players
-			.iter()
-			.filter_map(animate_movement)
-			.collect::<Vec<_>>();
-
-		if !errors.is_empty() {
-			return Err(errors);
 		}
-
-		Ok(())
 	}
 
 	fn start_run_or_walk_animation(
@@ -87,12 +68,7 @@ pub(crate) mod tests {
 	use super::*;
 	use common::traits::{
 		accessors::get::View,
-		handles_animations::{
-			ActiveAnimations,
-			AnimationKey,
-			AnimationPriority,
-			AnimationsUnprepared,
-		},
+		handles_animations::{ActiveAnimations, AnimationKey, AnimationPriority},
 		handles_movement::MovementTarget,
 	};
 	use std::{collections::HashMap, sync::LazyLock};
@@ -119,66 +95,33 @@ pub(crate) mod tests {
 
 	static EMPTY: LazyLock<HashSet<AnimationKey>> = LazyLock::new(HashSet::default);
 
-	#[derive(Component, Debug, PartialEq)]
-	pub(crate) enum _Animations {
-		Unprepared(Entity),
-		Prepared(HashMap<AnimationPriority, HashSet<AnimationKey>>),
-	}
-
-	impl Default for _Animations {
-		fn default() -> Self {
-			Self::Prepared(HashMap::default())
-		}
-	}
+	#[derive(Component, Debug, PartialEq, Default)]
+	pub(crate) struct _Animations(pub(crate) HashMap<AnimationPriority, HashSet<AnimationKey>>);
 
 	impl ActiveAnimations for _Animations {
-		fn active_animations<TLayer>(
-			&self,
-			layer: TLayer,
-		) -> Result<&HashSet<AnimationKey>, AnimationsUnprepared>
+		fn active_animations<TLayer>(&self, layer: TLayer) -> &HashSet<AnimationKey>
 		where
 			TLayer: Into<AnimationPriority>,
 		{
-			match self {
-				_Animations::Unprepared(entity) => Err(AnimationsUnprepared { entity: *entity }),
-				_Animations::Prepared(hash_map) => {
-					Ok(hash_map.get(&layer.into()).unwrap_or(&*EMPTY))
-				}
-			}
+			self.0.get(&layer.into()).unwrap_or(&*EMPTY)
 		}
 	}
 
 	impl ActiveAnimationsMut for _Animations {
-		fn active_animations_mut<TLayer>(
-			&mut self,
-			layer: TLayer,
-		) -> Result<&mut HashSet<AnimationKey>, AnimationsUnprepared>
+		fn active_animations_mut<TLayer>(&mut self, layer: TLayer) -> &mut HashSet<AnimationKey>
 		where
 			TLayer: Into<AnimationPriority>,
 		{
-			match self {
-				_Animations::Unprepared(entity) => Err(AnimationsUnprepared { entity: *entity }),
-				_Animations::Prepared(hash_map) => Ok(hash_map.entry(layer.into()).or_default()),
-			}
+			self.0.entry(layer.into()).or_default()
 		}
 	}
-
-	#[derive(Resource, Debug, PartialEq)]
-	pub(crate) struct _AnimationErrors(pub(crate) Vec<AnimationsUnprepared>);
 
 	fn setup() -> App {
 		let mut app = App::new().single_threaded(Update);
 
 		app.add_systems(
 			Update,
-			Player::animate_movement::<Query<Ref<_Movement>>, Query<Mut<_Animations>>>.pipe(
-				|In(errors), mut commands: Commands| {
-					let Err(errors) = errors else {
-						return;
-					};
-					commands.insert_resource(_AnimationErrors(errors));
-				},
-			),
+			Player::animate_movement::<Query<Ref<_Movement>>, Query<Mut<_Animations>>>,
 		);
 
 		app
@@ -203,7 +146,7 @@ pub(crate) mod tests {
 		app.update();
 
 		assert_eq!(
-			Some(&_Animations::Prepared(HashMap::from([(
+			Some(&_Animations(HashMap::from([(
 				Move.into(),
 				HashSet::from([animation])
 			)]))),
@@ -220,7 +163,7 @@ pub(crate) mod tests {
 			.spawn((
 				Player,
 				movement,
-				_Animations::Prepared(HashMap::from([(
+				_Animations(HashMap::from([(
 					Move.into(),
 					HashSet::from([AnimationKey::Idle]),
 				)])),
@@ -230,7 +173,7 @@ pub(crate) mod tests {
 		app.update();
 
 		assert_eq!(
-			Some(&_Animations::Prepared(HashMap::from([(
+			Some(&_Animations(HashMap::from([(
 				Move.into(),
 				HashSet::from([animation])
 			)]))),
@@ -277,7 +220,7 @@ pub(crate) mod tests {
 					target: Some(MovementTarget::Dir(Dir3::X)),
 					..default()
 				},
-				_Animations::Prepared(HashMap::from([(
+				_Animations(HashMap::from([(
 					Move.into(),
 					HashSet::from([AnimationKey::Idle]),
 				)])),
@@ -291,7 +234,7 @@ pub(crate) mod tests {
 		app.update();
 
 		assert_eq!(
-			Some(&_Animations::Prepared(HashMap::from([(
+			Some(&_Animations(HashMap::from([(
 				Move.into(),
 				HashSet::from([]),
 			)])),),
@@ -318,31 +261,6 @@ pub(crate) mod tests {
 		assert_eq!(
 			Some(&_Animations::default()),
 			app.world().entity(entity).get::<_Animations>(),
-		);
-	}
-
-	#[test]
-	fn return_error() {
-		let mut app = setup();
-		let entity = app
-			.world_mut()
-			.spawn((
-				Player,
-				_Movement {
-					target: Some(MovementTarget::Dir(Dir3::X)),
-					..default()
-				},
-			))
-			.id();
-		app.world_mut()
-			.entity_mut(entity)
-			.insert(_Animations::Unprepared(entity));
-
-		app.update();
-
-		assert_eq!(
-			Some(&_AnimationErrors(vec![AnimationsUnprepared { entity }])),
-			app.world().get_resource::<_AnimationErrors>(),
 		);
 	}
 }

--- a/src/plugins/animations/src/components/animation_dispatch.rs
+++ b/src/plugins/animations/src/components/animation_dispatch.rs
@@ -1,7 +1,10 @@
 mod dto;
 
 use crate::{
-	components::animation_dispatch::dto::AnimationDispatchDto,
+	components::{
+		animation_dispatch::dto::AnimationDispatchDto,
+		movement_direction::MovementDirection,
+	},
 	traits::{
 		AnimationPlayers,
 		AnimationPlayersWithoutGraph,
@@ -24,6 +27,7 @@ use std::{
 };
 
 #[derive(Component, SavableComponent, Debug, PartialEq, Clone)]
+#[require(MovementDirection)]
 #[savable_component(id = "animation dispatch", dto = AnimationDispatchDto)]
 pub struct AnimationDispatch {
 	pub(crate) animation_players: HashSet<Entity>,

--- a/src/plugins/animations/src/components/movement_direction.rs
+++ b/src/plugins/animations/src/components/movement_direction.rs
@@ -1,4 +1,4 @@
 use bevy::prelude::*;
 
-#[derive(Component, Debug, PartialEq)]
-pub(crate) struct MovementDirection(pub(crate) Dir3);
+#[derive(Component, Debug, PartialEq, Default)]
+pub(crate) struct MovementDirection(pub(crate) Option<Dir3>);

--- a/src/plugins/animations/src/system_params/animations.rs
+++ b/src/plugins/animations/src/system_params/animations.rs
@@ -10,7 +10,7 @@ use bevy::{ecs::system::SystemParam, prelude::*};
 use common::{
 	traits::{
 		accessors::get::{GetContextMut, GetMut},
-		handles_animations::Animations,
+		handles_animations::{Animations, WithoutAnimations},
 	},
 	zyheeda_commands::{ZyheedaCommands, ZyheedaEntityCommands},
 };
@@ -32,13 +32,41 @@ pub struct AnimationsParamMut<
 	graphs: ResMut<'w, Assets<TAnimationGraph>>,
 }
 
+impl<TAnimationServer, TAnimationGraph> GetContextMut<WithoutAnimations>
+	for AnimationsParamMut<'_, '_, TAnimationServer, TAnimationGraph>
+where
+	TAnimationServer: Resource,
+	TAnimationGraph: Asset,
+{
+	type TContext<'ctx> = AnimationsRegisterContextMut<'ctx, TAnimationServer, TAnimationGraph>;
+
+	fn get_context_mut<'ctx>(
+		param: &'ctx mut AnimationsParamMut<TAnimationServer, TAnimationGraph>,
+		WithoutAnimations { entity }: WithoutAnimations,
+	) -> Option<Self::TContext<'ctx>> {
+		if param.dispatchers.contains(entity) {
+			return None;
+		}
+
+		let entity = param.commands.get_mut(&entity)?;
+		let asset_server = &mut param.asset_server;
+		let graphs = &mut param.graphs;
+
+		Some(AnimationsRegisterContextMut {
+			entity,
+			asset_server,
+			graphs,
+		})
+	}
+}
+
 impl<TAnimationServer, TAnimationGraph> GetContextMut<Animations>
 	for AnimationsParamMut<'_, '_, TAnimationServer, TAnimationGraph>
 where
 	TAnimationServer: Resource,
 	TAnimationGraph: Asset,
 {
-	type TContext<'ctx> = AnimationsContextMut<'ctx, TAnimationServer, TAnimationGraph>;
+	type TContext<'ctx> = AnimationsContextMut<'ctx>;
 
 	fn get_context_mut<'ctx>(
 		param: &'ctx mut AnimationsParamMut<TAnimationServer, TAnimationGraph>,
@@ -48,26 +76,29 @@ where
 		let dispatch = param.dispatchers.get_mut(animations.entity).ok();
 		let movement_direction = param.movement_directions.get(animations.entity).ok();
 		let movement_direction = movement_direction.map(|MovementDirection(d)| *d);
-		let asset_server = &mut param.asset_server;
-		let graphs = &mut param.graphs;
 
 		Some(AnimationsContextMut {
 			entity,
 			dispatch,
 			movement_direction,
-			asset_server,
-			graphs,
 		})
 	}
 }
 
-pub struct AnimationsContextMut<'a, TLoadAnimations = AssetServer, TAnimationGraph = AnimationGraph>
-where
+pub struct AnimationsRegisterContextMut<
+	'a,
+	TLoadAnimations = AssetServer,
+	TAnimationGraph = AnimationGraph,
+> where
 	TAnimationGraph: Asset,
 {
 	entity: ZyheedaEntityCommands<'a>,
-	dispatch: Option<Mut<'a, AnimationDispatch>>,
-	movement_direction: Option<Dir3>,
 	asset_server: &'a mut TLoadAnimations,
 	graphs: &'a mut Assets<TAnimationGraph>,
+}
+
+pub struct AnimationsContextMut<'a> {
+	entity: ZyheedaEntityCommands<'a>,
+	dispatch: Option<Mut<'a, AnimationDispatch>>,
+	movement_direction: Option<Dir3>,
 }

--- a/src/plugins/animations/src/system_params/animations.rs
+++ b/src/plugins/animations/src/system_params/animations.rs
@@ -27,8 +27,14 @@ pub struct AnimationsParamMut<
 {
 	commands: ZyheedaCommands<'w, 's>,
 	asset_server: ResMut<'w, TAnimationServer>,
-	dispatchers: Query<'w, 's, &'static mut AnimationDispatch>,
-	movement_directions: Query<'w, 's, &'static MovementDirection>,
+	animators: Query<
+		'w,
+		's,
+		(
+			&'static mut AnimationDispatch,
+			&'static mut MovementDirection,
+		),
+	>,
 	graphs: ResMut<'w, Assets<TAnimationGraph>>,
 }
 
@@ -44,7 +50,7 @@ where
 		param: &'ctx mut AnimationsParamMut<TAnimationServer, TAnimationGraph>,
 		WithoutAnimations { entity }: WithoutAnimations,
 	) -> Option<Self::TContext<'ctx>> {
-		if param.dispatchers.contains(entity) {
+		if param.animators.contains(entity) {
 			return None;
 		}
 
@@ -72,13 +78,9 @@ where
 		param: &'ctx mut AnimationsParamMut<TAnimationServer, TAnimationGraph>,
 		animations: Animations,
 	) -> Option<Self::TContext<'ctx>> {
-		let entity = param.commands.get_mut(&animations.entity)?;
-		let dispatch = param.dispatchers.get_mut(animations.entity).ok()?;
-		let movement_direction = param.movement_directions.get(animations.entity).ok();
-		let movement_direction = movement_direction.map(|MovementDirection(d)| *d);
+		let (dispatch, movement_direction) = param.animators.get_mut(animations.entity).ok()?;
 
 		Some(AnimationsContextMut {
-			entity,
 			dispatch,
 			movement_direction,
 		})
@@ -98,7 +100,6 @@ pub struct AnimationsRegisterContextMut<
 }
 
 pub struct AnimationsContextMut<'a> {
-	entity: ZyheedaEntityCommands<'a>,
 	dispatch: Mut<'a, AnimationDispatch>,
-	movement_direction: Option<Dir3>,
+	movement_direction: Mut<'a, MovementDirection>,
 }

--- a/src/plugins/animations/src/system_params/animations.rs
+++ b/src/plugins/animations/src/system_params/animations.rs
@@ -73,7 +73,7 @@ where
 		animations: Animations,
 	) -> Option<Self::TContext<'ctx>> {
 		let entity = param.commands.get_mut(&animations.entity)?;
-		let dispatch = param.dispatchers.get_mut(animations.entity).ok();
+		let dispatch = param.dispatchers.get_mut(animations.entity).ok()?;
 		let movement_direction = param.movement_directions.get(animations.entity).ok();
 		let movement_direction = movement_direction.map(|MovementDirection(d)| *d);
 
@@ -99,6 +99,6 @@ pub struct AnimationsRegisterContextMut<
 
 pub struct AnimationsContextMut<'a> {
 	entity: ZyheedaEntityCommands<'a>,
-	dispatch: Option<Mut<'a, AnimationDispatch>>,
+	dispatch: Mut<'a, AnimationDispatch>,
 	movement_direction: Option<Dir3>,
 }

--- a/src/plugins/animations/src/system_params/animations/active_animations.rs
+++ b/src/plugins/animations/src/system_params/animations/active_animations.rs
@@ -8,7 +8,7 @@ use common::traits::handles_animations::{
 };
 use std::collections::HashSet;
 
-impl<TServer> ActiveAnimations for AnimationsContextMut<'_, TServer> {
+impl ActiveAnimations for AnimationsContextMut<'_> {
 	fn active_animations<TLayer>(
 		&self,
 		layer: TLayer,
@@ -25,7 +25,7 @@ impl<TServer> ActiveAnimations for AnimationsContextMut<'_, TServer> {
 	}
 }
 
-impl<TServer> ActiveAnimationsMut for AnimationsContextMut<'_, TServer> {
+impl ActiveAnimationsMut for AnimationsContextMut<'_> {
 	fn active_animations_mut<TLayer>(
 		&mut self,
 		layer: TLayer,

--- a/src/plugins/animations/src/system_params/animations/active_animations.rs
+++ b/src/plugins/animations/src/system_params/animations/active_animations.rs
@@ -4,41 +4,24 @@ use common::traits::handles_animations::{
 	ActiveAnimationsMut,
 	AnimationKey,
 	AnimationPriority,
-	AnimationsUnprepared,
 };
 use std::collections::HashSet;
 
 impl ActiveAnimations for AnimationsContextMut<'_> {
-	fn active_animations<TLayer>(
-		&self,
-		layer: TLayer,
-	) -> Result<&HashSet<AnimationKey>, AnimationsUnprepared>
+	fn active_animations<TLayer>(&self, layer: TLayer) -> &HashSet<AnimationKey>
 	where
 		TLayer: Into<AnimationPriority>,
 	{
-		match &self.dispatch {
-			Some(dispatch) => Ok(dispatch.slot(layer)),
-			None => Err(AnimationsUnprepared {
-				entity: self.entity.id(),
-			}),
-		}
+		self.dispatch.slot(layer)
 	}
 }
 
 impl ActiveAnimationsMut for AnimationsContextMut<'_> {
-	fn active_animations_mut<TLayer>(
-		&mut self,
-		layer: TLayer,
-	) -> Result<&mut HashSet<AnimationKey>, AnimationsUnprepared>
+	fn active_animations_mut<TLayer>(&mut self, layer: TLayer) -> &mut HashSet<AnimationKey>
 	where
 		TLayer: Into<AnimationPriority>,
 	{
-		match &mut self.dispatch {
-			Some(dispatch) => Ok(dispatch.slot_mut(layer)),
-			None => Err(AnimationsUnprepared {
-				entity: self.entity.id(),
-			}),
-		}
+		self.dispatch.slot_mut(layer)
 	}
 }
 
@@ -99,7 +82,6 @@ mod tests {
 				let key = Animations { entity };
 				let mut ctx = AnimationsParamMut::get_context_mut(&mut p, key).unwrap();
 				ctx.active_animations_mut(animation_priority)
-					.unwrap()
 					.extend(animations);
 			})?;
 
@@ -127,7 +109,7 @@ mod tests {
 				let ctx = AnimationsParamMut::get_context_mut(&mut p, key).unwrap();
 
 				assert_eq!(
-					Ok(&HashSet::from(animations)),
+					&HashSet::from(animations),
 					ctx.active_animations(animation_priority)
 				);
 			})

--- a/src/plugins/animations/src/system_params/animations/move_direction.rs
+++ b/src/plugins/animations/src/system_params/animations/move_direction.rs
@@ -30,7 +30,10 @@ impl Drop for AnimationsContextMut<'_> {
 mod tests {
 	#![allow(clippy::unwrap_used)]
 	use super::*;
-	use crate::system_params::animations::AnimationsParamMut;
+	use crate::{
+		components::animation_dispatch::AnimationDispatch,
+		system_params::animations::AnimationsParamMut,
+	};
 	use bevy::{
 		animation::graph::AnimationGraph,
 		asset::Assets,
@@ -59,7 +62,11 @@ mod tests {
 		let mut app = setup();
 		let entity = app
 			.world_mut()
-			.spawn((GlobalTransform::default(), MovementDirection(Dir3::NEG_Z)))
+			.spawn((
+				AnimationDispatch::default(),
+				GlobalTransform::default(),
+				MovementDirection(Dir3::NEG_Z),
+			))
 			.id();
 
 		app.world_mut()
@@ -74,7 +81,10 @@ mod tests {
 	#[test]
 	fn set_movement_direction() -> Result<(), RunSystemError> {
 		let mut app = setup();
-		let entity = app.world_mut().spawn(GlobalTransform::default()).id();
+		let entity = app
+			.world_mut()
+			.spawn((AnimationDispatch::default(), GlobalTransform::default()))
+			.id();
 
 		app.world_mut()
 			.run_system_once(move |mut p: AnimationsParamMut<_Server>| {
@@ -95,7 +105,11 @@ mod tests {
 		let mut app = setup();
 		let entity = app
 			.world_mut()
-			.spawn((GlobalTransform::default(), MovementDirection(Dir3::NEG_Z)))
+			.spawn((
+				AnimationDispatch::default(),
+				GlobalTransform::default(),
+				MovementDirection(Dir3::NEG_Z),
+			))
 			.id();
 
 		app.world_mut()

--- a/src/plugins/animations/src/system_params/animations/move_direction.rs
+++ b/src/plugins/animations/src/system_params/animations/move_direction.rs
@@ -1,28 +1,16 @@
-use crate::{
-	components::movement_direction::MovementDirection,
-	system_params::animations::AnimationsContextMut,
-};
+use crate::system_params::animations::AnimationsContextMut;
 use bevy::prelude::*;
 use common::traits::handles_animations::{MoveDirection, MoveDirectionMut};
 
 impl MoveDirection for AnimationsContextMut<'_> {
 	fn move_direction(&self) -> Option<Dir3> {
-		self.movement_direction
+		self.movement_direction.0
 	}
 }
 
 impl MoveDirectionMut for AnimationsContextMut<'_> {
 	fn move_direction_mut(&mut self) -> &mut Option<Dir3> {
-		&mut self.movement_direction
-	}
-}
-
-impl Drop for AnimationsContextMut<'_> {
-	fn drop(&mut self) {
-		match self.movement_direction {
-			Some(dir) => self.entity.try_insert(MovementDirection(dir)),
-			None => self.entity.try_remove::<MovementDirection>(),
-		};
+		&mut self.movement_direction.0
 	}
 }
 
@@ -31,7 +19,10 @@ mod tests {
 	#![allow(clippy::unwrap_used)]
 	use super::*;
 	use crate::{
-		components::animation_dispatch::AnimationDispatch,
+		components::{
+			animation_dispatch::AnimationDispatch,
+			movement_direction::MovementDirection,
+		},
 		system_params::animations::AnimationsParamMut,
 	};
 	use bevy::{
@@ -65,7 +56,7 @@ mod tests {
 			.spawn((
 				AnimationDispatch::default(),
 				GlobalTransform::default(),
-				MovementDirection(Dir3::NEG_Z),
+				MovementDirection(Some(Dir3::NEG_Z)),
 			))
 			.id();
 
@@ -94,7 +85,7 @@ mod tests {
 			})?;
 
 		assert_eq!(
-			Some(&MovementDirection(Dir3::NEG_Z)),
+			Some(&MovementDirection(Some(Dir3::NEG_Z))),
 			app.world().entity(entity).get::<MovementDirection>(),
 		);
 		Ok(())
@@ -108,7 +99,7 @@ mod tests {
 			.spawn((
 				AnimationDispatch::default(),
 				GlobalTransform::default(),
-				MovementDirection(Dir3::NEG_Z),
+				MovementDirection(Some(Dir3::NEG_Z)),
 			))
 			.id();
 
@@ -119,7 +110,10 @@ mod tests {
 				*ctx.move_direction_mut() = None;
 			})?;
 
-		assert_eq!(None, app.world().entity(entity).get::<MovementDirection>());
+		assert_eq!(
+			Some(&MovementDirection(None)),
+			app.world().entity(entity).get::<MovementDirection>()
+		);
 		Ok(())
 	}
 }

--- a/src/plugins/animations/src/system_params/animations/move_direction.rs
+++ b/src/plugins/animations/src/system_params/animations/move_direction.rs
@@ -5,22 +5,19 @@ use crate::{
 use bevy::prelude::*;
 use common::traits::handles_animations::{MoveDirection, MoveDirectionMut};
 
-impl<TServer> MoveDirection for AnimationsContextMut<'_, TServer> {
+impl MoveDirection for AnimationsContextMut<'_> {
 	fn move_direction(&self) -> Option<Dir3> {
 		self.movement_direction
 	}
 }
 
-impl<TServer> MoveDirectionMut for AnimationsContextMut<'_, TServer> {
+impl MoveDirectionMut for AnimationsContextMut<'_> {
 	fn move_direction_mut(&mut self) -> &mut Option<Dir3> {
 		&mut self.movement_direction
 	}
 }
 
-impl<TServer, TAnimationGraph> Drop for AnimationsContextMut<'_, TServer, TAnimationGraph>
-where
-	TAnimationGraph: Asset,
-{
+impl Drop for AnimationsContextMut<'_> {
 	fn drop(&mut self) {
 		match self.movement_direction {
 			Some(dir) => self.entity.try_insert(MovementDirection(dir)),

--- a/src/plugins/animations/src/system_params/animations/register_animations.rs
+++ b/src/plugins/animations/src/system_params/animations/register_animations.rs
@@ -3,7 +3,7 @@ use crate::{
 		animation_dispatch::AnimationDispatch,
 		animation_lookup::{AnimationClips, AnimationLookup, AnimationLookupData},
 	},
-	system_params::animations::AnimationsContextMut,
+	system_params::animations::AnimationsRegisterContextMut,
 	traits::LoadAnimationAssets,
 };
 use bevy::prelude::*;
@@ -19,7 +19,7 @@ use common::traits::{
 };
 use std::collections::HashMap;
 
-impl<TServer, TGraph> RegisterAnimations for AnimationsContextMut<'_, TServer, TGraph>
+impl<TServer, TGraph> RegisterAnimations for AnimationsRegisterContextMut<'_, TServer, TGraph>
 where
 	TGraph: Asset + WrapHandle + Sync + Send + 'static,
 	TServer: Resource + LoadAnimationAssets<TGraph, AnimationClips>,
@@ -77,8 +77,8 @@ mod tests {
 			handles_animations::{
 				AffectedAnimationBones,
 				AnimationPath,
-				Animations as AnimationsKey,
 				PlayMode,
+				WithoutAnimations,
 			},
 			wrap_handle::GetHandle,
 		},
@@ -144,7 +144,7 @@ mod tests {
 
 		app.world_mut()
 			.run_system_once(move |mut p: AnimationsParamMut<_Server, _Graph>| {
-				let key = AnimationsKey { entity };
+				let key = WithoutAnimations { entity };
 				let mut ctx = AnimationsParamMut::get_context_mut(&mut p, key).unwrap();
 				ctx.register_animations(&HashMap::default(), &HashMap::default());
 			})?;
@@ -163,7 +163,7 @@ mod tests {
 
 		app.world_mut()
 			.run_system_once(move |mut p: AnimationsParamMut<_Server, _Graph>| {
-				let key = AnimationsKey { entity };
+				let key = WithoutAnimations { entity };
 				let mut ctx = AnimationsParamMut::get_context_mut(&mut p, key).unwrap();
 				ctx.register_animations(&HashMap::default(), &HashMap::default());
 			})?;
@@ -212,7 +212,7 @@ mod tests {
 
 		app.world_mut()
 			.run_system_once(move |mut p: AnimationsParamMut<_Server, _Graph>| {
-				let key = AnimationsKey { entity };
+				let key = WithoutAnimations { entity };
 				let mut ctx = AnimationsParamMut::get_context_mut(&mut p, key).unwrap();
 				let a = Animation {
 					path: AnimationPath::from("path/a"),
@@ -316,6 +316,24 @@ mod tests {
 			}),
 			app.world().entity(entity).get::<AnimationLookup>()
 		);
+		Ok(())
+	}
+
+	#[test]
+	fn no_context_when_animation_dispatch_present() -> Result<(), RunSystemError> {
+		let mut app = setup(_Server::new().with_mock(|mock| {
+			mock.expect_load_animation_assets()
+				.return_const((_Graph, HashMap::default()));
+		}));
+		let entity = app.world_mut().spawn(AnimationDispatch::default()).id();
+
+		let ctx = app.world_mut().run_system_once(
+			move |mut p: AnimationsParamMut<_Server, _Graph>| {
+				AnimationsParamMut::get_context_mut(&mut p, WithoutAnimations { entity }).is_some()
+			},
+		)?;
+
+		assert!(!ctx);
 		Ok(())
 	}
 }

--- a/src/plugins/animations/src/systems/set_directional_animation_weights.rs
+++ b/src/plugins/animations/src/systems/set_directional_animation_weights.rs
@@ -44,11 +44,15 @@ fn set_directional_animation_weights<TDispatch, TGraph>(
 	TDispatch: Component + AnimationPlayers + GetAllActiveAnimations,
 	TGraph: Asset + GetNodeMut + WrapHandle,
 {
-	for (dispatch, MovementDirection(direction), transform, lookup) in &agents {
+	for (dispatch, movement_direction, transform, lookup) in &agents {
 		let forward = transform.forward();
 		let backward = transform.back();
 		let left = transform.left();
 		let right = transform.right();
+
+		let MovementDirection(Some(direction)) = movement_direction else {
+			continue;
+		};
 
 		for entity in dispatch.animation_players() {
 			let Ok(player) = players.get(entity) else {
@@ -244,7 +248,7 @@ mod tests {
 				players: vec![player],
 				animations: vec![AnimationKey::Walk],
 			},
-			MovementDirection(direction),
+			MovementDirection(Some(direction)),
 			lookup,
 		));
 
@@ -293,7 +297,7 @@ mod tests {
 				players: vec![player],
 				animations: vec![AnimationKey::Walk],
 			},
-			MovementDirection(direction),
+			MovementDirection(Some(direction)),
 			lookup,
 		));
 
@@ -348,7 +352,7 @@ mod tests {
 				players: vec![player],
 				animations: vec![AnimationKey::Walk],
 			},
-			MovementDirection(direction),
+			MovementDirection(Some(direction)),
 			lookup,
 		));
 
@@ -398,7 +402,7 @@ mod tests {
 				players: vec![player],
 				animations: vec![AnimationKey::Walk],
 			},
-			MovementDirection(Dir3::new(Vec3::new(-0.039663114, 0.0, -0.9992131)).unwrap()),
+			MovementDirection(Dir3::new(Vec3::new(-0.039663114, 0.0, -0.9992131)).ok()),
 			lookup,
 		));
 

--- a/src/plugins/common/src/traits/handles_animations.rs
+++ b/src/plugins/common/src/traits/handles_animations.rs
@@ -18,9 +18,19 @@ use std::{
 
 pub trait HandlesAnimations {
 	type TAnimationsMut<'w, 's>: SystemParam
-		+ for<'c> GetContextMut<Animations, TContext<'c>: RegisterAnimations>
+		+ for<'c> GetContextMut<WithoutAnimations, TContext<'c>: RegisterAnimations>
 		+ for<'c> GetContextMut<Animations, TContext<'c>: ActiveAnimationsMut>
 		+ for<'c> GetContextMut<Animations, TContext<'c>: MoveDirectionMut>;
+}
+
+pub struct WithoutAnimations {
+	pub entity: Entity,
+}
+
+impl From<WithoutAnimations> for Entity {
+	fn from(WithoutAnimations { entity }: WithoutAnimations) -> Self {
+		entity
+	}
 }
 
 pub struct Animations {

--- a/src/plugins/common/src/traits/handles_animations.rs
+++ b/src/plugins/common/src/traits/handles_animations.rs
@@ -1,7 +1,6 @@
 mod priority_order;
 
 use crate::{
-	errors::{ErrorData, Level},
 	tools::{action_key::slot::SlotKey, bone_name::BoneName, path::Path},
 	traits::{
 		accessors::get::GetContextMut,
@@ -12,7 +11,6 @@ use bevy::{ecs::system::SystemParam, prelude::*};
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Error};
 use std::{
 	collections::{HashMap, HashSet},
-	fmt::Display,
 	ops::{Deref, DerefMut},
 };
 
@@ -68,10 +66,7 @@ where
 }
 
 pub trait ActiveAnimations {
-	fn active_animations<TLayer>(
-		&self,
-		layer: TLayer,
-	) -> Result<&HashSet<AnimationKey>, AnimationsUnprepared>
+	fn active_animations<TLayer>(&self, layer: TLayer) -> &HashSet<AnimationKey>
 	where
 		TLayer: Into<AnimationPriority>;
 }
@@ -80,10 +75,7 @@ impl<T> ActiveAnimations for T
 where
 	T: Deref<Target: ActiveAnimations>,
 {
-	fn active_animations<TLayer>(
-		&self,
-		layer: TLayer,
-	) -> Result<&HashSet<AnimationKey>, AnimationsUnprepared>
+	fn active_animations<TLayer>(&self, layer: TLayer) -> &HashSet<AnimationKey>
 	where
 		TLayer: Into<AnimationPriority>,
 	{
@@ -92,10 +84,7 @@ where
 }
 
 pub trait ActiveAnimationsMut: ActiveAnimations {
-	fn active_animations_mut<TLayer>(
-		&mut self,
-		layer: TLayer,
-	) -> Result<&mut HashSet<AnimationKey>, AnimationsUnprepared>
+	fn active_animations_mut<TLayer>(&mut self, layer: TLayer) -> &mut HashSet<AnimationKey>
 	where
 		TLayer: Into<AnimationPriority>;
 }
@@ -104,36 +93,11 @@ impl<T> ActiveAnimationsMut for T
 where
 	T: DerefMut<Target: ActiveAnimationsMut>,
 {
-	fn active_animations_mut<TLayer>(
-		&mut self,
-		layer: TLayer,
-	) -> Result<&mut HashSet<AnimationKey>, AnimationsUnprepared>
+	fn active_animations_mut<TLayer>(&mut self, layer: TLayer) -> &mut HashSet<AnimationKey>
 	where
 		TLayer: Into<AnimationPriority>,
 	{
 		self.deref_mut().active_animations_mut(layer)
-	}
-}
-
-#[derive(Debug, PartialEq)]
-pub struct AnimationsUnprepared {
-	pub entity: Entity,
-}
-
-impl ErrorData for AnimationsUnprepared {
-	fn level(&self) -> Level {
-		Level::Error
-	}
-
-	fn label() -> impl Display {
-		"Animations unprepared"
-	}
-
-	fn into_details(self) -> impl Display {
-		format!(
-			"Tried to retrieve animations for {:?}, but animations have not been registered (yet)",
-			self.entity
-		)
 	}
 }
 


### PR DESCRIPTION
Animation system param context has been reworked:
- `WithoutAnimations`: allows registration of animations if not done yet
- `Animations`: allows usage of animations that have been set up
