### PR TITLE
Player pitch aim animations

### DIFF
--- a/assets/agents/player.agent
+++ b/assets/agents/player.agent
@@ -104,7 +104,17 @@
 					},
 					{
 						"path": {
-							"Single": "models/player.glb#Animation10"
+							"PitchedForward": {
+								"neutral": "models/player.glb#Animation10",
+								"up": [
+									0.5,
+									"models/player.glb#Animation11"
+								],
+								"down": [
+									0.5,
+									"models/player.glb#Animation12"
+								]
+							}
 						},
 						"play_mode": "Repeat",
 						"mask_groups": "010"
@@ -116,7 +126,17 @@
 					},
 					{
 						"path": {
-							"Single": "models/player.glb#Animation11"
+							"PitchedForward": {
+								"neutral": "models/player.glb#Animation13",
+								"up": [
+									0.5,
+									"models/player.glb#Animation14"
+								],
+								"down": [
+									0.5,
+									"models/player.glb#Animation15"
+								]
+							}
 						},
 						"play_mode": "Repeat",
 						"mask_groups": "100"

--- a/assets/models/player.glb
+++ b/assets/models/player.glb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a2a48baf3470c2c01e1f17fbe2dec4c9a3b2e82d9a472048af07979b9a883bd2
-size 1518364
+oid sha256:eff79396caf32b81788fa7764a583d634d84c25d51f050382a88a29f1530d5d6
+size 1775164

--- a/blueprints/blender/models.blend
+++ b/blueprints/blender/models.blend
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:86551d1e0e7eececede8d56a9720a902096d35be63731dbfb66bc5fd6b976645
-size 2604110
+oid sha256:0fc666faec37f1a9d356f57620a765b8da022519b84e213cd0fd74311651d945
+size 2664182

--- a/src/plugins/animations/src/systems/set_pitch_animation_weights.rs
+++ b/src/plugins/animations/src/systems/set_pitch_animation_weights.rs
@@ -26,6 +26,9 @@ pub(crate) trait SetPitchAnimationWeights:
 	}
 }
 
+/// Using a min neutral animation weight to prevent odd deformations.
+const MIN_NEUTRAL_WEIGHT: f32 = 1e-6;
+
 macro_rules! set {
 	($value:expr, $graph:expr, $($clip:expr),+ $(,)?) => {
 		$({
@@ -38,11 +41,13 @@ macro_rules! set {
 
 macro_rules! blend {
 	($pitch:expr, $graph:expr, $neutral_clip:expr, $pitched_clip:expr) => {{
-		let (max_pitch, pitch_node) = $pitched_clip;
-		let pitch = **$pitch;
-		let scale = 1. / *max_pitch;
-		set!((1. - pitch * scale).clamp(0., 1.), $graph, $neutral_clip);
-		set!((pitch * scale).clamp(0., 1.), $graph, pitch_node);
+		let (max_pitch, pitched_clip) = $pitched_clip;
+		let offset = **$pitch / *max_pitch;
+		let neutral_weight = (1. - offset).clamp(MIN_NEUTRAL_WEIGHT, 1.);
+		let pitched_weight = offset.clamp(0., 1.);
+
+		set!(neutral_weight, $graph, $neutral_clip);
+		set!(pitched_weight, $graph, pitched_clip);
 	}};
 }
 
@@ -198,8 +203,8 @@ mod tests {
 	}
 
 	#[test_case(None, [1., 0., 0.]; "neutral")]
-	#[test_case(Some(DirForwardPitch::Up(ForwardPitch::MAX)), [0., 1., 0.]; "up")]
-	#[test_case(Some(DirForwardPitch::Down(ForwardPitch::MAX)), [0., 0., 1.]; "down")]
+	#[test_case(Some(DirForwardPitch::Up(ForwardPitch::MAX)), [MIN_NEUTRAL_WEIGHT, 1., 0.]; "up")]
+	#[test_case(Some(DirForwardPitch::Down(ForwardPitch::MAX)), [MIN_NEUTRAL_WEIGHT, 0., 1.]; "down")]
 	fn apply_full_weights(pitch: Option<DirForwardPitch>, expected_weights: [f32; 3]) {
 		let initial_weights = || {
 			expected_weights
@@ -372,8 +377,8 @@ mod tests {
 		);
 	}
 
-	#[test_case(Some(DirForwardPitch::Up(ForwardPitch::try_from(0.9).unwrap())), [0., 1., 0.]; "up")]
-	#[test_case(Some(DirForwardPitch::Down(ForwardPitch::try_from(0.9).unwrap())), [0., 0., 1.]; "down")]
+	#[test_case(Some(DirForwardPitch::Up(ForwardPitch::try_from(0.9).unwrap())), [MIN_NEUTRAL_WEIGHT, 1., 0.]; "up")]
+	#[test_case(Some(DirForwardPitch::Down(ForwardPitch::try_from(0.9).unwrap())), [MIN_NEUTRAL_WEIGHT, 0., 1.]; "down")]
 	fn apply_clamped_blended_weights_when_configured_with_less_than_max_pitch(
 		pitch: Option<DirForwardPitch>,
 		expected_weights: [f32; 3],

--- a/src/plugins/skills/src/lib.rs
+++ b/src/plugins/skills/src/lib.rs
@@ -15,7 +15,7 @@ use crate::{
 		slots::visualization::SlotVisualization,
 		target::Target,
 	},
-	skills::SkillId,
+	skills::{SkillId, behaviors::SkillBehaviorConfig},
 	system_parameters::{
 		loadout::{
 			LoadoutPrep,
@@ -125,7 +125,7 @@ where
 				Combos::update::<Queue>,
 				flush_skill_combos::<Combos, CombosTimeOut, Virtual, Queue>,
 				schedule_active_skill::<Queue, FacingSystemParamMut<TMovement>, ActiveSkill, Virtual>,
-				ActiveSkill::execute::<SkillSpawnerMut<TPhysics>>,
+				ActiveSkill::<SkillBehaviorConfig>::execute::<SkillSpawnerMut<TPhysics>>,
 				flush::<Queue>,
 				HeldSlots::<Old>::update_from::<Current>,
 				Target::update_pitch::<

--- a/src/plugins/skills/src/skills/behaviors.rs
+++ b/src/plugins/skills/src/skills/behaviors.rs
@@ -1,7 +1,11 @@
 pub(crate) mod dto;
 
+use crate::{skills::shape::OnSkillStop, traits::spawn_skill::extension::SkillConfigData};
 use bevy::prelude::*;
-use common::traits::handles_skill_physics::{Effect, SkillShape};
+use common::{
+	components::persistent_entity::PersistentEntity,
+	traits::handles_skill_physics::{Effect, SkillShape},
+};
 
 #[derive(PartialEq, Debug, Clone)]
 pub struct SkillBehaviorConfig {
@@ -19,22 +23,32 @@ impl SkillBehaviorConfig {
 			projection: vec![],
 		}
 	}
+}
 
-	#[cfg(test)]
-	pub(crate) fn with_contact_effects(self, contact: Vec<Effect>) -> Self {
-		Self {
-			shape: self.shape,
-			contact,
-			projection: self.projection,
-		}
+impl SkillConfigData for SkillBehaviorConfig {
+	fn use_neutral_spawn(&self) -> bool {
+		matches!(
+			&self.shape,
+			SkillShape::Shield(_) | SkillShape::SphereAoE(_)
+		)
 	}
 
-	#[cfg(test)]
-	pub(crate) fn with_projection_effects(self, projection: Vec<Effect>) -> Self {
-		Self {
-			shape: self.shape,
-			contact: self.contact,
-			projection,
+	fn shape(&self) -> &'_ SkillShape {
+		&self.shape
+	}
+
+	fn contact_effects(&self) -> &'_ [Effect] {
+		&self.contact
+	}
+
+	fn projection_effects(&self) -> &'_ [Effect] {
+		&self.projection
+	}
+
+	fn on_skill_stop(&self, skill: PersistentEntity) -> OnSkillStop {
+		match &self.shape {
+			SkillShape::Beam(_) | SkillShape::Shield(_) => OnSkillStop::Stop(skill),
+			_ => OnSkillStop::Ignore,
 		}
 	}
 }

--- a/src/plugins/skills/src/systems/active_skill/execute.rs
+++ b/src/plugins/skills/src/systems/active_skill/execute.rs
@@ -10,7 +10,7 @@ use bevy::{
 use common::{
 	components::persistent_entity::PersistentEntity,
 	traits::{
-		handles_skill_physics::{Despawn, SkillCaster, SkillEntity, SkillSpawner},
+		handles_skill_physics::{Despawn, SkillCaster, SkillEntity},
 		thread_safe::ThreadSafe,
 	},
 };
@@ -35,12 +35,8 @@ where
 					let Some(target) = target else {
 						continue;
 					};
-					let on_stop_skill = spawn.spawn_skill(
-						shape.clone(),
-						SkillCaster(*entity),
-						SkillSpawner::Slot(*slot_key),
-						*target,
-					);
+					let on_stop_skill =
+						spawn.spawn_skill(shape.clone(), SkillCaster(*entity), *slot_key, *target);
 					match on_stop_skill {
 						OnSkillStop::Ignore => *skill_executer = Self::Idle,
 						OnSkillStop::Stop(skill) => *skill_executer = Self::Stoppable(skill),
@@ -84,10 +80,10 @@ mod tests {
 			&mut self,
 			config: _Config,
 			caster: SkillCaster,
-			spawner: SkillSpawner,
+			slot: SlotKey,
 			target: SkillTarget,
 		) -> OnSkillStop {
-			self.mock.spawn_skill(config, caster, spawner, target)
+			self.mock.spawn_skill(config, caster, slot, target)
 		}
 	}
 
@@ -104,7 +100,7 @@ mod tests {
 				&mut self,
 				config: _Config,
 				caster: SkillCaster,
-				spawner: SkillSpawner,
+				slot: SlotKey,
 				target: SkillTarget,
 			) -> OnSkillStop;
 		}
@@ -154,7 +150,7 @@ mod tests {
 				.with(
 					eq(_Config),
 					eq(SkillCaster(*CASTER)),
-					eq(SkillSpawner::Slot(SlotKey(11))),
+					eq(SlotKey(11)),
 					eq(SkillTarget::Entity(*TARGET)),
 				)
 				.return_const(OnSkillStop::Ignore);

--- a/src/plugins/skills/src/systems/update_target_pitch.rs
+++ b/src/plugins/skills/src/systems/update_target_pitch.rs
@@ -18,7 +18,7 @@ impl Target {
 	pub(crate) fn update_pitch<TRayCast, TAnimations>(
 		mut animations: StaticSystemParam<TAnimations>,
 		mut ray_caster: StaticSystemParam<TRayCast>,
-		targets: Query<(Entity, &Self, &GlobalTransform), Changed<Self>>,
+		targets: Query<(Entity, &Self, &GlobalTransform)>,
 		transforms: Query<&GlobalTransform>,
 		commands: ZyheedaCommands,
 	) where
@@ -322,57 +322,5 @@ mod tests {
 		}));
 
 		app.update();
-	}
-
-	#[test]
-	fn act_only_once() {
-		let mut app = setup();
-		let translation = Vec3::new(10., 2., 0.);
-		let entity = app
-			.world_mut()
-			.spawn((
-				Target(Some(SkillTarget::Cursor)),
-				GlobalTransform::from_translation(translation),
-				_Animations {
-					forward_pitch: None,
-				},
-			))
-			.id();
-
-		app.update();
-		app.update();
-
-		assert_eq!(
-			Some(&IsChanged::FALSE),
-			app.world().entity(entity).get::<IsChanged<_Animations>>(),
-		);
-	}
-
-	#[test]
-	fn act_again_if_changed() {
-		let mut app = setup();
-		let translation = Vec3::new(10., 2., 0.);
-		let entity = app
-			.world_mut()
-			.spawn((
-				Target(Some(SkillTarget::Cursor)),
-				GlobalTransform::from_translation(translation),
-				_Animations {
-					forward_pitch: None,
-				},
-			))
-			.id();
-
-		app.update();
-		app.world_mut()
-			.entity_mut(entity)
-			.get_mut::<Target>()
-			.as_deref_mut();
-		app.update();
-
-		assert_eq!(
-			Some(&IsChanged::TRUE),
-			app.world().entity(entity).get::<IsChanged<_Animations>>(),
-		);
 	}
 }

--- a/src/plugins/skills/src/traits/spawn_skill.rs
+++ b/src/plugins/skills/src/traits/spawn_skill.rs
@@ -1,14 +1,17 @@
-mod extension;
+pub(crate) mod extension;
 
 use crate::skills::shape::OnSkillStop;
-use common::traits::handles_skill_physics::{SkillCaster, SkillSpawner, SkillTarget};
+use common::{
+	tools::action_key::slot::SlotKey,
+	traits::handles_skill_physics::{SkillCaster, SkillTarget},
+};
 
 pub(crate) trait SpawnSkill<TSkillConfig> {
 	fn spawn_skill(
 		&mut self,
 		config: TSkillConfig,
 		caster: SkillCaster,
-		spawner: SkillSpawner,
+		slot: SlotKey,
 		target: SkillTarget,
 	) -> OnSkillStop;
 }

--- a/src/plugins/skills/src/traits/spawn_skill/extension.rs
+++ b/src/plugins/skills/src/traits/spawn_skill/extension.rs
@@ -1,66 +1,127 @@
-use crate::{
-	skills::{behaviors::SkillBehaviorConfig, shape::OnSkillStop},
-	traits::spawn_skill::SpawnSkill,
-};
-use common::traits::handles_skill_physics::{
-	SkillCaster,
-	SkillShape,
-	SkillSpawner,
-	SkillTarget,
-	Spawn,
-	SpawnArgs,
+use crate::{skills::shape::OnSkillStop, traits::spawn_skill::SpawnSkill};
+use common::{
+	components::persistent_entity::PersistentEntity,
+	tools::action_key::slot::SlotKey,
+	traits::handles_skill_physics::{
+		Effect,
+		SkillCaster,
+		SkillShape,
+		SkillSpawner,
+		SkillTarget,
+		Spawn,
+		SpawnArgs,
+	},
 };
 
-impl<T> SpawnSkill<SkillBehaviorConfig> for T
+impl<T, TConfig> SpawnSkill<TConfig> for T
 where
 	T: Spawn,
+	TConfig: SkillConfigData,
 {
 	fn spawn_skill(
 		&mut self,
-		config: SkillBehaviorConfig,
+		config: TConfig,
 		caster: SkillCaster,
-		spawner: SkillSpawner,
+		slot: SlotKey,
 		target: SkillTarget,
 	) -> OnSkillStop {
-		let entity = self.spawn(SpawnArgs {
-			shape: &config.shape,
-			contact_effects: &config.contact,
-			projection_effects: &config.projection,
+		let spawner = if config.use_neutral_spawn() {
+			SkillSpawner::Neutral
+		} else {
+			SkillSpawner::Slot(slot)
+		};
+
+		let skill = self.spawn(SpawnArgs {
+			shape: config.shape(),
+			contact_effects: config.contact_effects(),
+			projection_effects: config.projection_effects(),
 			caster,
 			spawner,
 			target,
 		});
 
-		match config.shape {
-			SkillShape::Shield(..) | SkillShape::Beam(..) => OnSkillStop::Stop(entity),
-			_ => OnSkillStop::Ignore,
-		}
+		config.on_skill_stop(skill)
 	}
+}
+
+pub(crate) trait SkillConfigData {
+	fn use_neutral_spawn(&self) -> bool;
+	fn shape(&self) -> &'_ SkillShape;
+	fn contact_effects(&self) -> &'_ [Effect];
+	fn projection_effects(&self) -> &'_ [Effect];
+	fn on_skill_stop(&self, skill: PersistentEntity) -> OnSkillStop;
 }
 
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use bevy::prelude::default;
 	use common::{
 		components::persistent_entity::PersistentEntity,
 		effects::force::Force,
 		tools::{Units, action_key::slot::SlotKey},
-		traits::{
-			handles_physics::physical_bodies::Blockers,
-			handles_skill_physics::{
-				Effect,
-				SkillShape,
-				beam::Beam,
-				ground_target::SphereAoE,
-				shield::Shield,
-			},
-		},
+		traits::handles_skill_physics::{Effect, SkillShape, ground_target::SphereAoE},
 	};
 	use macros::simple_mock;
 	use std::time::Duration;
 	use test_case::test_case;
 	use testing::Mock;
 	use uuid::uuid;
+
+	struct _Config {
+		use_neutral_spawn: bool,
+		shape: SkillShape,
+		contact: Vec<Effect>,
+		projection: Vec<Effect>,
+		on_skill_stop: fn(PersistentEntity) -> OnSkillStop,
+	}
+
+	impl _Config {
+		const DEFAULT: Self = Self {
+			use_neutral_spawn: false,
+			shape: SkillShape::SphereAoE(SphereAoE {
+				max_range: Units::from_u8(u8::MAX),
+				radius: Units::from_u8(1),
+				lifetime: Some(Duration::from_secs(1)),
+			}),
+			contact: vec![],
+			projection: vec![],
+			on_skill_stop: |_| OnSkillStop::Ignore,
+		};
+
+		const fn using_neutral_spawn(mut self, use_neutral_spawn: bool) -> Self {
+			self.use_neutral_spawn = use_neutral_spawn;
+			self
+		}
+	}
+
+	impl Default for _Config {
+		fn default() -> Self {
+			Self::DEFAULT
+		}
+	}
+
+	impl SkillConfigData for _Config {
+		fn use_neutral_spawn(&self) -> bool {
+			self.use_neutral_spawn
+		}
+
+		fn shape(&self) -> &'_ SkillShape {
+			&self.shape
+		}
+
+		fn contact_effects(&self) -> &'_ [Effect] {
+			&self.contact
+		}
+
+		fn projection_effects(&self) -> &'_ [Effect] {
+			&self.projection
+		}
+
+		fn on_skill_stop(&self, skill: PersistentEntity) -> OnSkillStop {
+			(self.on_skill_stop)(skill)
+		}
+	}
 
 	simple_mock! {
 		_Spawn {}
@@ -69,38 +130,28 @@ mod tests {
 		}
 	}
 
-	const fn ground_target(radius: u8, lifetime: Option<Duration>) -> SkillBehaviorConfig {
-		SkillBehaviorConfig::from_shape(SkillShape::SphereAoE(SphereAoE {
-			max_range: Units::from_u8(u8::MAX),
-			radius: Units::from_u8(radius),
-			lifetime,
-		}))
-	}
-
-	const SHIELD: SkillBehaviorConfig = SkillBehaviorConfig::from_shape(SkillShape::Shield(Shield));
-
 	static CASTER: SkillCaster = SkillCaster(PersistentEntity::from_uuid(uuid!(
 		"91409ebe-e94d-43b2-8dc1-53949e4f0dc2"
 	)));
-	const SPAWNER: SkillSpawner = SkillSpawner::Slot(SlotKey(123));
+	const SLOT: SlotKey = SlotKey(123);
 	static TARGET: SkillTarget = SkillTarget::Entity(PersistentEntity::from_uuid(uuid!(
 		"d0032d1c-a840-4ea5-9047-86f88a0437dc"
 	)));
 
 	#[test]
-	fn spawn_contact_and_projection() {
-		const CONFIG: SkillBehaviorConfig = ground_target(11, None);
+	fn spawn_contact_and_projection_on_slot() {
+		const CONFIG: _Config = _Config::DEFAULT.using_neutral_spawn(false);
 		const ARGS: SpawnArgs = SpawnArgs {
 			shape: &CONFIG.shape,
 			caster: CASTER,
-			spawner: SPAWNER,
+			spawner: SkillSpawner::Slot(SLOT),
 			target: TARGET,
 			contact_effects: &[],
 			projection_effects: &[],
 		};
 		let mut spawn = Mock_Spawn::new_mock(assert_contact_and_projection_used);
 
-		spawn.spawn_skill(CONFIG, CASTER, SPAWNER, TARGET);
+		spawn.spawn_skill(CONFIG, CASTER, SLOT, TARGET);
 
 		fn assert_contact_and_projection_used(mock: &mut Mock_Spawn) {
 			mock.expect_spawn()
@@ -110,39 +161,55 @@ mod tests {
 		}
 	}
 
-	#[test_case(SkillShape::Shield(Shield); "shield")]
-	#[test_case(SkillShape::Beam(Beam {range: Units::ZERO, blocked_by: Blockers::All}); "beam")]
-	fn return_stoppable(shape: SkillShape) {
-		let config = SkillBehaviorConfig::from_shape(shape);
+	#[test]
+	fn spawn_contact_and_projection_on_neutral() {
+		const CONFIG: _Config = _Config::DEFAULT.using_neutral_spawn(true);
+		const ARGS: SpawnArgs = SpawnArgs {
+			shape: &CONFIG.shape,
+			caster: CASTER,
+			spawner: SkillSpawner::Neutral,
+			target: TARGET,
+			contact_effects: &[],
+			projection_effects: &[],
+		};
+		let mut spawn = Mock_Spawn::new_mock(assert_contact_and_projection_used);
+
+		spawn.spawn_skill(CONFIG, CASTER, SLOT, TARGET);
+
+		fn assert_contact_and_projection_used(mock: &mut Mock_Spawn) {
+			mock.expect_spawn()
+				.once()
+				.withf(|args| args == &ARGS)
+				.return_const(PersistentEntity::default());
+		}
+	}
+
+	#[test_case(|_| OnSkillStop::Ignore; "infinite")]
+	#[test_case(OnSkillStop::Stop; "with lifetime")]
+	fn return_skill_stop(on_skill_stop: fn(PersistentEntity) -> OnSkillStop) {
 		let entity = PersistentEntity::default();
+		let config = _Config {
+			on_skill_stop,
+			..default()
+		};
 		let mut spawn = Mock_Spawn::new_mock(move |mock| {
 			mock.expect_spawn().return_const(entity);
 		});
 
-		let on_skill_stop = spawn.spawn_skill(config, CASTER, SPAWNER, TARGET);
+		let result = spawn.spawn_skill(config, CASTER, SLOT, TARGET);
 
-		assert_eq!(OnSkillStop::Stop(entity), on_skill_stop);
-	}
-
-	#[test_case(ground_target(1, None); "infinite")]
-	#[test_case(ground_target(1, Some(Duration::ZERO)); "with lifetime")]
-	fn return_non_stoppable(config: SkillBehaviorConfig) {
-		let mut spawn = Mock_Spawn::new_mock(move |mock| {
-			mock.expect_spawn()
-				.return_const(PersistentEntity::default());
-		});
-
-		let on_skill_stop = spawn.spawn_skill(config, CASTER, SPAWNER, TARGET);
-
-		assert_eq!(OnSkillStop::Ignore, on_skill_stop);
+		assert_eq!(on_skill_stop(entity), result);
 	}
 
 	#[test]
 	fn add_contact_effect() {
-		let config = SHIELD.with_contact_effects(vec![Effect::Force(Force)]);
+		let config = _Config {
+			contact: vec![Effect::Force(Force)],
+			..default()
+		};
 		let mut spawn = Mock_Spawn::new_mock(assert_added_effects);
 
-		spawn.spawn_skill(config, CASTER, SPAWNER, TARGET);
+		spawn.spawn_skill(config, CASTER, SLOT, TARGET);
 
 		fn assert_added_effects(mock: &mut Mock_Spawn) {
 			mock.expect_spawn()
@@ -154,10 +221,13 @@ mod tests {
 
 	#[test]
 	fn add_projection_effect() {
-		let config = SHIELD.with_projection_effects(vec![Effect::Force(Force)]);
+		let config = _Config {
+			projection: vec![Effect::Force(Force)],
+			..default()
+		};
 		let mut spawn = Mock_Spawn::new_mock(assert_added_effects);
 
-		spawn.spawn_skill(config, CASTER, SPAWNER, TARGET);
+		spawn.spawn_skill(config, CASTER, SLOT, TARGET);
 
 		fn assert_added_effects(mock: &mut Mock_Spawn) {
 			mock.expect_spawn()


### PR DESCRIPTION
Use pitched animations for player aim:
- updated model animations
- updating pitch each frame and not only when skill target changes
- spawn shield on neutral spawn, so it doesn't move with current aim pitch
- limited minimal animation weight when blending neutral and pitched animations to prevent buggy skeleton deformations