### PR TITLE
Get context logging

### DIFF
--- a/src/macros/src/lib.rs
+++ b/src/macros/src/lib.rs
@@ -634,3 +634,25 @@ pub fn simple_mock(tokens: TokenStream) -> TokenStream {
 		}
 	})
 }
+
+/// Derives `View<Entity>` for the given struct based on an `entity` field.
+///
+/// This is useful for `GetContext(Mut)` traits, which have blanket implementations
+/// for `Queries` when used with keys that implement `View<Entity>`.
+#[proc_macro_derive(EntityKey)]
+pub fn entity_key(input: TokenStream) -> TokenStream {
+	let input = parse_macro_input!(input as DeriveInput);
+	let ident = input.ident;
+	let common = match crate_root("common") {
+		Ok(common) => common,
+		Err(error) => return error,
+	};
+
+	TokenStream::from(quote! {
+		impl #common::traits::accessors::get::View<bevy::prelude::Entity> for #ident {
+			fn view(&self) -> bevy::prelude::Entity {
+				self.entity
+			}
+		}
+	})
+}

--- a/src/plugins/agents/src/systems/enemy/animate_movement.rs
+++ b/src/plugins/agents/src/systems/enemy/animate_movement.rs
@@ -1,9 +1,12 @@
 use crate::{components::enemy::Enemy, systems::player::animate_movement::Move};
 use bevy::{ecs::system::StaticSystemParam, prelude::*};
-use common::traits::{
-	accessors::get::{GetChangedContext, GetContext, GetContextMut, View},
-	handles_animations::{ActiveAnimationsMut, AnimationKey, Animations},
-	handles_movement::{Movement, MovementTarget},
+use common::{
+	errors::Level,
+	traits::{
+		accessors::get::{GetChangedContext, GetContext, GetContextMut, Logged, View},
+		handles_animations::{ActiveAnimationsMut, AnimationKey, Animations},
+		handles_movement::{Movement, MovementTarget},
+	},
 };
 use std::collections::HashSet;
 
@@ -13,16 +16,16 @@ impl Enemy {
 		mut animations: StaticSystemParam<TAnimations>,
 		enemies: Query<Entity, With<Self>>,
 	) where
-		TMovement: for<'c> GetContext<Movement, TContext<'c>: View<Option<MovementTarget>>>,
-		TAnimations: for<'c> GetContextMut<Animations, TContext<'c>: ActiveAnimationsMut>,
+		TMovement: for<'c> GetContext<Logged<Movement>, TContext<'c>: View<Option<MovementTarget>>>,
+		TAnimations: for<'c> GetContextMut<Logged<Animations>, TContext<'c>: ActiveAnimationsMut>,
 	{
 		for entity in enemies {
-			let key = Movement { entity };
+			let key = Logged::key(Movement { entity }).with_level(Level::Error);
 			let Some(movement) = TMovement::get_changed_context(&movement, key) else {
 				continue;
 			};
 
-			let key = Animations { entity };
+			let key = Logged::key(Animations { entity }).with_level(Level::Error);
 			let Some(mut animations) = TAnimations::get_context_mut(&mut animations, key) else {
 				continue;
 			};

--- a/src/plugins/agents/src/systems/player/animate_movement.rs
+++ b/src/plugins/agents/src/systems/player/animate_movement.rs
@@ -1,9 +1,12 @@
 use crate::components::player::Player;
 use bevy::{ecs::system::StaticSystemParam, prelude::*};
-use common::traits::{
-	accessors::get::{GetChangedContext, GetContext, GetContextMut, View, ViewOf},
-	handles_animations::{ActiveAnimationsMut, AnimationKey, AnimationPriority, Animations},
-	handles_movement::{CurrentMovement, Movement, MovementTarget, SpeedToggle},
+use common::{
+	errors::Level,
+	traits::{
+		accessors::get::{GetChangedContext, GetContext, GetContextMut, Logged, View, ViewOf},
+		handles_animations::{ActiveAnimationsMut, AnimationKey, AnimationPriority, Animations},
+		handles_movement::{CurrentMovement, Movement, MovementTarget, SpeedToggle},
+	},
 };
 use std::collections::HashSet;
 
@@ -13,16 +16,16 @@ impl Player {
 		mut animations: StaticSystemParam<TAnimations>,
 		players: Query<Entity, With<Self>>,
 	) where
-		TMovement: for<'c> GetContext<Movement, TContext<'c>: CurrentMovement>,
-		TAnimations: for<'c> GetContextMut<Animations, TContext<'c>: ActiveAnimationsMut>,
+		TMovement: for<'c> GetContext<Logged<Movement>, TContext<'c>: CurrentMovement>,
+		TAnimations: for<'c> GetContextMut<Logged<Animations>, TContext<'c>: ActiveAnimationsMut>,
 	{
 		for entity in players {
-			let key = Movement { entity };
+			let key = Logged::key(Movement { entity }).with_level(Level::Error);
 			let Some(movement) = TMovement::get_changed_context(&movement, key) else {
 				continue;
 			};
 
-			let key = Animations { entity };
+			let key = Logged::key(Animations { entity }).with_level(Level::Error);
 			let Some(mut animations) = TAnimations::get_context_mut(&mut animations, key) else {
 				continue;
 			};

--- a/src/plugins/common/src/errors.rs
+++ b/src/plugins/common/src/errors.rs
@@ -13,7 +13,7 @@ use std::{
 };
 use zyheeda_core::write_iter;
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub enum Level {
 	Warning,
 	Error,

--- a/src/plugins/common/src/systems/log.rs
+++ b/src/plugins/common/src/systems/log.rs
@@ -1,6 +1,5 @@
-use crate::errors::{ErrorData, Level};
+use crate::errors::ErrorData;
 use bevy::ecs::system::In;
-use tracing::{error, field::display, warn};
 
 pub struct OnError;
 
@@ -40,7 +39,7 @@ where
 		match self {
 			Ok(value) => value,
 			Err(error) => {
-				output(error);
+				output::log(error);
 				fallback()
 			}
 		}
@@ -61,20 +60,38 @@ where
 	}
 }
 
-fn output<TError>(error: TError)
-where
-	TError: ErrorData,
-{
-	let level = error.level();
-	let label = TError::label();
-	let details = display(error.into_details());
+#[cfg(not(test))]
+pub(crate) mod output {
+	use super::*;
+	use crate::errors::Level;
+	use tracing::{error, field::display, warn};
 
-	match level {
-		Level::Error => {
-			error!(details, "{label}");
+	pub(crate) fn log<TError>(error: TError)
+	where
+		TError: ErrorData,
+	{
+		let level = error.level();
+		let label = TError::label();
+		let details = display(error.into_details());
+
+		match level {
+			Level::Error => {
+				error!(details, "{label}");
+			}
+			Level::Warning => {
+				warn!(details, "{label}");
+			}
 		}
-		Level::Warning => {
-			warn!(details, "{label}");
-		}
+	}
+}
+
+#[cfg(test)]
+pub(crate) mod output {
+	use super::*;
+
+	pub(crate) fn log<TError>(_: TError)
+	where
+		TError: ErrorData,
+	{
 	}
 }

--- a/src/plugins/common/src/traits/accessors/get.rs
+++ b/src/plugins/common/src/traits/accessors/get.rs
@@ -7,7 +7,16 @@ mod option;
 mod ray;
 mod result;
 
-use bevy::ecs::system::{SystemParam, SystemParamItem};
+use bevy::{
+	ecs::system::{SystemParam, SystemParamItem},
+	prelude::*,
+};
+use std::{any::type_name, fmt::Display, marker::PhantomData};
+
+use crate::{
+	errors::{ErrorData, Level},
+	systems::log::output,
+};
 
 pub trait Get<TKey> {
 	type TValue;
@@ -79,6 +88,117 @@ pub trait GetContextMut<TKey>: SystemParam {
 		param: &'ctx mut SystemParamItem<Self>,
 		key: TKey,
 	) -> Option<Self::TContext<'ctx>>;
+}
+
+impl<T, TKey> GetContext<Logged<TKey>> for T
+where
+	T: GetContext<TKey>,
+	TKey: View<Entity>,
+{
+	type TContext<'ctx> = T::TContext<'ctx>;
+
+	fn get_context<'ctx>(
+		param: &'ctx SystemParamItem<Self>,
+		Logged { key, level }: Logged<TKey>,
+	) -> Option<Self::TContext<'ctx>> {
+		let entity = key.view();
+		let ctx = T::get_context(param, key);
+
+		if ctx.is_none() {
+			output::log(MissingContext {
+				entity,
+				level,
+				_key: PhantomData::<TKey>,
+			});
+		}
+
+		ctx
+	}
+}
+
+impl<T, TKey> GetContextMut<Logged<TKey>> for T
+where
+	T: GetContextMut<TKey>,
+	TKey: View<Entity>,
+{
+	type TContext<'ctx> = T::TContext<'ctx>;
+
+	fn get_context_mut<'ctx>(
+		param: &'ctx mut SystemParamItem<Self>,
+		Logged { key, level }: Logged<TKey>,
+	) -> Option<Self::TContext<'ctx>> {
+		let entity = key.view();
+		let ctx = T::get_context_mut(param, key);
+
+		if ctx.is_none() {
+			output::log(MissingContext {
+				entity,
+				level,
+				_key: PhantomData::<TKey>,
+			});
+		}
+
+		ctx
+	}
+}
+
+/// A wrapper for [`GetContext`] and [`GetContextMut`] keys.
+///
+/// Both traits have a blanket implementation to log [`None`] cases.
+pub struct Logged<TKey>
+where
+	TKey: View<Entity>,
+{
+	pub key: TKey,
+	pub level: Level,
+}
+
+impl<TKey> Logged<TKey>
+where
+	TKey: View<Entity>,
+{
+	pub fn key(key: TKey) -> Self {
+		Self {
+			key,
+			level: Level::Error,
+		}
+	}
+
+	pub fn with_level(mut self, level: Level) -> Self {
+		self.level = level;
+		self
+	}
+}
+
+struct MissingContext<TKey> {
+	entity: Entity,
+	level: Level,
+	_key: PhantomData<TKey>,
+}
+
+impl<TKey> Display for MissingContext<TKey> {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		write!(
+			f,
+			"{}: missing context `{}`",
+			self.entity,
+			type_name::<TKey>()
+		)
+	}
+}
+
+impl<TKey> ErrorData for MissingContext<TKey> {
+	fn level(&self) -> Level {
+		self.level
+	}
+
+	fn label() -> impl Display {
+		"Missing Context Error"
+	}
+
+	fn into_details(self) -> impl Display {
+		self
+	}
 }
 
 pub trait TryApplyOn<'a, TKey>: GetMut<TKey> + 'a {

--- a/src/plugins/common/src/traits/accessors/get/components.rs
+++ b/src/plugins/common/src/traits/accessors/get/components.rs
@@ -1,4 +1,4 @@
-use crate::traits::accessors::get::{ContextChanged, GetContext, GetContextMut};
+use crate::traits::accessors::get::{ContextChanged, GetContext, GetContextMut, View};
 use bevy::{ecs::component::Mutable, prelude::*};
 
 impl<T> ContextChanged for Ref<'_, T>
@@ -13,19 +13,19 @@ where
 impl<T, TKey> GetContext<TKey> for Query<'_, '_, Ref<'static, T>>
 where
 	T: Component,
-	TKey: Into<Entity>,
+	TKey: View<Entity>,
 {
 	type TContext<'ctx> = Ref<'ctx, T>;
 
 	fn get_context<'ctx>(query: &'ctx Query<Ref<T>>, key: TKey) -> Option<Self::TContext<'ctx>> {
-		query.get(key.into()).ok()
+		query.get(key.view()).ok()
 	}
 }
 
 impl<T, TKey> GetContextMut<TKey> for Query<'_, '_, Mut<'static, T>>
 where
 	T: Component<Mutability = Mutable>,
-	TKey: Into<Entity>,
+	TKey: View<Entity>,
 {
 	type TContext<'ctx> = Mut<'ctx, T>;
 
@@ -33,14 +33,14 @@ where
 		query: &'ctx mut Query<Mut<T>>,
 		key: TKey,
 	) -> Option<Self::TContext<'ctx>> {
-		query.get_mut(key.into()).ok()
+		query.get_mut(key.view()).ok()
 	}
 }
 
 impl<T, TKey> GetContextMut<TKey> for Query<'_, '_, &'static mut T>
 where
 	T: Component<Mutability = Mutable>,
-	TKey: Into<Entity>,
+	TKey: View<Entity>,
 {
 	type TContext<'ctx> = Mut<'ctx, T>;
 
@@ -49,6 +49,6 @@ where
 
 		key: TKey,
 	) -> Option<Self::TContext<'ctx>> {
-		query.get_mut(key.into()).ok()
+		query.get_mut(key.view()).ok()
 	}
 }

--- a/src/plugins/common/src/traits/handles_animations.rs
+++ b/src/plugins/common/src/traits/handles_animations.rs
@@ -8,6 +8,7 @@ use crate::{
 	},
 };
 use bevy::{ecs::system::SystemParam, prelude::*};
+use macros::EntityKey;
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Error};
 use std::{
 	collections::{HashMap, HashSet},
@@ -21,24 +22,14 @@ pub trait HandlesAnimations {
 		+ for<'c> GetContextMut<Animations, TContext<'c>: MoveDirectionMut>;
 }
 
+#[derive(EntityKey)]
 pub struct WithoutAnimations {
 	pub entity: Entity,
 }
 
-impl From<WithoutAnimations> for Entity {
-	fn from(WithoutAnimations { entity }: WithoutAnimations) -> Self {
-		entity
-	}
-}
-
+#[derive(EntityKey)]
 pub struct Animations {
 	pub entity: Entity,
-}
-
-impl From<Animations> for Entity {
-	fn from(Animations { entity }: Animations) -> Self {
-		entity
-	}
 }
 
 pub type AnimationsSystemParamMut<'w, 's, T> = <T as HandlesAnimations>::TAnimationsMut<'w, 's>;

--- a/src/plugins/common/src/traits/handles_loadout/available_skills.rs
+++ b/src/plugins/common/src/traits/handles_loadout/available_skills.rs
@@ -6,16 +6,12 @@ use crate::{
 	},
 };
 use bevy::prelude::*;
+use macros::EntityKey;
 use std::ops::Deref;
 
+#[derive(EntityKey)]
 pub struct AvailableSkills {
 	pub entity: Entity,
-}
-
-impl From<AvailableSkills> for Entity {
-	fn from(AvailableSkills { entity }: AvailableSkills) -> Self {
-		entity
-	}
 }
 
 pub trait ReadAvailableSkills<TSkillID> {

--- a/src/plugins/common/src/traits/handles_loadout/combos.rs
+++ b/src/plugins/common/src/traits/handles_loadout/combos.rs
@@ -6,6 +6,7 @@ use crate::{
 	},
 };
 use bevy::{ecs::component::Mutable, prelude::*};
+use macros::EntityKey;
 use std::{
 	collections::HashSet,
 	ops::{Deref, DerefMut},
@@ -13,14 +14,9 @@ use std::{
 
 pub type Combo<TKey, TSkill> = Vec<(Vec<TKey>, TSkill)>;
 
+#[derive(EntityKey)]
 pub struct Combos {
 	pub entity: Entity,
-}
-
-impl From<Combos> for Entity {
-	fn from(Combos { entity }: Combos) -> Self {
-		entity
-	}
 }
 
 pub trait NextConfiguredKeys<TKey> {

--- a/src/plugins/common/src/traits/handles_loadout/insert_default_loadout.rs
+++ b/src/plugins/common/src/traits/handles_loadout/insert_default_loadout.rs
@@ -1,15 +1,11 @@
 use crate::traits::{handles_loadout::LoadoutKey, loadout::ItemName};
 use bevy::prelude::*;
+use macros::EntityKey;
 use std::ops::DerefMut;
 
+#[derive(EntityKey)]
 pub struct NotLoadedOut {
 	pub entity: Entity,
-}
-
-impl From<NotLoadedOut> for Entity {
-	fn from(NotLoadedOut { entity }: NotLoadedOut) -> Self {
-		entity
-	}
 }
 
 pub trait InsertDefaultLoadout {

--- a/src/plugins/common/src/traits/handles_loadout/items.rs
+++ b/src/plugins/common/src/traits/handles_loadout/items.rs
@@ -4,16 +4,12 @@ use crate::traits::{
 	handles_localization::Token,
 };
 use bevy::prelude::*;
+use macros::EntityKey;
 use std::ops::{Deref, DerefMut};
 
+#[derive(EntityKey)]
 pub struct Items {
 	pub entity: Entity,
-}
-
-impl From<Items> for Entity {
-	fn from(Items { entity }: Items) -> Self {
-		entity
-	}
 }
 
 pub struct ItemToken;

--- a/src/plugins/common/src/traits/handles_loadout/register_loadout_bones.rs
+++ b/src/plugins/common/src/traits/handles_loadout/register_loadout_bones.rs
@@ -1,15 +1,11 @@
 use crate::tools::{action_key::slot::SlotKey, bone_name::BoneName, mesh_name::MeshName};
 use bevy::prelude::*;
+use macros::EntityKey;
 use std::{collections::HashMap, ops::DerefMut};
 
+#[derive(EntityKey)]
 pub struct NoBonesRegistered {
 	pub entity: Entity,
-}
-
-impl From<NoBonesRegistered> for Entity {
-	fn from(NoBonesRegistered { entity }: NoBonesRegistered) -> Self {
-		entity
-	}
 }
 
 pub trait RegisterLoadoutBones {

--- a/src/plugins/common/src/traits/handles_loadout/skills.rs
+++ b/src/plugins/common/src/traits/handles_loadout/skills.rs
@@ -7,16 +7,12 @@ use crate::{
 	},
 };
 use bevy::prelude::*;
+use macros::EntityKey;
 use std::ops::Deref;
 
+#[derive(EntityKey)]
 pub struct Skills {
 	pub entity: Entity,
-}
-
-impl From<Skills> for Entity {
-	fn from(Skills { entity }: Skills) -> Self {
-		entity
-	}
 }
 
 pub struct SkillToken;

--- a/src/plugins/common/src/traits/handles_movement.rs
+++ b/src/plugins/common/src/traits/handles_movement.rs
@@ -6,6 +6,7 @@ use crate::{
 	},
 };
 use bevy::{ecs::system::SystemParam, prelude::*};
+use macros::EntityKey;
 use serde::{Deserialize, Serialize};
 use std::ops::DerefMut;
 
@@ -142,34 +143,19 @@ pub trait CurrentMovement: View<Option<MovementTarget>> + View<SpeedToggle> {}
 
 impl<T> CurrentMovement for T where T: View<Option<MovementTarget>> + View<SpeedToggle> {}
 
+#[derive(EntityKey)]
 pub struct Movement {
 	pub entity: Entity,
 }
 
-impl From<Movement> for Entity {
-	fn from(Movement { entity }: Movement) -> Self {
-		entity
-	}
-}
-
+#[derive(EntityKey)]
 pub struct ConfiguredMovement {
 	pub entity: Entity,
 }
 
-impl From<ConfiguredMovement> for Entity {
-	fn from(ConfiguredMovement { entity }: ConfiguredMovement) -> Self {
-		entity
-	}
-}
-
+#[derive(EntityKey)]
 pub struct NotConfiguredMovement {
 	pub entity: Entity,
-}
-
-impl From<NotConfiguredMovement> for Entity {
-	fn from(NotConfiguredMovement { entity }: NotConfiguredMovement) -> Self {
-		entity
-	}
 }
 
 #[cfg(test)]

--- a/src/plugins/common/src/traits/handles_orientation.rs
+++ b/src/plugins/common/src/traits/handles_orientation.rs
@@ -3,6 +3,7 @@ use crate::{
 	traits::accessors::get::GetContextMut,
 };
 use bevy::{ecs::system::SystemParam, prelude::*};
+use macros::EntityKey;
 use serde::{Deserialize, Serialize};
 use std::ops::DerefMut;
 
@@ -13,14 +14,9 @@ pub trait HandlesOrientation {
 
 pub type FacingSystemParamMut<'w, 's, T> = <T as HandlesOrientation>::TFaceSystemParam<'w, 's>;
 
+#[derive(EntityKey)]
 pub struct Facing {
 	pub entity: Entity,
-}
-
-impl From<Facing> for Entity {
-	fn from(Facing { entity }: Facing) -> Self {
-		entity
-	}
 }
 
 pub trait OverrideFace {

--- a/src/plugins/common/src/traits/handles_physics.rs
+++ b/src/plugins/common/src/traits/handles_physics.rs
@@ -11,6 +11,7 @@ use crate::{
 	},
 };
 use bevy::{ecs::system::SystemParam, prelude::*};
+use macros::EntityKey;
 use serde::{Deserialize, Serialize};
 use std::{
 	collections::HashSet,
@@ -64,14 +65,9 @@ pub trait HandlesPhysicsConfig {
 
 pub type PhysicsConfigMut<'w, 's, T> = <T as HandlesPhysicsConfig>::TConfigMut<'w, 's>;
 
+#[derive(EntityKey)]
 pub struct NoDefaultAttributes {
 	pub entity: Entity,
-}
-
-impl From<NoDefaultAttributes> for Entity {
-	fn from(NoDefaultAttributes { entity }: NoDefaultAttributes) -> Self {
-		entity
-	}
 }
 
 pub trait ConfigureDefaultAttributes {
@@ -87,14 +83,9 @@ where
 	}
 }
 
+#[derive(EntityKey)]
 pub struct NoBodyConfigured {
 	pub entity: Entity,
-}
-
-impl From<NoBodyConfigured> for Entity {
-	fn from(NoBodyConfigured { entity }: NoBodyConfigured) -> Self {
-		entity
-	}
 }
 
 pub trait ConfigureBody {

--- a/src/plugins/common/src/traits/handles_skill_physics.rs
+++ b/src/plugins/common/src/traits/handles_skill_physics.rs
@@ -21,6 +21,7 @@ use bevy::{
 	ecs::{entity::Entity, system::SystemParam},
 	prelude::*,
 };
+use macros::EntityKey;
 use serde::{Deserialize, Serialize};
 use std::{
 	collections::HashMap,
@@ -82,14 +83,9 @@ pub trait HandlesPhysicalSkillSpawnPoints {
 pub type SkillSpawnPointsMut<'w, 's, T> =
 	<T as HandlesPhysicalSkillSpawnPoints>::TSkillSpawnPointsMut<'w, 's>;
 
+#[derive(EntityKey)]
 pub struct SkillSpawnPoints {
 	pub entity: Entity,
-}
-
-impl From<SkillSpawnPoints> for Entity {
-	fn from(SkillSpawnPoints { entity }: SkillSpawnPoints) -> Self {
-		entity
-	}
 }
 
 pub trait RegisterDefinition {


### PR DESCRIPTION
Added a logger wrapper for `GetContext(Mut)` keys and a blanked implementation that logs errors/warnings when the returned context is none. This serves as a easy to use logging solution, so that consumers do not need to log misses manually all the time. Added logging for agent movement animations, because we recently removed it there in a trait rework.