### PR TITLE
Pitch animations from skill target

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,7 @@ fn prepare_game(app: &mut App) -> Result<(), ZyheedaAppError> {
 	let movement =
 		MovementPlugin::from_plugins(&input, &savegame, &animations, &physics, &path_finding);
 	let graphics = GraphicsPlugin::from_plugins(&loading, &savegame, &physics);
-	let skills = SkillsPlugin::from_plugins(&savegame, &physics, &loading, &movement);
+	let skills = SkillsPlugin::from_plugins(&savegame, &animations, &physics, &loading, &movement);
 	let agents = AgentsPlugin::from_plugins(
 		&loading,
 		&input,

--- a/src/plugins/animations/src/components.rs
+++ b/src/plugins/animations/src/components.rs
@@ -1,4 +1,5 @@
 pub(crate) mod animation_dispatch;
 pub(crate) mod animation_lookup;
-pub(crate) mod movement_direction;
+pub(crate) mod current_forward_pitch;
+pub(crate) mod current_movement_direction;
 pub(crate) mod setup_animations;

--- a/src/plugins/animations/src/components/animation_dispatch.rs
+++ b/src/plugins/animations/src/components/animation_dispatch.rs
@@ -3,7 +3,8 @@ mod dto;
 use crate::{
 	components::{
 		animation_dispatch::dto::AnimationDispatchDto,
-		movement_direction::MovementDirection,
+		current_forward_pitch::CurrentForwardPitch,
+		current_movement_direction::CurrentMovementDirection,
 	},
 	traits::{
 		AnimationPlayers,
@@ -27,7 +28,7 @@ use std::{
 };
 
 #[derive(Component, SavableComponent, Debug, PartialEq, Clone)]
-#[require(MovementDirection)]
+#[require(CurrentMovementDirection, CurrentForwardPitch)]
 #[savable_component(id = "animation dispatch", dto = AnimationDispatchDto)]
 pub struct AnimationDispatch {
 	pub(crate) animation_players: HashSet<Entity>,

--- a/src/plugins/animations/src/components/animation_lookup.rs
+++ b/src/plugins/animations/src/components/animation_lookup.rs
@@ -1,6 +1,12 @@
 use bevy::prelude::*;
 use common::traits::{
-	handles_animations::{AffectedAnimationBones, AnimationKey, AnimationMaskBits, PlayMode},
+	handles_animations::{
+		AffectedAnimationBones,
+		AnimationKey,
+		AnimationMaskBits,
+		ForwardPitch,
+		PlayMode,
+	},
 	iterate::Iterate,
 };
 use std::collections::HashMap;
@@ -31,6 +37,7 @@ pub(crate) struct AnimationLookupData<TAnimations = AnimationClips> {
 pub(crate) enum AnimationClips {
 	Single(AnimationNodeIndex),
 	Directional(DirectionalIndices),
+	PitchedForward(PitchedForwardIndices),
 }
 
 impl Default for AnimationClips {
@@ -50,10 +57,17 @@ impl<'a> Iterate<'a> for AnimationClips {
 
 #[derive(Debug, PartialEq, Eq, Hash, Default, Clone, Copy)]
 pub(crate) struct DirectionalIndices {
-	pub forward: AnimationNodeIndex,
-	pub backward: AnimationNodeIndex,
-	pub left: AnimationNodeIndex,
-	pub right: AnimationNodeIndex,
+	pub(crate) forward: AnimationNodeIndex,
+	pub(crate) backward: AnimationNodeIndex,
+	pub(crate) left: AnimationNodeIndex,
+	pub(crate) right: AnimationNodeIndex,
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, Default, Clone, Copy)]
+pub(crate) struct PitchedForwardIndices {
+	pub(crate) neutral: AnimationNodeIndex,
+	pub(crate) up: (ForwardPitch, AnimationNodeIndex),
+	pub(crate) down: (ForwardPitch, AnimationNodeIndex),
 }
 
 pub struct Iter<'a> {

--- a/src/plugins/animations/src/components/animation_lookup.rs
+++ b/src/plugins/animations/src/components/animation_lookup.rs
@@ -88,16 +88,20 @@ impl<'a> Iterator for Iter<'a> {
 	type Item = &'a AnimationNodeIndex;
 
 	fn next(&mut self) -> Option<Self::Item> {
+		use AnimationClips::{Directional, PitchedForward, Single};
 		let index = self.index;
 
 		self.index += 1;
 
-		match (self.animations, index) {
-			(AnimationClips::Single(node_index), 0) => Some(node_index),
-			(AnimationClips::Directional(DirectionalIndices { forward, .. }), 0) => Some(forward),
-			(AnimationClips::Directional(DirectionalIndices { backward, .. }), 1) => Some(backward),
-			(AnimationClips::Directional(DirectionalIndices { left, .. }), 2) => Some(left),
-			(AnimationClips::Directional(DirectionalIndices { right, .. }), 3) => Some(right),
+		match (index, self.animations) {
+			(0, Single(node_index)) => Some(node_index),
+			(0, Directional(DirectionalIndices { forward, .. })) => Some(forward),
+			(1, Directional(DirectionalIndices { backward, .. })) => Some(backward),
+			(2, Directional(DirectionalIndices { left, .. })) => Some(left),
+			(3, Directional(DirectionalIndices { right, .. })) => Some(right),
+			(0, PitchedForward(PitchedForwardIndices { neutral, .. })) => Some(neutral),
+			(1, PitchedForward(PitchedForwardIndices { up, .. })) => Some(&up.1),
+			(2, PitchedForward(PitchedForwardIndices { down, .. })) => Some(&down.1),
 			_ => None,
 		}
 	}
@@ -132,6 +136,24 @@ mod tests {
 				&AnimationNodeIndex::new(20),
 				&AnimationNodeIndex::new(9),
 				&AnimationNodeIndex::new(555),
+			],
+			animations.iterate().take(5).collect::<Vec<_>>()
+		)
+	}
+
+	#[test]
+	fn iter_pitch_animations() {
+		let animations = AnimationClips::PitchedForward(PitchedForwardIndices {
+			neutral: AnimationNodeIndex::new(11),
+			up: (ForwardPitch::MAX, AnimationNodeIndex::new(42)),
+			down: (ForwardPitch::MAX, AnimationNodeIndex::new(100)),
+		});
+
+		assert_eq!(
+			vec![
+				&AnimationNodeIndex::new(11),
+				&AnimationNodeIndex::new(42),
+				&AnimationNodeIndex::new(100),
 			],
 			animations.iterate().take(5).collect::<Vec<_>>()
 		)

--- a/src/plugins/animations/src/components/current_forward_pitch.rs
+++ b/src/plugins/animations/src/components/current_forward_pitch.rs
@@ -1,0 +1,5 @@
+use bevy::prelude::*;
+use common::traits::handles_animations::DirForwardPitch;
+
+#[derive(Component, Debug, PartialEq, Default)]
+pub(crate) struct CurrentForwardPitch(pub(crate) Option<DirForwardPitch>);

--- a/src/plugins/animations/src/components/current_movement_direction.rs
+++ b/src/plugins/animations/src/components/current_movement_direction.rs
@@ -1,4 +1,4 @@
 use bevy::prelude::*;
 
 #[derive(Component, Debug, PartialEq, Default)]
-pub(crate) struct MovementDirection(pub(crate) Option<Dir3>);
+pub(crate) struct CurrentMovementDirection(pub(crate) Option<Dir3>);

--- a/src/plugins/animations/src/lib.rs
+++ b/src/plugins/animations/src/lib.rs
@@ -13,6 +13,7 @@ use crate::{
 	systems::{
 		play_animation_clip::PlayAnimationClip,
 		set_directional_animation_weights::SetDirectionalAnimationWeights,
+		set_pitch_animation_weights::SetPitchAnimationWeights,
 	},
 };
 use bevy::{prelude::*, scene::SceneInstanceReady};
@@ -60,6 +61,7 @@ where
 				AnimationDispatch::distribute_player_components::<AnimationGraphHandle>,
 				AnimationDispatch::play_animation_clip::<&mut AnimationPlayer>,
 				AnimationDispatch::set_directional_animation_weights,
+				AnimationDispatch::set_pitch_animation_weights,
 			)
 				.chain()
 				.in_set(AnimationSystems),

--- a/src/plugins/animations/src/system_params/animations.rs
+++ b/src/plugins/animations/src/system_params/animations.rs
@@ -1,10 +1,12 @@
 pub(crate) mod active_animations;
-mod move_direction;
+mod get_forward_pitch;
+mod get_move_direction;
 mod register_animations;
 
 use crate::components::{
 	animation_dispatch::AnimationDispatch,
-	movement_direction::MovementDirection,
+	current_forward_pitch::CurrentForwardPitch,
+	current_movement_direction::CurrentMovementDirection,
 };
 use bevy::{ecs::system::SystemParam, prelude::*};
 use common::{
@@ -32,7 +34,8 @@ pub struct AnimationsParamMut<
 		's,
 		(
 			&'static mut AnimationDispatch,
-			&'static mut MovementDirection,
+			&'static mut CurrentMovementDirection,
+			&'static mut CurrentForwardPitch,
 		),
 	>,
 	graphs: ResMut<'w, Assets<TAnimationGraph>>,
@@ -78,11 +81,13 @@ where
 		param: &'ctx mut AnimationsParamMut<TAnimationServer, TAnimationGraph>,
 		animations: Animations,
 	) -> Option<Self::TContext<'ctx>> {
-		let (dispatch, movement_direction) = param.animators.get_mut(animations.entity).ok()?;
+		let (dispatch, movement_direction, forward_pitch) =
+			param.animators.get_mut(animations.entity).ok()?;
 
 		Some(AnimationsContextMut {
 			dispatch,
 			movement_direction,
+			forward_pitch,
 		})
 	}
 }
@@ -101,5 +106,6 @@ pub struct AnimationsRegisterContextMut<
 
 pub struct AnimationsContextMut<'a> {
 	dispatch: Mut<'a, AnimationDispatch>,
-	movement_direction: Mut<'a, MovementDirection>,
+	movement_direction: Mut<'a, CurrentMovementDirection>,
+	forward_pitch: Mut<'a, CurrentForwardPitch>,
 }

--- a/src/plugins/animations/src/system_params/animations/get_forward_pitch.rs
+++ b/src/plugins/animations/src/system_params/animations/get_forward_pitch.rs
@@ -1,0 +1,99 @@
+use crate::system_params::animations::AnimationsContextMut;
+use common::traits::handles_animations::{DirForwardPitch, GetForwardPitch, GetForwardPitchMut};
+
+impl GetForwardPitch for AnimationsContextMut<'_> {
+	fn get_forward_pitch(&self) -> Option<DirForwardPitch> {
+		self.forward_pitch.0
+	}
+}
+
+impl GetForwardPitchMut for AnimationsContextMut<'_> {
+	fn get_forward_pitch_mut(&mut self) -> &mut Option<DirForwardPitch> {
+		&mut self.forward_pitch.0
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	#![allow(clippy::unwrap_used)]
+	use super::*;
+	use crate::{
+		components::{
+			animation_dispatch::AnimationDispatch,
+			current_forward_pitch::CurrentForwardPitch,
+		},
+		system_params::animations::AnimationsParamMut,
+	};
+	use bevy::{
+		ecs::system::{RunSystemError, RunSystemOnce},
+		prelude::*,
+	};
+	use common::traits::{
+		accessors::get::GetContextMut,
+		handles_animations::{Animations, ForwardPitch},
+	};
+	use testing::SingleThreadedApp;
+
+	#[derive(Resource)]
+	struct _Server;
+
+	fn setup() -> App {
+		let mut app = App::new().single_threaded(Update);
+
+		app.insert_resource(_Server);
+		app.insert_resource(Assets::<AnimationGraph>::default());
+
+		app
+	}
+
+	#[test]
+	fn get_forward_pitch() -> Result<(), RunSystemError> {
+		let mut app = setup();
+		let entity = app
+			.world_mut()
+			.spawn((
+				AnimationDispatch::default(),
+				GlobalTransform::default(),
+				CurrentForwardPitch(Some(DirForwardPitch::Up(
+					ForwardPitch::try_from(0.4).unwrap(),
+				))),
+			))
+			.id();
+
+		app.world_mut()
+			.run_system_once(move |mut p: AnimationsParamMut<_Server>| {
+				let key = Animations { entity };
+				let ctx = AnimationsParamMut::get_context_mut(&mut p, key).unwrap();
+
+				assert_eq!(
+					Some(DirForwardPitch::Up(ForwardPitch::try_from(0.4).unwrap())),
+					ctx.get_forward_pitch(),
+				);
+			})
+	}
+
+	#[test]
+	fn set_forward_pitch() -> Result<(), RunSystemError> {
+		let mut app = setup();
+		let entity = app
+			.world_mut()
+			.spawn((AnimationDispatch::default(), GlobalTransform::default()))
+			.id();
+
+		app.world_mut()
+			.run_system_once(move |mut p: AnimationsParamMut<_Server>| {
+				let key = Animations { entity };
+				let mut ctx = AnimationsParamMut::get_context_mut(&mut p, key).unwrap();
+				*ctx.get_forward_pitch_mut() =
+					Some(DirForwardPitch::Up(ForwardPitch::try_from(0.4).unwrap()));
+			})?;
+
+		assert_eq!(
+			Some(&CurrentForwardPitch(Some(DirForwardPitch::Up(
+				ForwardPitch::try_from(0.4).unwrap()
+			)))),
+			app.world().entity(entity).get::<CurrentForwardPitch>(),
+		);
+		Ok(())
+	}
+}

--- a/src/plugins/animations/src/system_params/animations/get_move_direction.rs
+++ b/src/plugins/animations/src/system_params/animations/get_move_direction.rs
@@ -1,15 +1,15 @@
 use crate::system_params::animations::AnimationsContextMut;
 use bevy::prelude::*;
-use common::traits::handles_animations::{MoveDirection, MoveDirectionMut};
+use common::traits::handles_animations::{GetMoveDirection, GetMoveDirectionMut};
 
-impl MoveDirection for AnimationsContextMut<'_> {
-	fn move_direction(&self) -> Option<Dir3> {
+impl GetMoveDirection for AnimationsContextMut<'_> {
+	fn get_move_direction(&self) -> Option<Dir3> {
 		self.movement_direction.0
 	}
 }
 
-impl MoveDirectionMut for AnimationsContextMut<'_> {
-	fn move_direction_mut(&mut self) -> &mut Option<Dir3> {
+impl GetMoveDirectionMut for AnimationsContextMut<'_> {
+	fn get_move_direction_mut(&mut self) -> &mut Option<Dir3> {
 		&mut self.movement_direction.0
 	}
 }
@@ -21,7 +21,7 @@ mod tests {
 	use crate::{
 		components::{
 			animation_dispatch::AnimationDispatch,
-			movement_direction::MovementDirection,
+			current_movement_direction::CurrentMovementDirection,
 		},
 		system_params::animations::AnimationsParamMut,
 	};
@@ -56,7 +56,7 @@ mod tests {
 			.spawn((
 				AnimationDispatch::default(),
 				GlobalTransform::default(),
-				MovementDirection(Some(Dir3::NEG_Z)),
+				CurrentMovementDirection(Some(Dir3::NEG_Z)),
 			))
 			.id();
 
@@ -65,7 +65,7 @@ mod tests {
 				let key = Animations { entity };
 				let ctx = AnimationsParamMut::get_context_mut(&mut p, key).unwrap();
 
-				assert_eq!(Some(Dir3::NEG_Z), ctx.move_direction());
+				assert_eq!(Some(Dir3::NEG_Z), ctx.get_move_direction());
 			})
 	}
 
@@ -81,38 +81,12 @@ mod tests {
 			.run_system_once(move |mut p: AnimationsParamMut<_Server>| {
 				let key = Animations { entity };
 				let mut ctx = AnimationsParamMut::get_context_mut(&mut p, key).unwrap();
-				*ctx.move_direction_mut() = Some(Dir3::NEG_Z);
+				*ctx.get_move_direction_mut() = Some(Dir3::NEG_Z);
 			})?;
 
 		assert_eq!(
-			Some(&MovementDirection(Some(Dir3::NEG_Z))),
-			app.world().entity(entity).get::<MovementDirection>(),
-		);
-		Ok(())
-	}
-
-	#[test]
-	fn set_movement_direction_to_none() -> Result<(), RunSystemError> {
-		let mut app = setup();
-		let entity = app
-			.world_mut()
-			.spawn((
-				AnimationDispatch::default(),
-				GlobalTransform::default(),
-				MovementDirection(Some(Dir3::NEG_Z)),
-			))
-			.id();
-
-		app.world_mut()
-			.run_system_once(move |mut p: AnimationsParamMut<_Server>| {
-				let key = Animations { entity };
-				let mut ctx = AnimationsParamMut::get_context_mut(&mut p, key).unwrap();
-				*ctx.move_direction_mut() = None;
-			})?;
-
-		assert_eq!(
-			Some(&MovementDirection(None)),
-			app.world().entity(entity).get::<MovementDirection>()
+			Some(&CurrentMovementDirection(Some(Dir3::NEG_Z))),
+			app.world().entity(entity).get::<CurrentMovementDirection>(),
 		);
 		Ok(())
 	}

--- a/src/plugins/animations/src/systems.rs
+++ b/src/plugins/animations/src/systems.rs
@@ -1,4 +1,5 @@
 pub(crate) mod dispatch_player_components;
 pub(crate) mod play_animation_clip;
 pub(crate) mod set_directional_animation_weights;
+pub(crate) mod set_pitch_animation_weights;
 pub(crate) mod setup_animations;

--- a/src/plugins/animations/src/systems/set_directional_animation_weights.rs
+++ b/src/plugins/animations/src/systems/set_directional_animation_weights.rs
@@ -1,7 +1,7 @@
 use crate::{
 	components::{
 		animation_lookup::{AnimationClips, AnimationLookup},
-		movement_direction::MovementDirection,
+		current_movement_direction::CurrentMovementDirection,
 	},
 	traits::{AnimationPlayers, GetAllActiveAnimations, asset_server::animation_graph::GetNodeMut},
 };
@@ -21,7 +21,7 @@ pub(crate) trait SetDirectionalAnimationWeights:
 		graphs: ResMut<Assets<AnimationGraph>>,
 		agents: Query<(
 			&Self,
-			&MovementDirection,
+			&CurrentMovementDirection,
 			&GlobalTransform,
 			&AnimationLookup,
 		)>,
@@ -35,7 +35,7 @@ fn set_directional_animation_weights<TDispatch, TGraph>(
 	mut graphs: ResMut<Assets<TGraph>>,
 	agents: Query<(
 		&TDispatch,
-		&MovementDirection,
+		&CurrentMovementDirection,
 		&GlobalTransform,
 		&AnimationLookup,
 	)>,
@@ -50,7 +50,7 @@ fn set_directional_animation_weights<TDispatch, TGraph>(
 		let left = transform.left();
 		let right = transform.right();
 
-		let MovementDirection(Some(direction)) = movement_direction else {
+		let CurrentMovementDirection(Some(direction)) = movement_direction else {
 			continue;
 		};
 
@@ -248,7 +248,7 @@ mod tests {
 				players: vec![player],
 				animations: vec![AnimationKey::Walk],
 			},
-			MovementDirection(Some(direction)),
+			CurrentMovementDirection(Some(direction)),
 			lookup,
 		));
 
@@ -297,7 +297,7 @@ mod tests {
 				players: vec![player],
 				animations: vec![AnimationKey::Walk],
 			},
-			MovementDirection(Some(direction)),
+			CurrentMovementDirection(Some(direction)),
 			lookup,
 		));
 
@@ -352,7 +352,7 @@ mod tests {
 				players: vec![player],
 				animations: vec![AnimationKey::Walk],
 			},
-			MovementDirection(Some(direction)),
+			CurrentMovementDirection(Some(direction)),
 			lookup,
 		));
 
@@ -402,7 +402,7 @@ mod tests {
 				players: vec![player],
 				animations: vec![AnimationKey::Walk],
 			},
-			MovementDirection(Dir3::new(Vec3::new(-0.039663114, 0.0, -0.9992131)).ok()),
+			CurrentMovementDirection(Dir3::new(Vec3::new(-0.039663114, 0.0, -0.9992131)).ok()),
 			lookup,
 		));
 

--- a/src/plugins/animations/src/systems/set_pitch_animation_weights.rs
+++ b/src/plugins/animations/src/systems/set_pitch_animation_weights.rs
@@ -1,0 +1,437 @@
+use crate::{
+	components::{
+		animation_lookup::{AnimationClips, AnimationLookup},
+		current_forward_pitch::CurrentForwardPitch,
+	},
+	traits::{AnimationPlayers, GetAllActiveAnimations, asset_server::animation_graph::GetNodeMut},
+};
+use bevy::prelude::*;
+use common::traits::{
+	handles_animations::DirForwardPitch,
+	wrap_handle::{GetHandle, WrapHandle},
+};
+
+impl<T> SetPitchAnimationWeights for T where T: Component + AnimationPlayers + GetAllActiveAnimations
+{}
+
+pub(crate) trait SetPitchAnimationWeights:
+	Component + AnimationPlayers + GetAllActiveAnimations + Sized
+{
+	fn set_pitch_animation_weights(
+		graphs: ResMut<Assets<AnimationGraph>>,
+		agents: Query<(&Self, &CurrentForwardPitch, &AnimationLookup)>,
+		players: Query<&AnimationGraphHandle>,
+	) {
+		set_pitch_animation_weights(graphs, agents, players)
+	}
+}
+
+macro_rules! set {
+	($value:expr, $graph:expr, $($clip:expr),+ $(,)?) => {
+		$({
+			if let Some(animation) = $graph.get_node_mut($clip) {
+				animation.weight = $value;
+			}
+		})+
+	};
+}
+
+macro_rules! blend {
+	($pitch:expr, $graph:expr, $neutral_clip:expr, $pitched_clip:expr) => {{
+		let (max_pitch, pitch_node) = $pitched_clip;
+		let pitch = **$pitch;
+		let scale = 1. / *max_pitch;
+		set!((1. - pitch * scale).clamp(0., 1.), $graph, $neutral_clip);
+		set!((pitch * scale).clamp(0., 1.), $graph, pitch_node);
+	}};
+}
+
+fn set_pitch_animation_weights<TDispatch, TGraph>(
+	mut graphs: ResMut<Assets<TGraph>>,
+	agents: Query<(&TDispatch, &CurrentForwardPitch, &AnimationLookup)>,
+	players: Query<&TGraph::TComponent>,
+) where
+	TDispatch: Component + AnimationPlayers + GetAllActiveAnimations,
+	TGraph: Asset + GetNodeMut + WrapHandle,
+{
+	for (dispatch, CurrentForwardPitch(pitch), lookup) in &agents {
+		for entity in dispatch.animation_players() {
+			let Ok(player) = players.get(entity) else {
+				continue;
+			};
+			let Some(graph) = graphs.get_mut(player.get_handle()) else {
+				continue;
+			};
+
+			for animation in dispatch.get_all_active_animations() {
+				let Some(data) = lookup.animations.get(animation) else {
+					continue;
+				};
+				let AnimationClips::PitchedForward(pitched_clips) = &data.animation_clips else {
+					continue;
+				};
+
+				match pitch {
+					None => {
+						set!(1., graph, pitched_clips.neutral);
+						set!(0., graph, pitched_clips.up.1, pitched_clips.down.1);
+					}
+					Some(DirForwardPitch::Up(pitch)) => {
+						blend!(pitch, graph, pitched_clips.neutral, pitched_clips.up);
+						set!(0., graph, pitched_clips.down.1);
+					}
+					Some(DirForwardPitch::Down(pitch)) => {
+						blend!(pitch, graph, pitched_clips.neutral, pitched_clips.down);
+						set!(0., graph, pitched_clips.up.1);
+					}
+				}
+			}
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	#![allow(clippy::unwrap_used)]
+	use super::*;
+	use crate::components::animation_lookup::{
+		AnimationClips,
+		AnimationLookupData,
+		PitchedForwardIndices,
+	};
+	use common::{
+		tools::action_key::slot::SlotKey,
+		traits::{
+			handles_animations::{AnimationKey, ForwardPitch},
+			iterate::Iterate,
+			wrap_handle::{GetHandle, WrapHandle},
+		},
+	};
+	use std::{collections::HashMap, slice::Iter, vec::IntoIter};
+	use test_case::test_case;
+	use testing::{SingleThreadedApp, assert_eq_approx, new_handle};
+
+	#[derive(Component)]
+	struct _Dispatch {
+		players: Vec<Entity>,
+		animations: Vec<AnimationKey>,
+	}
+
+	impl AnimationPlayers for _Dispatch {
+		type TIter = IntoIter<Entity>;
+
+		fn animation_players(&self) -> Self::TIter {
+			self.players.clone().into_iter()
+		}
+	}
+
+	impl GetAllActiveAnimations for _Dispatch {
+		type TIter<'a>
+			= Iter<'a, AnimationKey>
+		where
+			Self: 'a;
+
+		fn get_all_active_animations(&self) -> Self::TIter<'_> {
+			self.animations.iter()
+		}
+	}
+
+	#[derive(Asset, TypePath, Default)]
+	struct _Graph {
+		nodes: HashMap<usize, AnimationGraphNode>,
+	}
+
+	impl GetNodeMut for _Graph {
+		fn get_node_mut(
+			&mut self,
+			animation: AnimationNodeIndex,
+		) -> Option<&mut AnimationGraphNode> {
+			self.nodes.get_mut(&animation.index())
+		}
+	}
+
+	impl WrapHandle for _Graph {
+		type TComponent = _GraphComponent;
+
+		fn wrap_handle(handle: Handle<Self>) -> Self::TComponent {
+			_GraphComponent(handle)
+		}
+	}
+
+	#[derive(Component)]
+	struct _GraphComponent(Handle<_Graph>);
+
+	impl GetHandle for _GraphComponent {
+		type TAsset = _Graph;
+
+		fn get_handle(&self) -> &Handle<Self::TAsset> {
+			&self.0
+		}
+	}
+
+	fn setup(
+		lookup: &AnimationLookup,
+		weights: HashMap<usize, f32>,
+		graph_handle: &Handle<_Graph>,
+	) -> App {
+		let mut app = App::new().single_threaded(Update);
+		let mut graphs = Assets::default();
+		let mut graph = _Graph::default();
+
+		for data in lookup.animations.values() {
+			for animation in data.animation_clips.iterate() {
+				graph.nodes.insert(
+					animation.index(),
+					AnimationGraphNode {
+						weight: weights.get(&animation.index()).copied().unwrap_or(0.),
+						..default()
+					},
+				);
+			}
+		}
+
+		_ = graphs.insert(graph_handle, graph);
+		app.insert_resource(graphs);
+		app.add_systems(Update, set_pitch_animation_weights::<_Dispatch, _Graph>);
+
+		app
+	}
+
+	#[test_case(None, [1., 0., 0.]; "neutral")]
+	#[test_case(Some(DirForwardPitch::Up(ForwardPitch::MAX)), [0., 1., 0.]; "up")]
+	#[test_case(Some(DirForwardPitch::Down(ForwardPitch::MAX)), [0., 0., 1.]; "down")]
+	fn apply_full_weights(pitch: Option<DirForwardPitch>, expected_weights: [f32; 3]) {
+		let initial_weights = || {
+			expected_weights
+				.map(|weight| match weight {
+					0. => 1.,
+					_ => 0.,
+				})
+				.into_iter()
+				.enumerate()
+		};
+		let handle = new_handle();
+		let lookup = AnimationLookup {
+			animations: HashMap::from([(
+				AnimationKey::Skill(SlotKey(11)),
+				AnimationLookupData {
+					animation_clips: AnimationClips::PitchedForward(PitchedForwardIndices {
+						neutral: AnimationNodeIndex::new(0),
+						up: (ForwardPitch::MAX, AnimationNodeIndex::new(1)),
+						down: (ForwardPitch::MAX, AnimationNodeIndex::new(2)),
+					}),
+					..default()
+				},
+			)]),
+			..default()
+		};
+		let weights = HashMap::from_iter(initial_weights());
+		let mut app = setup(&lookup, weights, &handle);
+		let player = app.world_mut().spawn(_GraphComponent(handle.clone())).id();
+		app.world_mut().spawn((
+			_Dispatch {
+				players: vec![player],
+				animations: vec![AnimationKey::Skill(SlotKey(11))],
+			},
+			CurrentForwardPitch(pitch),
+			lookup,
+		));
+
+		app.update();
+
+		let graphs = app.world().resource::<Assets<_Graph>>();
+		let graph = graphs.get(&handle).unwrap();
+		assert_eq_approx!(
+			expected_weights,
+			[
+				graph.nodes.get(&0).unwrap().weight,
+				graph.nodes.get(&1).unwrap().weight,
+				graph.nodes.get(&2).unwrap().weight,
+			],
+			f32::EPSILON
+		);
+	}
+
+	#[test_case(Some(DirForwardPitch::Up(ForwardPitch::try_from(0.3).unwrap())), [0.7, 0.3, 0.]; "up")]
+	#[test_case(Some(DirForwardPitch::Down(ForwardPitch::try_from(0.3).unwrap())), [0.7, 0., 0.3]; "down")]
+	fn apply_blended_weights_when_configured_with_max_pitch(
+		pitch: Option<DirForwardPitch>,
+		expected_weights: [f32; 3],
+	) {
+		let initial_weights = || {
+			expected_weights
+				.map(|weight| match weight {
+					0. => 1.,
+					_ => 0.,
+				})
+				.into_iter()
+				.enumerate()
+		};
+		let handle = new_handle();
+		let lookup = AnimationLookup {
+			animations: HashMap::from([(
+				AnimationKey::Skill(SlotKey(11)),
+				AnimationLookupData {
+					animation_clips: AnimationClips::PitchedForward(PitchedForwardIndices {
+						neutral: AnimationNodeIndex::new(0),
+						up: (ForwardPitch::MAX, AnimationNodeIndex::new(1)),
+						down: (ForwardPitch::MAX, AnimationNodeIndex::new(2)),
+					}),
+					..default()
+				},
+			)]),
+			..default()
+		};
+		let weights = HashMap::from_iter(initial_weights());
+		let mut app = setup(&lookup, weights, &handle);
+		let player = app.world_mut().spawn(_GraphComponent(handle.clone())).id();
+		app.world_mut().spawn((
+			_Dispatch {
+				players: vec![player],
+				animations: vec![AnimationKey::Skill(SlotKey(11))],
+			},
+			CurrentForwardPitch(pitch),
+			lookup,
+		));
+
+		app.update();
+
+		let graphs = app.world().resource::<Assets<_Graph>>();
+		let graph = graphs.get(&handle).unwrap();
+		assert_eq_approx!(
+			expected_weights,
+			[
+				graph.nodes.get(&0).unwrap().weight,
+				graph.nodes.get(&1).unwrap().weight,
+				graph.nodes.get(&2).unwrap().weight,
+			],
+			f32::EPSILON
+		);
+	}
+
+	#[test_case(Some(DirForwardPitch::Up(ForwardPitch::try_from(0.2).unwrap())), [0.75, 0.25, 0.]; "up")]
+	#[test_case(Some(DirForwardPitch::Down(ForwardPitch::try_from(0.2).unwrap())), [0.75, 0., 0.25]; "down")]
+	fn apply_blended_weights_when_configured_with_less_than_max_pitch(
+		pitch: Option<DirForwardPitch>,
+		expected_weights: [f32; 3],
+	) {
+		let initial_weights = || {
+			expected_weights
+				.map(|weight| match weight {
+					0. => 1.,
+					_ => 0.,
+				})
+				.into_iter()
+				.enumerate()
+		};
+		let handle = new_handle();
+		let lookup = AnimationLookup {
+			animations: HashMap::from([(
+				AnimationKey::Skill(SlotKey(11)),
+				AnimationLookupData {
+					animation_clips: AnimationClips::PitchedForward(PitchedForwardIndices {
+						neutral: AnimationNodeIndex::new(0),
+						up: (
+							ForwardPitch::try_from(0.8).unwrap(),
+							AnimationNodeIndex::new(1),
+						),
+						down: (
+							ForwardPitch::try_from(0.8).unwrap(),
+							AnimationNodeIndex::new(2),
+						),
+					}),
+					..default()
+				},
+			)]),
+			..default()
+		};
+		let weights = HashMap::from_iter(initial_weights());
+		let mut app = setup(&lookup, weights, &handle);
+		let player = app.world_mut().spawn(_GraphComponent(handle.clone())).id();
+		app.world_mut().spawn((
+			_Dispatch {
+				players: vec![player],
+				animations: vec![AnimationKey::Skill(SlotKey(11))],
+			},
+			CurrentForwardPitch(pitch),
+			lookup,
+		));
+
+		app.update();
+
+		let graphs = app.world().resource::<Assets<_Graph>>();
+		let graph = graphs.get(&handle).unwrap();
+		assert_eq_approx!(
+			expected_weights,
+			[
+				graph.nodes.get(&0).unwrap().weight,
+				graph.nodes.get(&1).unwrap().weight,
+				graph.nodes.get(&2).unwrap().weight,
+			],
+			f32::EPSILON
+		);
+	}
+
+	#[test_case(Some(DirForwardPitch::Up(ForwardPitch::try_from(0.9).unwrap())), [0., 1., 0.]; "up")]
+	#[test_case(Some(DirForwardPitch::Down(ForwardPitch::try_from(0.9).unwrap())), [0., 0., 1.]; "down")]
+	fn apply_clamped_blended_weights_when_configured_with_less_than_max_pitch(
+		pitch: Option<DirForwardPitch>,
+		expected_weights: [f32; 3],
+	) {
+		let initial_weights = || {
+			expected_weights
+				.map(|weight| match weight {
+					0. => 1.,
+					_ => 0.,
+				})
+				.into_iter()
+				.enumerate()
+		};
+		let handle = new_handle();
+		let lookup = AnimationLookup {
+			animations: HashMap::from([(
+				AnimationKey::Skill(SlotKey(11)),
+				AnimationLookupData {
+					animation_clips: AnimationClips::PitchedForward(PitchedForwardIndices {
+						neutral: AnimationNodeIndex::new(0),
+						up: (
+							ForwardPitch::try_from(0.8).unwrap(),
+							AnimationNodeIndex::new(1),
+						),
+						down: (
+							ForwardPitch::try_from(0.8).unwrap(),
+							AnimationNodeIndex::new(2),
+						),
+					}),
+					..default()
+				},
+			)]),
+			..default()
+		};
+		let weights = HashMap::from_iter(initial_weights());
+		let mut app = setup(&lookup, weights, &handle);
+		let player = app.world_mut().spawn(_GraphComponent(handle.clone())).id();
+		app.world_mut().spawn((
+			_Dispatch {
+				players: vec![player],
+				animations: vec![AnimationKey::Skill(SlotKey(11))],
+			},
+			CurrentForwardPitch(pitch),
+			lookup,
+		));
+
+		app.update();
+
+		let graphs = app.world().resource::<Assets<_Graph>>();
+		let graph = graphs.get(&handle).unwrap();
+		assert_eq_approx!(
+			expected_weights,
+			[
+				graph.nodes.get(&0).unwrap().weight,
+				graph.nodes.get(&1).unwrap().weight,
+				graph.nodes.get(&2).unwrap().weight,
+			],
+			f32::EPSILON
+		);
+	}
+}

--- a/src/plugins/animations/src/traits/asset_server.rs
+++ b/src/plugins/animations/src/traits/asset_server.rs
@@ -1,12 +1,16 @@
 pub(crate) mod animation_graph;
 
 use super::LoadAnimationAssets;
-use crate::components::animation_lookup::{AnimationClips, DirectionalIndices};
+use crate::components::animation_lookup::{
+	AnimationClips,
+	DirectionalIndices,
+	PitchedForwardIndices,
+};
 use bevy::prelude::*;
 use common::{
 	tools::path::Path,
 	traits::{
-		handles_animations::{AnimationPath, Directional},
+		handles_animations::{AnimationPath, Directional, PitchedForward},
 		load_asset::LoadAsset,
 	},
 };
@@ -46,16 +50,34 @@ where
 				let index = graph.add_clip(clip, 1., blend_node);
 				AnimationClips::Single(index)
 			}
-			AnimationPath::Directional(direction_paths) => {
+			AnimationPath::Directional(paths) => {
 				let blend_node = graph.add_blend(1., blend_node);
 				let mut animations = DirectionalIndices::default();
 
-				for (animation, path) in iter_parallel(&mut animations, direction_paths) {
+				for (animation, path) in iter_parallel(&mut animations, paths) {
 					let clip = server.load_asset(path);
 					*animation = graph.add_clip(clip, 0., blend_node);
 				}
 
 				AnimationClips::Directional(animations)
+			}
+			AnimationPath::PitchedForward(paths) => {
+				let blend_node = graph.add_blend(1., blend_node);
+
+				let PitchedForward {
+					neutral,
+					up: (up_pitch, up_path),
+					down: (down_pitch, down_path),
+				} = paths;
+				let neutral = server.load_asset(neutral);
+				let up = server.load_asset(up_path);
+				let down = server.load_asset(down_path);
+
+				AnimationClips::PitchedForward(PitchedForwardIndices {
+					neutral: graph.add_clip(neutral, 0., blend_node),
+					up: (*up_pitch, graph.add_clip(up, 0., blend_node)),
+					down: (*down_pitch, graph.add_clip(down, 0., blend_node)),
+				})
 			}
 		};
 		(animation, animations)
@@ -90,7 +112,11 @@ trait AnimationGraphTrait {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use common::traits::load_asset::mock::MockAssetServer;
+	use crate::components::animation_lookup::PitchedForwardIndices;
+	use common::traits::{
+		handles_animations::{ForwardPitch, PitchedForward},
+		load_asset::mock::MockAssetServer,
+	};
 	use mockall::{mock, predicate::eq};
 	use testing::new_handle;
 
@@ -377,6 +403,138 @@ mod tests {
 						backward: AnimationNodeIndex::new(2),
 						left: AnimationNodeIndex::new(3),
 						right: AnimationNodeIndex::new(4)
+					})
+				)]),
+				map
+			);
+		}
+	}
+
+	mod pitched_animation_asset {
+		#![allow(clippy::unwrap_used)]
+		use super::*;
+		use std::sync::LazyLock;
+
+		#[test]
+		fn load_assets() {
+			setup_graph!(|_| {});
+			let neutral = "neutral";
+			let up = "up";
+			let down = "down";
+			let mut server = MockAssetServer::default();
+
+			let _: _AnimAssets =
+				server.load_animation_assets(vec![AnimationPath::PitchedForward(PitchedForward {
+					neutral: Path::from(neutral),
+					up: (ForwardPitch::default(), Path::from(up)),
+					down: (ForwardPitch::default(), Path::from(down)),
+				})]);
+
+			assert_eq!(
+				(1, 1, 1),
+				(server.calls(up), server.calls(down), server.calls(neutral)),
+			)
+		}
+
+		#[test]
+		fn add_loaded_clips_to_graph() {
+			static NEUTRAL: LazyLock<Handle<AnimationClip>> = LazyLock::new(new_handle);
+			static UP: LazyLock<Handle<AnimationClip>> = LazyLock::new(new_handle);
+			static DOWN: LazyLock<Handle<AnimationClip>> = LazyLock::new(new_handle);
+			setup_graph!(|mock| {
+				mock.expect_add_additive_blend()
+					.return_const(AnimationNodeIndex::new(11));
+				mock.expect_add_blend()
+					.times(1)
+					.with(eq(1.), eq(AnimationNodeIndex::new(11)))
+					.return_const(AnimationNodeIndex::new(4242));
+				mock.expect_add_clip()
+					.times(1)
+					.with(
+						eq(NEUTRAL.clone()),
+						eq(0.),
+						eq(AnimationNodeIndex::new(4242)),
+					)
+					.return_const(AnimationNodeIndex::default());
+				mock.expect_add_clip()
+					.times(1)
+					.with(eq(UP.clone()), eq(0.), eq(AnimationNodeIndex::new(4242)))
+					.return_const(AnimationNodeIndex::default());
+				mock.expect_add_clip()
+					.times(1)
+					.with(eq(DOWN.clone()), eq(0.), eq(AnimationNodeIndex::new(4242)))
+					.return_const(AnimationNodeIndex::default());
+			});
+			let neutral = "neutral";
+			let up = "up";
+			let down = "down";
+			let mut server = MockAssetServer::default()
+				.path(neutral)
+				.returns(NEUTRAL.clone())
+				.path(up)
+				.returns(UP.clone())
+				.path(down)
+				.returns(DOWN.clone());
+
+			let _: _AnimAssets =
+				server.load_animation_assets(vec![AnimationPath::PitchedForward(PitchedForward {
+					neutral: Path::from(neutral),
+					up: (ForwardPitch::default(), Path::from(up)),
+					down: (ForwardPitch::default(), Path::from(down)),
+				})]);
+		}
+
+		#[test]
+		fn return_animation_node_indices() {
+			static NEUTRAL: LazyLock<Handle<AnimationClip>> = LazyLock::new(new_handle);
+			static UP: LazyLock<Handle<AnimationClip>> = LazyLock::new(new_handle);
+			static DOWN: LazyLock<Handle<AnimationClip>> = LazyLock::new(new_handle);
+			setup_graph!(|mock| {
+				mock.expect_add_clip()
+					.with(
+						eq(NEUTRAL.clone()),
+						eq(0.),
+						eq(AnimationNodeIndex::default()),
+					)
+					.return_const(AnimationNodeIndex::new(1));
+				mock.expect_add_clip()
+					.with(eq(UP.clone()), eq(0.), eq(AnimationNodeIndex::default()))
+					.return_const(AnimationNodeIndex::new(2));
+				mock.expect_add_clip()
+					.with(eq(DOWN.clone()), eq(0.), eq(AnimationNodeIndex::default()))
+					.return_const(AnimationNodeIndex::new(3));
+			});
+			let neutral = "neutral";
+			let up = "up";
+			let down = "down";
+			let mut server = MockAssetServer::default()
+				.path(neutral)
+				.returns(NEUTRAL.clone())
+				.path(up)
+				.returns(UP.clone())
+				.path(down)
+				.returns(DOWN.clone());
+			let asset = AnimationPath::PitchedForward(PitchedForward {
+				neutral: Path::from(neutral),
+				up: (ForwardPitch::try_from(0.9).unwrap(), Path::from(up)),
+				down: (ForwardPitch::try_from(0.3).unwrap(), Path::from(down)),
+			});
+
+			let (_, map): _AnimAssets = server.load_animation_assets(vec![asset.clone()]);
+
+			assert_eq!(
+				HashMap::from([(
+					asset,
+					AnimationClips::PitchedForward(PitchedForwardIndices {
+						neutral: AnimationNodeIndex::new(1),
+						up: (
+							ForwardPitch::try_from(0.9).unwrap(),
+							AnimationNodeIndex::new(2)
+						),
+						down: (
+							ForwardPitch::try_from(0.3).unwrap(),
+							AnimationNodeIndex::new(3)
+						),
 					})
 				)]),
 				map

--- a/src/plugins/common/src/traits/handles_animations.rs
+++ b/src/plugins/common/src/traits/handles_animations.rs
@@ -20,7 +20,8 @@ pub trait HandlesAnimations {
 	type TAnimationsMut<'w, 's>: SystemParam
 		+ for<'c> GetContextMut<WithoutAnimations, TContext<'c>: RegisterAnimations>
 		+ for<'c> GetContextMut<Animations, TContext<'c>: ActiveAnimationsMut>
-		+ for<'c> GetContextMut<Animations, TContext<'c>: MoveDirectionMut>;
+		+ for<'c> GetContextMut<Animations, TContext<'c>: GetMoveDirectionMut>
+		+ for<'c> GetContextMut<Animations, TContext<'c>: GetForwardPitchMut>;
 }
 
 #[derive(EntityKey)]
@@ -93,30 +94,38 @@ where
 	}
 }
 
-pub trait MoveDirection {
-	fn move_direction(&self) -> Option<Dir3>;
+pub trait GetMoveDirection {
+	fn get_move_direction(&self) -> Option<Dir3>;
 }
 
-impl<T> MoveDirection for T
+impl<T> GetMoveDirection for T
 where
-	T: Deref<Target: MoveDirection>,
+	T: Deref<Target: GetMoveDirection>,
 {
-	fn move_direction(&self) -> Option<Dir3> {
-		self.deref().move_direction()
+	fn get_move_direction(&self) -> Option<Dir3> {
+		self.deref().get_move_direction()
 	}
 }
 
-pub trait MoveDirectionMut: MoveDirection {
-	fn move_direction_mut(&mut self) -> &mut Option<Dir3>;
+pub trait GetMoveDirectionMut: GetMoveDirection {
+	fn get_move_direction_mut(&mut self) -> &mut Option<Dir3>;
 }
 
-impl<T> MoveDirectionMut for T
+impl<T> GetMoveDirectionMut for T
 where
-	T: DerefMut<Target: MoveDirectionMut>,
+	T: DerefMut<Target: GetMoveDirectionMut>,
 {
-	fn move_direction_mut(&mut self) -> &mut Option<Dir3> {
-		self.deref_mut().move_direction_mut()
+	fn get_move_direction_mut(&mut self) -> &mut Option<Dir3> {
+		self.deref_mut().get_move_direction_mut()
 	}
+}
+
+pub trait GetForwardPitch {
+	fn get_forward_pitch(&self) -> Option<DirForwardPitch>;
+}
+
+pub trait GetForwardPitchMut: GetForwardPitch {
+	fn get_forward_pitch_mut(&mut self) -> &mut Option<DirForwardPitch>;
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
@@ -151,9 +160,13 @@ pub struct PitchedForward {
 #[in_range(low = >0., high = 1.)]
 pub struct ForwardPitch(f32);
 
+impl ForwardPitch {
+	pub const MAX: Self = Self(1.);
+}
+
 impl Default for ForwardPitch {
 	fn default() -> Self {
-		Self(1.)
+		Self::MAX
 	}
 }
 
@@ -168,6 +181,12 @@ impl Hash for ForwardPitch {
 
 		bits.hash(state);
 	}
+}
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum DirForwardPitch {
+	Up(ForwardPitch),
+	Down(ForwardPitch),
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]

--- a/src/plugins/common/src/traits/handles_animations.rs
+++ b/src/plugins/common/src/traits/handles_animations.rs
@@ -8,10 +8,11 @@ use crate::{
 	},
 };
 use bevy::{ecs::system::SystemParam, prelude::*};
-use macros::EntityKey;
+use macros::{EntityKey, InRange};
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Error};
 use std::{
 	collections::{HashMap, HashSet},
+	hash::Hash,
 	ops::{Deref, DerefMut},
 };
 
@@ -122,6 +123,7 @@ where
 pub enum AnimationPath {
 	Single(Path),
 	Directional(Directional),
+	PitchedForward(PitchedForward),
 }
 
 impl From<&'static str> for AnimationPath {
@@ -136,6 +138,36 @@ pub struct Directional {
 	pub backward: Path,
 	pub left: Path,
 	pub right: Path,
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+pub struct PitchedForward {
+	pub neutral: Path,
+	pub up: (ForwardPitch, Path),
+	pub down: (ForwardPitch, Path),
+}
+
+#[derive(InRange, Debug, PartialEq, Clone, Copy, Serialize, Deserialize)]
+#[in_range(low = >0., high = 1.)]
+pub struct ForwardPitch(f32);
+
+impl Default for ForwardPitch {
+	fn default() -> Self {
+		Self(1.)
+	}
+}
+
+impl Eq for ForwardPitch {}
+
+impl Hash for ForwardPitch {
+	fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+		let bits = match self.0 {
+			0.0 => 0,
+			v => v.to_bits(),
+		};
+
+		bits.hash(state);
+	}
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]

--- a/src/plugins/common/src/traits/handles_animations.rs
+++ b/src/plugins/common/src/traits/handles_animations.rs
@@ -124,8 +124,26 @@ pub trait GetForwardPitch {
 	fn get_forward_pitch(&self) -> Option<DirForwardPitch>;
 }
 
+impl<T> GetForwardPitch for T
+where
+	T: Deref<Target: GetForwardPitch>,
+{
+	fn get_forward_pitch(&self) -> Option<DirForwardPitch> {
+		self.deref().get_forward_pitch()
+	}
+}
+
 pub trait GetForwardPitchMut: GetForwardPitch {
 	fn get_forward_pitch_mut(&mut self) -> &mut Option<DirForwardPitch>;
+}
+
+impl<T> GetForwardPitchMut for T
+where
+	T: DerefMut<Target: GetForwardPitchMut>,
+{
+	fn get_forward_pitch_mut(&mut self) -> &mut Option<DirForwardPitch> {
+		self.deref_mut().get_forward_pitch_mut()
+	}
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]

--- a/src/plugins/common/src/traits/handles_physics.rs
+++ b/src/plugins/common/src/traits/handles_physics.rs
@@ -294,6 +294,12 @@ pub struct MouseHover {
 
 impl MouseHover {
 	pub const NO_EXCLUDES: Self = Self { exclude: vec![] };
+
+	pub fn excluding(exclude: impl IntoIterator<Item = Entity>) -> Self {
+		Self {
+			exclude: Vec::from_iter(exclude),
+		}
+	}
 }
 
 impl RaycastResult for MouseHover {

--- a/src/plugins/movement/src/systems/animate_forward.rs
+++ b/src/plugins/movement/src/systems/animate_forward.rs
@@ -1,7 +1,7 @@
 use bevy::{ecs::system::StaticSystemParam, prelude::*};
 use common::traits::{
 	accessors::get::{GetContextMut, View},
-	handles_animations::{Animations, MoveDirectionMut},
+	handles_animations::{Animations, GetMoveDirectionMut},
 	handles_physics::CharacterMotion,
 };
 
@@ -14,7 +14,7 @@ pub(crate) trait SetForwardAnimationDirection:
 		mut animations: StaticSystemParam<TAnimations>,
 		movements: Query<(Entity, &Self, &Transform), Changed<Self>>,
 	) where
-		TAnimations: for<'c> GetContextMut<Animations, TContext<'c>: MoveDirectionMut>,
+		TAnimations: for<'c> GetContextMut<Animations, TContext<'c>: GetMoveDirectionMut>,
 	{
 		for (entity, movement, transform) in &movements {
 			let key = Animations { entity };
@@ -26,7 +26,7 @@ pub(crate) trait SetForwardAnimationDirection:
 				continue;
 			};
 
-			*animations.move_direction_mut() = Some(forward);
+			*animations.get_move_direction_mut() = Some(forward);
 		}
 	}
 }
@@ -48,7 +48,7 @@ where
 mod tests {
 	#![allow(clippy::unwrap_used)]
 	use super::*;
-	use common::{tools::speed::Speed, traits::handles_animations::MoveDirection};
+	use common::{tools::speed::Speed, traits::handles_animations::GetMoveDirection};
 	use testing::SingleThreadedApp;
 
 	#[derive(Component)]
@@ -63,14 +63,14 @@ mod tests {
 	#[derive(Component, Debug, PartialEq)]
 	struct _Animations(Option<Dir3>);
 
-	impl MoveDirection for _Animations {
-		fn move_direction(&self) -> Option<Dir3> {
+	impl GetMoveDirection for _Animations {
+		fn get_move_direction(&self) -> Option<Dir3> {
 			self.0
 		}
 	}
 
-	impl MoveDirectionMut for _Animations {
-		fn move_direction_mut(&mut self) -> &mut Option<Dir3> {
+	impl GetMoveDirectionMut for _Animations {
+		fn get_move_direction_mut(&mut self) -> &mut Option<Dir3> {
 			&mut self.0
 		}
 	}

--- a/src/plugins/skills/src/lib.rs
+++ b/src/plugins/skills/src/lib.rs
@@ -13,6 +13,7 @@ use crate::{
 		queue::dto::QueueDto,
 		slot_definitions::SlotDefinitions,
 		slots::visualization::SlotVisualization,
+		target::Target,
 	},
 	skills::SkillId,
 	system_parameters::{
@@ -31,11 +32,12 @@ use common::{
 	states::game_state::{GameState, LoadingGame},
 	traits::{
 		after_plugin::AfterPlugin,
+		handles_animations::{AnimationsSystemParamMut, HandlesAnimations},
 		handles_custom_assets::{HandlesCustomAssets, HandlesCustomFolderAssets},
 		handles_load_tracking::HandlesLoadTracking,
 		handles_loadout::HandlesLoadout,
 		handles_orientation::{FacingSystemParamMut, HandlesOrientation},
-		handles_physics::HandlesAllPhysicalEffects,
+		handles_physics::{HandlesAllPhysicalEffects, HandlesRaycast, RaycastSystemParam},
 		handles_saving::HandlesSaving,
 		handles_skill_physics::{HandlesSkillPhysics, SkillSpawnerMut},
 		system_set_definition::SystemSetDefinition,
@@ -63,16 +65,23 @@ use systems::{
 
 pub struct SkillsPlugin<TDependencies>(PhantomData<TDependencies>);
 
-impl<TSaveGame, TPhysics, TLoading, TMovement>
-	SkillsPlugin<(TSaveGame, TPhysics, TLoading, TMovement)>
+impl<TSaveGame, TAnimations, TPhysics, TLoading, TMovement>
+	SkillsPlugin<(TSaveGame, TAnimations, TPhysics, TLoading, TMovement)>
 where
 	TSaveGame: ThreadSafe + HandlesSaving,
-	TPhysics: ThreadSafe + HandlesAllPhysicalEffects + HandlesSkillPhysics,
+	TAnimations: ThreadSafe + HandlesAnimations,
+	TPhysics: ThreadSafe + HandlesAllPhysicalEffects + HandlesSkillPhysics + HandlesRaycast,
 	TLoading: ThreadSafe + HandlesCustomAssets + HandlesCustomFolderAssets + HandlesLoadTracking,
 	TMovement: ThreadSafe + HandlesOrientation + SystemSetDefinition,
 {
 	#[allow(clippy::too_many_arguments)]
-	pub fn from_plugins(_: &TSaveGame, _: &TPhysics, _: &TLoading, _: &TMovement) -> Self {
+	pub fn from_plugins(
+		_: &TSaveGame,
+		_: &TAnimations,
+		_: &TPhysics,
+		_: &TLoading,
+		_: &TMovement,
+	) -> Self {
 		Self(PhantomData)
 	}
 
@@ -119,6 +128,10 @@ where
 				ActiveSkill::execute::<SkillSpawnerMut<TPhysics>>,
 				flush::<Queue>,
 				HeldSlots::<Old>::update_from::<Current>,
+				Target::update_pitch::<
+					RaycastSystemParam<TPhysics>,
+					AnimationsSystemParamMut<TAnimations>,
+				>,
 			)
 				.chain()
 				.after_plugin(TMovement::SYSTEMS)
@@ -127,11 +140,12 @@ where
 	}
 }
 
-impl<TSaveGame, TPhysics, TLoading, TMovement> Plugin
-	for SkillsPlugin<(TSaveGame, TPhysics, TLoading, TMovement)>
+impl<TSaveGame, TAnimations, TPhysics, TLoading, TMovement> Plugin
+	for SkillsPlugin<(TSaveGame, TAnimations, TPhysics, TLoading, TMovement)>
 where
 	TSaveGame: ThreadSafe + HandlesSaving,
-	TPhysics: ThreadSafe + HandlesAllPhysicalEffects + HandlesSkillPhysics,
+	TPhysics: ThreadSafe + HandlesAllPhysicalEffects + HandlesSkillPhysics + HandlesRaycast,
+	TAnimations: ThreadSafe + HandlesAnimations,
 	TLoading: ThreadSafe + HandlesCustomAssets + HandlesCustomFolderAssets + HandlesLoadTracking,
 	TMovement: ThreadSafe + HandlesOrientation + SystemSetDefinition,
 {

--- a/src/plugins/skills/src/systems.rs
+++ b/src/plugins/skills/src/systems.rs
@@ -6,3 +6,4 @@ pub(crate) mod flush;
 pub(crate) mod flush_skill_combos;
 pub(crate) mod schedule_active_skill;
 pub(crate) mod slot;
+pub(crate) mod update_target_pitch;

--- a/src/plugins/skills/src/systems/update_target_pitch.rs
+++ b/src/plugins/skills/src/systems/update_target_pitch.rs
@@ -1,0 +1,378 @@
+use crate::components::target::Target;
+use bevy::{
+	ecs::system::{StaticSystemParam, SystemParam},
+	prelude::*,
+};
+use common::{
+	traits::{
+		accessors::get::{Get, GetContextMut},
+		handles_animations::{Animations, DirForwardPitch, ForwardPitch, GetForwardPitchMut},
+		handles_physics::{MouseHover, MouseHoversOver, Raycast},
+		handles_skill_physics::SkillTarget,
+	},
+	zyheeda_commands::ZyheedaCommands,
+};
+use std::f32::consts::FRAC_PI_2;
+
+impl Target {
+	pub(crate) fn update_pitch<TRayCast, TAnimations>(
+		mut animations: StaticSystemParam<TAnimations>,
+		mut ray_caster: StaticSystemParam<TRayCast>,
+		targets: Query<(Entity, &Self, &GlobalTransform), Changed<Self>>,
+		transforms: Query<&GlobalTransform>,
+		commands: ZyheedaCommands,
+	) where
+		for<'w, 's> TRayCast: SystemParam<Item<'w, 's>: Raycast<MouseHover>>,
+		for<'c> TAnimations:
+			SystemParam + GetContextMut<Animations, TContext<'c>: GetForwardPitchMut>,
+	{
+		for (entity, target, transform) in targets {
+			let key = Animations { entity };
+			let Some(mut ctx) = TAnimations::get_context_mut(&mut animations, key) else {
+				continue;
+			};
+			let pitch = target.get_pitch(entity, transform, transforms, &commands, &mut ray_caster);
+
+			*ctx.get_forward_pitch_mut() = pitch;
+		}
+	}
+
+	fn get_pitch(
+		&self,
+		entity: Entity,
+		transform: &GlobalTransform,
+		transforms: Query<&GlobalTransform>,
+		commands: &ZyheedaCommands,
+		ray_cast: &mut impl Raycast<MouseHover>,
+	) -> Option<DirForwardPitch> {
+		match self.0.as_ref()? {
+			SkillTarget::Entity(entity) => {
+				let target = commands.get(entity)?;
+				let target = transforms.get(target).ok()?.translation();
+				get_pitch(transform, target)
+			}
+			SkillTarget::Cursor => match ray_cast.raycast(MouseHover::excluding([entity]))? {
+				MouseHoversOver::Terrain { point } => get_pitch(transform, point),
+				MouseHoversOver::Object { entity, .. } => {
+					let target = transforms.get(entity).ok()?.translation();
+					get_pitch(transform, target)
+				}
+			},
+		}
+	}
+}
+
+fn get_pitch(transform: &GlobalTransform, to: Vec3) -> Option<DirForwardPitch> {
+	let dir = (to - transform.translation()).try_normalize()?;
+	let pitch = ForwardPitch::try_from((dir.y.asin() / FRAC_PI_2).abs()).ok()?;
+
+	if dir.y > 0. {
+		Some(DirForwardPitch::Up(pitch))
+	} else {
+		Some(DirForwardPitch::Down(pitch))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	#![allow(clippy::unwrap_used)]
+	use super::*;
+	use common::{
+		CommonPlugin,
+		components::persistent_entity::PersistentEntity,
+		traits::{
+			handles_animations::{ForwardPitch, GetForwardPitch},
+			handles_skill_physics::SkillTarget,
+		},
+	};
+	use macros::NestedMocks;
+	use mockall::{automock, predicate::eq};
+	use test_case::test_case;
+	use testing::{ApproxEqual, IsChanged, NestedMocks, SingleThreadedApp, assert_eq_approx};
+
+	#[derive(Resource, NestedMocks)]
+	struct _RayCast {
+		mock: Mock_RayCast,
+	}
+
+	impl Default for _RayCast {
+		fn default() -> Self {
+			Self::new().with_mock(|mock| {
+				mock.expect_raycast().return_const(None);
+			})
+		}
+	}
+
+	#[automock]
+	impl Raycast<MouseHover> for _RayCast {
+		fn raycast(&mut self, args: MouseHover) -> Option<MouseHoversOver> {
+			self.mock.raycast(args)
+		}
+	}
+
+	#[derive(Component, Debug, PartialEq)]
+	struct _Animations {
+		forward_pitch: Option<DirForwardPitch>,
+	}
+
+	impl ApproxEqual<f32> for _Animations {
+		fn approx_equal(&self, other: &Self, tolerance: &f32) -> bool {
+			match (&self.forward_pitch, &other.forward_pitch) {
+				(None, None) => true,
+				(Some(DirForwardPitch::Up(l)), Some(DirForwardPitch::Up(r))) => {
+					l.approx_equal(r, tolerance)
+				}
+				(Some(DirForwardPitch::Down(l)), Some(DirForwardPitch::Down(r))) => {
+					l.approx_equal(r, tolerance)
+				}
+				_ => false,
+			}
+		}
+	}
+
+	impl GetForwardPitch for _Animations {
+		fn get_forward_pitch(&self) -> Option<DirForwardPitch> {
+			self.forward_pitch
+		}
+	}
+
+	impl GetForwardPitchMut for _Animations {
+		fn get_forward_pitch_mut(&mut self) -> &mut Option<DirForwardPitch> {
+			&mut self.forward_pitch
+		}
+	}
+
+	fn setup() -> App {
+		let mut app = App::new().single_threaded(Update);
+
+		app.add_plugins(CommonPlugin);
+		app.init_resource::<_RayCast>();
+		app.add_systems(
+			Update,
+			(
+				Target::update_pitch::<ResMut<_RayCast>, Query<&mut _Animations>>,
+				IsChanged::<_Animations>::detect,
+			)
+				.chain(),
+		);
+
+		app
+	}
+
+	#[test]
+	fn set_none() {
+		let mut app = setup();
+		let entity = app
+			.world_mut()
+			.spawn((
+				Target(None),
+				GlobalTransform::default(),
+				_Animations {
+					forward_pitch: Some(DirForwardPitch::Down(ForwardPitch::MAX)),
+				},
+			))
+			.id();
+
+		app.update();
+
+		assert_eq!(
+			Some(&_Animations {
+				forward_pitch: None
+			}),
+			app.world().entity(entity).get::<_Animations>(),
+		);
+	}
+
+	#[test_case(0., None; "0 degrees")]
+	#[test_case(45., ForwardPitch::try_from(0.5).ok().map(DirForwardPitch::Up); "45 degrees up")]
+	#[test_case(-45., ForwardPitch::try_from(0.5).ok().map(DirForwardPitch::Down); "45 degrees down")]
+	#[test_case(90., DirForwardPitch::Up(ForwardPitch::MAX); "90 degrees up")]
+	#[test_case(-90., DirForwardPitch::Down(ForwardPitch::MAX); "90 degrees down")]
+	fn set_target_entity_pitch(angle: f32, forward_pitch: impl Into<Option<DirForwardPitch>>) {
+		let mut app = setup();
+		let translation = Vec3::new(10., 2., 0.);
+		let offset = Quat::from_rotation_x(angle.to_radians()).mul_vec3(Vec3::new(0., 0., -30.));
+		let target_entity = PersistentEntity::default();
+		let entity = app
+			.world_mut()
+			.spawn((
+				Target(Some(SkillTarget::Entity(target_entity))),
+				GlobalTransform::from_translation(translation),
+				_Animations {
+					forward_pitch: None,
+				},
+			))
+			.id();
+
+		app.world_mut().spawn((
+			target_entity,
+			GlobalTransform::from_translation(translation + offset),
+		));
+
+		app.update();
+
+		assert_eq_approx!(
+			Some(&_Animations {
+				forward_pitch: forward_pitch.into()
+			}),
+			app.world().entity(entity).get::<_Animations>(),
+			1e-5,
+		);
+	}
+
+	#[test_case(0., None; "0 degrees")]
+	#[test_case(45., ForwardPitch::try_from(0.5).ok().map(DirForwardPitch::Up); "45 degrees up")]
+	#[test_case(-45., ForwardPitch::try_from(0.5).ok().map(DirForwardPitch::Down); "45 degrees down")]
+	#[test_case(90., DirForwardPitch::Up(ForwardPitch::MAX); "90 degrees up")]
+	#[test_case(-90., DirForwardPitch::Down(ForwardPitch::MAX); "90 degrees down")]
+	fn set_cursor_terrain_hit_pitch(angle: f32, forward_pitch: impl Into<Option<DirForwardPitch>>) {
+		let mut app = setup();
+		let translation = Vec3::new(10., 2., 0.);
+		let offset = Quat::from_rotation_x(angle.to_radians()).mul_vec3(Vec3::new(0., 0., -30.));
+		let entity = app
+			.world_mut()
+			.spawn((
+				Target(Some(SkillTarget::Cursor)),
+				GlobalTransform::from_translation(translation),
+				_Animations {
+					forward_pitch: None,
+				},
+			))
+			.id();
+		app.insert_resource(_RayCast::new().with_mock(|mock| {
+			mock.expect_raycast()
+				.return_const(Some(MouseHoversOver::Terrain {
+					point: translation + offset,
+				}));
+		}));
+
+		app.update();
+
+		assert_eq_approx!(
+			Some(&_Animations {
+				forward_pitch: forward_pitch.into()
+			}),
+			app.world().entity(entity).get::<_Animations>(),
+			1e-5,
+		);
+	}
+
+	#[test_case(0., None; "0 degrees")]
+	#[test_case(45., ForwardPitch::try_from(0.5).ok().map(DirForwardPitch::Up); "45 degrees up")]
+	#[test_case(-45., ForwardPitch::try_from(0.5).ok().map(DirForwardPitch::Down); "45 degrees down")]
+	#[test_case(90., DirForwardPitch::Up(ForwardPitch::MAX); "90 degrees up")]
+	#[test_case(-90., DirForwardPitch::Down(ForwardPitch::MAX); "90 degrees down")]
+	fn set_cursor_entity_hit_pitch(angle: f32, forward_pitch: impl Into<Option<DirForwardPitch>>) {
+		let mut app = setup();
+		let translation = Vec3::new(10., 2., 0.);
+		let offset = Quat::from_rotation_x(angle.to_radians()).mul_vec3(Vec3::new(0., 0., -30.));
+		let target = app
+			.world_mut()
+			.spawn(GlobalTransform::from_translation(translation + offset))
+			.id();
+		let entity = app
+			.world_mut()
+			.spawn((
+				Target(Some(SkillTarget::Cursor)),
+				GlobalTransform::from_translation(translation),
+				_Animations {
+					forward_pitch: None,
+				},
+			))
+			.id();
+		app.insert_resource(_RayCast::new().with_mock(|mock| {
+			mock.expect_raycast()
+				.return_const(Some(MouseHoversOver::Object {
+					entity: target,
+					point: Vec3::ZERO,
+				}));
+		}));
+
+		app.update();
+
+		assert_eq_approx!(
+			Some(&_Animations {
+				forward_pitch: forward_pitch.into()
+			}),
+			app.world().entity(entity).get::<_Animations>(),
+			1e-5,
+		);
+	}
+
+	#[test]
+	fn raycast_excludes_self() {
+		let mut app = setup();
+		let translation = Vec3::new(10., 2., 0.);
+		let entity = app
+			.world_mut()
+			.spawn((
+				Target(Some(SkillTarget::Cursor)),
+				GlobalTransform::from_translation(translation),
+				_Animations {
+					forward_pitch: None,
+				},
+			))
+			.id();
+
+		app.insert_resource(_RayCast::new().with_mock(|mock| {
+			mock.expect_raycast()
+				.with(eq(MouseHover::excluding([entity])))
+				.once()
+				.return_const(None);
+		}));
+
+		app.update();
+	}
+
+	#[test]
+	fn act_only_once() {
+		let mut app = setup();
+		let translation = Vec3::new(10., 2., 0.);
+		let entity = app
+			.world_mut()
+			.spawn((
+				Target(Some(SkillTarget::Cursor)),
+				GlobalTransform::from_translation(translation),
+				_Animations {
+					forward_pitch: None,
+				},
+			))
+			.id();
+
+		app.update();
+		app.update();
+
+		assert_eq!(
+			Some(&IsChanged::FALSE),
+			app.world().entity(entity).get::<IsChanged<_Animations>>(),
+		);
+	}
+
+	#[test]
+	fn act_again_if_changed() {
+		let mut app = setup();
+		let translation = Vec3::new(10., 2., 0.);
+		let entity = app
+			.world_mut()
+			.spawn((
+				Target(Some(SkillTarget::Cursor)),
+				GlobalTransform::from_translation(translation),
+				_Animations {
+					forward_pitch: None,
+				},
+			))
+			.id();
+
+		app.update();
+		app.world_mut()
+			.entity_mut(entity)
+			.get_mut::<Target>()
+			.as_deref_mut();
+		app.update();
+
+		assert_eq!(
+			Some(&IsChanged::TRUE),
+			app.world().entity(entity).get::<IsChanged<_Animations>>(),
+		);
+	}
+}


### PR DESCRIPTION
Skill target changes now update a forward pitch value in animations, which is used to blend newly added pitch-able animations.