### PR TITLE
Player aim with head

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,6 +204,7 @@ dependencies = [
  "testing",
  "tracing",
  "uuid",
+ "zyheeda_core",
 ]
 
 [[package]]

--- a/assets/agents/player.agent
+++ b/assets/agents/player.agent
@@ -65,7 +65,7 @@
 							"Single": "models/player.glb#Animation1"
 						},
 						"play_mode": "Repeat",
-						"mask_groups": "111"
+						"mask_groups": "1111"
 					}
 				],
 				[
@@ -80,7 +80,7 @@
 							}
 						},
 						"play_mode": "Repeat",
-						"mask_groups": "111"
+						"mask_groups": "1111"
 					}
 				],
 				[
@@ -95,7 +95,7 @@
 							}
 						},
 						"play_mode": "Repeat",
-						"mask_groups": "111"
+						"mask_groups": "1111"
 					}
 				],
 				[
@@ -117,7 +117,7 @@
 							}
 						},
 						"play_mode": "Repeat",
-						"mask_groups": "010"
+						"mask_groups": "1010"
 					}
 				],
 				[
@@ -139,23 +139,27 @@
 							}
 						},
 						"play_mode": "Repeat",
-						"mask_groups": "100"
+						"mask_groups": "1100"
 					}
 				]
 			],
 			"animation_mask_groups": {
-				"001": {
+				"0001": {
 					"from_root": "metarig",
 					"until_exclusive": [
 						"shoulder.L",
-						"shoulder.R"
+						"shoulder.R",
+						"spine.004"
 					]
 				},
-				"010": {
+				"0010": {
 					"from_root": "shoulder.L"
 				},
-				"100": {
+				"0100": {
 					"from_root": "shoulder.R"
+				},
+				"1000": {
+					"from_root": "spine.004"
 				}
 			}
 		}

--- a/src/plugins/agents/src/systems/agent_config/animate_idle.rs
+++ b/src/plugins/agents/src/systems/agent_config/animate_idle.rs
@@ -7,7 +7,7 @@ use common::{
 	},
 	zyheeda_commands::ZyheedaCommands,
 };
-use std::collections::HashSet;
+use zyheeda_core::prelude::*;
 
 impl AnimateIdle {
 	pub(crate) fn execute<TAnimations>(
@@ -23,7 +23,7 @@ impl AnimateIdle {
 				continue;
 			};
 
-			*animations.active_animations_mut(Idle) = HashSet::from([AnimationKey::Idle]);
+			*animations.active_animations_mut(Idle) = OrderedSet::from([AnimationKey::Idle]);
 			commands.try_apply_on(&entity, |mut e| {
 				e.try_remove::<Self>();
 			});
@@ -44,7 +44,7 @@ mod test {
 	use super::*;
 	use crate::systems::player::animate_movement::tests::_Animations;
 	use common::traits::handles_animations::AnimationKey;
-	use std::collections::{HashMap, HashSet};
+	use std::collections::HashMap;
 	use testing::SingleThreadedApp;
 
 	fn setup() -> App {
@@ -68,7 +68,7 @@ mod test {
 		assert_eq!(
 			Some(&_Animations(HashMap::from([(
 				Idle.into(),
-				HashSet::from([AnimationKey::Idle])
+				OrderedSet::from([AnimationKey::Idle])
 			)]))),
 			app.world().entity(entity).get::<_Animations>()
 		);
@@ -83,7 +83,7 @@ mod test {
 				AnimateIdle,
 				_Animations(HashMap::from([(
 					Idle.into(),
-					HashSet::from([AnimationKey::Walk]),
+					OrderedSet::from([AnimationKey::Walk]),
 				)])),
 			))
 			.id();
@@ -93,7 +93,7 @@ mod test {
 		assert_eq!(
 			Some(&_Animations(HashMap::from([(
 				Idle.into(),
-				HashSet::from([AnimationKey::Idle])
+				OrderedSet::from([AnimationKey::Idle])
 			)]))),
 			app.world().entity(entity).get::<_Animations>()
 		);

--- a/src/plugins/agents/src/systems/agent_config/animate_skills.rs
+++ b/src/plugins/agents/src/systems/agent_config/animate_skills.rs
@@ -70,12 +70,9 @@ mod tests {
 			handles_loadout::{ActiveSkill, ActiveSkills},
 		},
 	};
-	use std::{
-		collections::{HashMap, HashSet},
-		iter::Copied,
-		slice::Iter,
-	};
+	use std::{collections::HashMap, iter::Copied, slice::Iter};
 	use testing::{SingleThreadedApp, new_handle};
+	use zyheeda_core::prelude::*;
 
 	#[derive(Component)]
 	struct _Loadout {
@@ -134,7 +131,7 @@ mod tests {
 		assert_eq!(
 			Some(&_Animations(HashMap::from([(
 				AnimationPriority::High,
-				HashSet::from([
+				OrderedSet::from([
 					AnimationKey::Skill(SlotKey(42)),
 					AnimationKey::Skill(SlotKey(11)),
 				])
@@ -173,7 +170,7 @@ mod tests {
 		assert_eq!(
 			Some(&_Animations(HashMap::from([(
 				AnimationPriority::High,
-				HashSet::from([AnimationKey::Skill(SlotKey(42))])
+				OrderedSet::from([AnimationKey::Skill(SlotKey(42))])
 			)]))),
 			app.world().entity(entity).get::<_Animations>(),
 		);
@@ -190,14 +187,17 @@ mod tests {
 				},
 				_Loadout { active: vec![] },
 				_Animations(HashMap::from([
-					(AnimationPriority::Low, HashSet::from([AnimationKey::Idle])),
+					(
+						AnimationPriority::Low,
+						OrderedSet::from([AnimationKey::Idle]),
+					),
 					(
 						AnimationPriority::Medium,
-						HashSet::from([AnimationKey::Run]),
+						OrderedSet::from([AnimationKey::Run]),
 					),
 					(
 						AnimationPriority::High,
-						HashSet::from([
+						OrderedSet::from([
 							AnimationKey::Skill(SlotKey(42)),
 							AnimationKey::Skill(SlotKey(11)),
 						]),
@@ -210,12 +210,15 @@ mod tests {
 
 		assert_eq!(
 			Some(&_Animations(HashMap::from([
-				(AnimationPriority::Low, HashSet::from([AnimationKey::Idle])),
+				(
+					AnimationPriority::Low,
+					OrderedSet::from([AnimationKey::Idle])
+				),
 				(
 					AnimationPriority::Medium,
-					HashSet::from([AnimationKey::Run]),
+					OrderedSet::from([AnimationKey::Run]),
 				),
-				(AnimationPriority::High, HashSet::from([]),),
+				(AnimationPriority::High, OrderedSet::from([]),),
 			])),),
 			app.world().entity(entity).get::<_Animations>(),
 		);
@@ -306,7 +309,7 @@ mod tests {
 		assert_eq!(
 			Some(&_Animations(HashMap::from([(
 				AnimationPriority::High,
-				HashSet::from([AnimationKey::Skill(SlotKey(42))])
+				OrderedSet::from([AnimationKey::Skill(SlotKey(42))])
 			)]))),
 			app.world().entity(entity).get::<_Animations>(),
 		);

--- a/src/plugins/agents/src/systems/enemy/animate_movement.rs
+++ b/src/plugins/agents/src/systems/enemy/animate_movement.rs
@@ -8,7 +8,7 @@ use common::{
 		handles_movement::{Movement, MovementTarget},
 	},
 };
-use std::collections::HashSet;
+use zyheeda_core::prelude::OrderedSet;
 
 impl Enemy {
 	pub(crate) fn animate_movement<TMovement, TAnimations>(
@@ -33,7 +33,7 @@ impl Enemy {
 			let movement_animations = animations.active_animations_mut(Move);
 
 			match movement.view() {
-				Some(_) => *movement_animations = HashSet::from([AnimationKey::Run]),
+				Some(_) => *movement_animations = OrderedSet::from([AnimationKey::Run]),
 				None => movement_animations.clear(),
 			};
 		}
@@ -46,7 +46,7 @@ mod tests {
 	use super::*;
 	use crate::systems::player::animate_movement::tests::{_Animations, _Movement};
 	use common::traits::{handles_animations::AnimationKey, handles_movement::MovementTarget};
-	use std::collections::{HashMap, HashSet};
+	use std::collections::HashMap;
 	use testing::SingleThreadedApp;
 
 	fn setup() -> App {
@@ -80,7 +80,7 @@ mod tests {
 		assert_eq!(
 			Some(&_Animations(HashMap::from([(
 				Move.into(),
-				HashSet::from([AnimationKey::Run]),
+				OrderedSet::from([AnimationKey::Run]),
 			)]))),
 			app.world().entity(entity).get::<_Animations>(),
 		);
@@ -99,7 +99,7 @@ mod tests {
 				},
 				_Animations(HashMap::from([(
 					Move.into(),
-					HashSet::from([AnimationKey::Walk]),
+					OrderedSet::from([AnimationKey::Walk]),
 				)])),
 			))
 			.id();
@@ -109,7 +109,7 @@ mod tests {
 		assert_eq!(
 			Some(&_Animations(HashMap::from([(
 				Move.into(),
-				HashSet::from([AnimationKey::Run]),
+				OrderedSet::from([AnimationKey::Run]),
 			)]))),
 			app.world().entity(entity).get::<_Animations>(),
 		);
@@ -156,7 +156,7 @@ mod tests {
 				},
 				_Animations(HashMap::from([(
 					Move.into(),
-					HashSet::from([AnimationKey::Run]),
+					OrderedSet::from([AnimationKey::Run]),
 				)])),
 			))
 			.id();
@@ -170,7 +170,7 @@ mod tests {
 		assert_eq!(
 			Some(&_Animations(HashMap::from([(
 				Move.into(),
-				HashSet::from([])
+				OrderedSet::from([])
 			)]))),
 			app.world().entity(entity).get::<_Animations>(),
 		);

--- a/src/plugins/agents/src/systems/player/animate_movement.rs
+++ b/src/plugins/agents/src/systems/player/animate_movement.rs
@@ -8,7 +8,7 @@ use common::{
 		handles_movement::{CurrentMovement, Movement, MovementTarget, SpeedToggle},
 	},
 };
-use std::collections::HashSet;
+use zyheeda_core::prelude::OrderedSet;
 
 impl Player {
 	pub(crate) fn animate_movement<TMovement, TAnimations>(
@@ -40,7 +40,7 @@ impl Player {
 	}
 
 	fn start_run_or_walk_animation(
-		movement_animations: &mut HashSet<AnimationKey>,
+		movement_animations: &mut OrderedSet<AnimationKey>,
 		config: impl View<SpeedToggle>,
 	) {
 		let walk_or_run = match config.view() {
@@ -48,10 +48,10 @@ impl Player {
 			SpeedToggle::Right => AnimationKey::Walk,
 		};
 
-		*movement_animations = HashSet::from([walk_or_run]);
+		*movement_animations = OrderedSet::from([walk_or_run]);
 	}
 
-	fn stop_move_animations(movement_animations: &mut HashSet<AnimationKey>) {
+	fn stop_move_animations(movement_animations: &mut OrderedSet<AnimationKey>) {
 		movement_animations.clear();
 	}
 }
@@ -74,7 +74,7 @@ pub(crate) mod tests {
 		handles_animations::{ActiveAnimations, AnimationKey, AnimationPriority},
 		handles_movement::MovementTarget,
 	};
-	use std::{collections::HashMap, sync::LazyLock};
+	use std::collections::HashMap;
 	use test_case::test_case;
 	use testing::SingleThreadedApp;
 
@@ -96,22 +96,22 @@ pub(crate) mod tests {
 		}
 	}
 
-	static EMPTY: LazyLock<HashSet<AnimationKey>> = LazyLock::new(HashSet::default);
+	const EMPTY: &OrderedSet<AnimationKey> = &OrderedSet::EMPTY;
 
 	#[derive(Component, Debug, PartialEq, Default)]
-	pub(crate) struct _Animations(pub(crate) HashMap<AnimationPriority, HashSet<AnimationKey>>);
+	pub(crate) struct _Animations(pub(crate) HashMap<AnimationPriority, OrderedSet<AnimationKey>>);
 
 	impl ActiveAnimations for _Animations {
-		fn active_animations<TLayer>(&self, layer: TLayer) -> &HashSet<AnimationKey>
+		fn active_animations<TLayer>(&self, layer: TLayer) -> &OrderedSet<AnimationKey>
 		where
 			TLayer: Into<AnimationPriority>,
 		{
-			self.0.get(&layer.into()).unwrap_or(&*EMPTY)
+			self.0.get(&layer.into()).unwrap_or(EMPTY)
 		}
 	}
 
 	impl ActiveAnimationsMut for _Animations {
-		fn active_animations_mut<TLayer>(&mut self, layer: TLayer) -> &mut HashSet<AnimationKey>
+		fn active_animations_mut<TLayer>(&mut self, layer: TLayer) -> &mut OrderedSet<AnimationKey>
 		where
 			TLayer: Into<AnimationPriority>,
 		{
@@ -151,7 +151,7 @@ pub(crate) mod tests {
 		assert_eq!(
 			Some(&_Animations(HashMap::from([(
 				Move.into(),
-				HashSet::from([animation])
+				OrderedSet::from([animation])
 			)]))),
 			app.world().entity(entity).get::<_Animations>(),
 		);
@@ -168,7 +168,7 @@ pub(crate) mod tests {
 				movement,
 				_Animations(HashMap::from([(
 					Move.into(),
-					HashSet::from([AnimationKey::Idle]),
+					OrderedSet::from([AnimationKey::Idle]),
 				)])),
 			))
 			.id();
@@ -178,7 +178,7 @@ pub(crate) mod tests {
 		assert_eq!(
 			Some(&_Animations(HashMap::from([(
 				Move.into(),
-				HashSet::from([animation])
+				OrderedSet::from([animation])
 			)]))),
 			app.world().entity(entity).get::<_Animations>(),
 		);
@@ -225,7 +225,7 @@ pub(crate) mod tests {
 				},
 				_Animations(HashMap::from([(
 					Move.into(),
-					HashSet::from([AnimationKey::Idle]),
+					OrderedSet::from([AnimationKey::Idle]),
 				)])),
 			))
 			.id();
@@ -239,7 +239,7 @@ pub(crate) mod tests {
 		assert_eq!(
 			Some(&_Animations(HashMap::from([(
 				Move.into(),
-				HashSet::from([]),
+				OrderedSet::from([]),
 			)])),),
 			app.world().entity(entity).get::<_Animations>(),
 		);

--- a/src/plugins/animations/Cargo.toml
+++ b/src/plugins/animations/Cargo.toml
@@ -13,6 +13,7 @@ serde.workspace = true
 # internal
 common.workspace = true
 macros.workspace = true
+zyheeda_core.workspace = true
 
 [dev-dependencies]
 # external

--- a/src/plugins/animations/src/components/animation_dispatch.rs
+++ b/src/plugins/animations/src/components/animation_dispatch.rs
@@ -9,8 +9,8 @@ use crate::{
 	traits::{
 		AnimationPlayers,
 		AnimationPlayersWithoutGraph,
-		GetActiveAnimations,
 		GetAllActiveAnimations,
+		YoungestToOldestActiveAnimations,
 	},
 };
 use bevy::prelude::*;
@@ -20,12 +20,11 @@ use common::traits::{
 };
 use macros::SavableComponent;
 use std::{
-	collections::{
-		HashSet,
-		hash_set::{IntoIter, Iter},
-	},
+	collections::{HashSet, hash_set::IntoIter},
 	fmt::Debug,
+	iter::Rev,
 };
+use zyheeda_core::prelude::*;
 
 #[derive(Component, SavableComponent, Debug, PartialEq, Clone)]
 #[require(CurrentMovementDirection, CurrentForwardPitch)]
@@ -34,14 +33,14 @@ pub struct AnimationDispatch {
 	pub(crate) animation_players: HashSet<Entity>,
 	animation_handles: HashSet<Entity>,
 	priorities: (
-		HashSet<AnimationKey>,
-		HashSet<AnimationKey>,
-		HashSet<AnimationKey>,
+		OrderedSet<AnimationKey>,
+		OrderedSet<AnimationKey>,
+		OrderedSet<AnimationKey>,
 	),
 }
 
 impl AnimationDispatch {
-	pub(crate) fn slot_mut<TLayer>(&mut self, layer: TLayer) -> &mut HashSet<AnimationKey>
+	pub(crate) fn slot_mut<TLayer>(&mut self, layer: TLayer) -> &mut OrderedSet<AnimationKey>
 	where
 		TLayer: Into<AnimationPriority>,
 	{
@@ -52,7 +51,7 @@ impl AnimationDispatch {
 		}
 	}
 
-	pub(crate) fn slot<TLayer>(&self, layer: TLayer) -> &HashSet<AnimationKey>
+	pub(crate) fn slot<TLayer>(&self, layer: TLayer) -> &OrderedSet<AnimationKey>
 	where
 		TLayer: Into<AnimationPriority>,
 	{
@@ -132,17 +131,20 @@ impl AnimationPlayersWithoutGraph for AnimationDispatch {
 	}
 }
 
-impl GetActiveAnimations for AnimationDispatch {
+impl YoungestToOldestActiveAnimations for AnimationDispatch {
 	type TIter<'a>
-		= Iter<'a, AnimationKey>
+		= Rev<UniqueIter<'a, AnimationKey>>
 	where
 		Self: 'a;
 
-	fn get_active_animations<TPriority>(&self, priority: TPriority) -> Self::TIter<'_>
+	fn youngest_to_oldest_active_animations<TPriority>(
+		&self,
+		priority: TPriority,
+	) -> Self::TIter<'_>
 	where
 		TPriority: Into<AnimationPriority>,
 	{
-		self.slot(priority).iter()
+		self.slot(priority).iter().rev()
 	}
 }
 
@@ -162,9 +164,9 @@ impl GetAllActiveAnimations for AnimationDispatch {
 }
 
 pub struct IterAllAnimations<'a>(
-	Iter<'a, AnimationKey>,
-	Iter<'a, AnimationKey>,
-	Iter<'a, AnimationKey>,
+	UniqueIter<'a, AnimationKey>,
+	UniqueIter<'a, AnimationKey>,
+	UniqueIter<'a, AnimationKey>,
 );
 
 impl<'a> Iterator for IterAllAnimations<'a> {
@@ -339,19 +341,19 @@ mod tests {
 			animation_players: default(),
 			animation_handles: default(),
 			priorities: (
-				HashSet::from([
+				OrderedSet::from([
 					AnimationKey::Skill(SlotKey(1)),
 					AnimationKey::Skill(SlotKey(2)),
 					AnimationKey::Skill(SlotKey(3)),
 				]),
-				HashSet::from([
+				OrderedSet::from([
 					AnimationKey::Skill(SlotKey(4)),
 					AnimationKey::Skill(SlotKey(5)),
 					AnimationKey::Skill(SlotKey(6)),
 				]),
-				HashSet::from([
+				OrderedSet::from([
 					AnimationKey::Skill(SlotKey(7)),
-					AnimationKey::Skill(SlotKey(9)),
+					AnimationKey::Skill(SlotKey(8)),
 					AnimationKey::Skill(SlotKey(9)),
 				]),
 			),
@@ -366,7 +368,7 @@ mod tests {
 				AnimationKey::Skill(SlotKey(5)),
 				AnimationKey::Skill(SlotKey(6)),
 				AnimationKey::Skill(SlotKey(7)),
-				AnimationKey::Skill(SlotKey(9)),
+				AnimationKey::Skill(SlotKey(8)),
 				AnimationKey::Skill(SlotKey(9)),
 			]),
 			dispatch
@@ -374,5 +376,61 @@ mod tests {
 				.copied()
 				.collect::<HashSet<_>>()
 		)
+	}
+
+	#[test]
+	fn iter_youngest_to_oldest() {
+		let dispatch = AnimationDispatch {
+			animation_players: default(),
+			animation_handles: default(),
+			priorities: (
+				OrderedSet::from([
+					AnimationKey::Skill(SlotKey(1)),
+					AnimationKey::Skill(SlotKey(2)),
+					AnimationKey::Skill(SlotKey(3)),
+				]),
+				OrderedSet::from([
+					AnimationKey::Skill(SlotKey(4)),
+					AnimationKey::Skill(SlotKey(5)),
+					AnimationKey::Skill(SlotKey(6)),
+				]),
+				OrderedSet::from([
+					AnimationKey::Skill(SlotKey(7)),
+					AnimationKey::Skill(SlotKey(8)),
+					AnimationKey::Skill(SlotKey(9)),
+				]),
+			),
+		};
+
+		assert_eq!(
+			(
+				vec![
+					&AnimationKey::Skill(SlotKey(3)),
+					&AnimationKey::Skill(SlotKey(2)),
+					&AnimationKey::Skill(SlotKey(1)),
+				],
+				vec![
+					&AnimationKey::Skill(SlotKey(6)),
+					&AnimationKey::Skill(SlotKey(5)),
+					&AnimationKey::Skill(SlotKey(4)),
+				],
+				vec![
+					&AnimationKey::Skill(SlotKey(9)),
+					&AnimationKey::Skill(SlotKey(8)),
+					&AnimationKey::Skill(SlotKey(7)),
+				],
+			),
+			(
+				dispatch
+					.youngest_to_oldest_active_animations(AnimationPriority::High)
+					.collect::<Vec<_>>(),
+				dispatch
+					.youngest_to_oldest_active_animations(AnimationPriority::Medium)
+					.collect::<Vec<_>>(),
+				dispatch
+					.youngest_to_oldest_active_animations(AnimationPriority::Low)
+					.collect::<Vec<_>>(),
+			)
+		);
 	}
 }

--- a/src/plugins/animations/src/components/animation_dispatch/dto.rs
+++ b/src/plugins/animations/src/components/animation_dispatch/dto.rs
@@ -5,14 +5,14 @@ use common::{
 	traits::{handles_animations::AnimationKey, handles_custom_assets::TryLoadFrom},
 };
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use zyheeda_core::prelude::*;
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct AnimationDispatchDto {
 	priorities: (
-		HashSet<AnimationKey>,
-		HashSet<AnimationKey>,
-		HashSet<AnimationKey>,
+		OrderedSet<AnimationKey>,
+		OrderedSet<AnimationKey>,
+		OrderedSet<AnimationKey>,
 	),
 }
 

--- a/src/plugins/animations/src/system_params/animations/active_animations.rs
+++ b/src/plugins/animations/src/system_params/animations/active_animations.rs
@@ -5,10 +5,10 @@ use common::traits::handles_animations::{
 	AnimationKey,
 	AnimationPriority,
 };
-use std::collections::HashSet;
+use zyheeda_core::prelude::*;
 
 impl ActiveAnimations for AnimationsContextMut<'_> {
-	fn active_animations<TLayer>(&self, layer: TLayer) -> &HashSet<AnimationKey>
+	fn active_animations<TLayer>(&self, layer: TLayer) -> &OrderedSet<AnimationKey>
 	where
 		TLayer: Into<AnimationPriority>,
 	{
@@ -17,7 +17,7 @@ impl ActiveAnimations for AnimationsContextMut<'_> {
 }
 
 impl ActiveAnimationsMut for AnimationsContextMut<'_> {
-	fn active_animations_mut<TLayer>(&mut self, layer: TLayer) -> &mut HashSet<AnimationKey>
+	fn active_animations_mut<TLayer>(&mut self, layer: TLayer) -> &mut OrderedSet<AnimationKey>
 	where
 		TLayer: Into<AnimationPriority>,
 	{
@@ -109,7 +109,7 @@ mod tests {
 				let ctx = AnimationsParamMut::get_context_mut(&mut p, key).unwrap();
 
 				assert_eq!(
-					&HashSet::from(animations),
+					&OrderedSet::from(animations),
 					ctx.active_animations(animation_priority)
 				);
 			})

--- a/src/plugins/animations/src/systems/play_animation_clip.rs
+++ b/src/plugins/animations/src/systems/play_animation_clip.rs
@@ -5,11 +5,11 @@ use crate::{
 	},
 	traits::{
 		AnimationPlayers,
-		GetActiveAnimations,
 		IsPlaying,
 		RepeatAnimation,
 		ReplayAnimation,
 		StopAnimation,
+		YoungestToOldestActiveAnimations,
 		asset_server::animation_graph::GetNodeMut,
 	},
 };
@@ -23,13 +23,13 @@ use common::traits::{
 use std::collections::HashSet;
 
 impl<TDispatch> PlayAnimationClip for TDispatch where
-	TDispatch: Component + AnimationPlayers + GetActiveAnimations
+	TDispatch: Component + AnimationPlayers + YoungestToOldestActiveAnimations
 {
 }
 
 pub(crate) trait PlayAnimationClip
 where
-	Self: Component + AnimationPlayers + GetActiveAnimations + Sized,
+	Self: Component + AnimationPlayers + YoungestToOldestActiveAnimations + Sized,
 {
 	#[allow(clippy::type_complexity)]
 	fn play_animation_clip<TAnimationPlayer>(
@@ -65,7 +65,7 @@ fn play_animation_clip<TAnimationPlayer, TDispatch, TGraph, TAnimations>(
 ) where
 	TAnimationPlayer: QueryData,
 	TGraph: Asset + GetNodeMut + WrapHandle,
-	TDispatch: Component + AnimationPlayers + GetActiveAnimations,
+	TDispatch: Component + AnimationPlayers + YoungestToOldestActiveAnimations,
 	for<'a> TAnimations: ThreadSafe + Iterate<'a, TItem = &'a AnimationNodeIndex>,
 	for<'w, 's> TAnimationPlayer::Item<'w, 's>: IsPlaying<AnimationNodeIndex>
 		+ ReplayAnimation<AnimationNodeIndex>
@@ -107,7 +107,7 @@ where
 	TPlayer: IsPlaying<AnimationNodeIndex>
 		+ ReplayAnimation<AnimationNodeIndex>
 		+ RepeatAnimation<AnimationNodeIndex>,
-	TDispatcher: GetActiveAnimations,
+	TDispatcher: YoungestToOldestActiveAnimations,
 	TGraph: Asset + GetNodeMut,
 	for<'a> TAnimations: Iterate<'a, TItem = &'a AnimationNodeIndex>,
 {
@@ -117,7 +117,7 @@ where
 	for priority in AnimationPriority::ordered_descending() {
 		let blocked_by_higher_priority = higher_priority_mask;
 
-		for key in dispatcher.get_active_animations(priority) {
+		for key in dispatcher.youngest_to_oldest_active_animations(priority) {
 			let Some(animation_data) = lookup.animations.get(key) else {
 				continue;
 			};
@@ -203,17 +203,20 @@ mod tests {
 		}
 	}
 
-	impl GetActiveAnimations for _AnimationDispatch {
+	impl YoungestToOldestActiveAnimations for _AnimationDispatch {
 		type TIter<'a>
 			= Iter<'a, AnimationKey>
 		where
 			Self: 'a;
 
-		fn get_active_animations<TPriority>(&self, priority: TPriority) -> Self::TIter<'_>
+		fn youngest_to_oldest_active_animations<TPriority>(
+			&self,
+			priority: TPriority,
+		) -> Self::TIter<'_>
 		where
 			TPriority: Into<AnimationPriority> + 'static,
 		{
-			self.mock.get_active_animations(priority)
+			self.mock.youngest_to_oldest_active_animations(priority)
 		}
 	}
 
@@ -224,13 +227,13 @@ mod tests {
 
 			fn animation_players(&self) -> _Iter;
 		}
-		impl GetActiveAnimations for _AnimationDispatch {
+		impl YoungestToOldestActiveAnimations for _AnimationDispatch {
 			type TIter<'a>
 				= Iter<'a, AnimationKey>
 			where
 				Self: 'a;
 
-			fn get_active_animations<TPriority>(&self, priority: TPriority) -> Iter<'static, AnimationKey>
+			fn youngest_to_oldest_active_animations<TPriority>(&self, priority: TPriority) -> Iter<'static, AnimationKey>
 			where
 				TPriority: Into<AnimationPriority> + 'static;
 		}
@@ -456,10 +459,10 @@ mod tests {
 			_AnimationDispatch::new().with_mock(|mock| {
 				mock.expect_animation_players()
 					.return_const(_Iter::from([animation_player]));
-				mock.expect_get_active_animations()
+				mock.expect_youngest_to_oldest_active_animations()
 					.with(eq(AnimationPriority::High))
 					.return_const(leak_iterator(vec![AnimationKey::Walk]));
-				mock.expect_get_active_animations::<AnimationPriority>()
+				mock.expect_youngest_to_oldest_active_animations::<AnimationPriority>()
 					.return_const(leak_iterator(vec![]));
 			}),
 			lookup,
@@ -511,10 +514,10 @@ mod tests {
 			_AnimationDispatch::new().with_mock(|mock| {
 				mock.expect_animation_players()
 					.return_const(_Iter::from([animation_player]));
-				mock.expect_get_active_animations()
+				mock.expect_youngest_to_oldest_active_animations()
 					.with(eq(AnimationPriority::High))
 					.return_const(leak_iterator(vec![AnimationKey::Walk]));
-				mock.expect_get_active_animations::<AnimationPriority>()
+				mock.expect_youngest_to_oldest_active_animations::<AnimationPriority>()
 					.return_const(leak_iterator(vec![]));
 			}),
 			lookup,
@@ -617,19 +620,19 @@ mod tests {
 			_AnimationDispatch::new().with_mock(|mock: &mut Mock_AnimationDispatch| {
 				mock.expect_animation_players()
 					.return_const(_Iter::from([animation_player]));
-				mock.expect_get_active_animations()
+				mock.expect_youngest_to_oldest_active_animations()
 					.with(eq(AnimationPriority::High))
 					.return_const(leak_iterator(vec![
 						AnimationKey::Skill(SlotKey(11)),
 						AnimationKey::Skill(SlotKey(12)),
 					]));
-				mock.expect_get_active_animations()
+				mock.expect_youngest_to_oldest_active_animations()
 					.with(eq(AnimationPriority::Medium))
 					.return_const(leak_iterator(vec![
 						AnimationKey::Skill(SlotKey(21)),
 						AnimationKey::Skill(SlotKey(22)),
 					]));
-				mock.expect_get_active_animations()
+				mock.expect_youngest_to_oldest_active_animations()
 					.with(eq(AnimationPriority::Low))
 					.return_const(leak_iterator(vec![
 						AnimationKey::Skill(SlotKey(31)),
@@ -686,10 +689,10 @@ mod tests {
 				mock.expect_animation_players()
 					.return_const(_Iter::from([animation_player]));
 
-				mock.expect_get_active_animations()
+				mock.expect_youngest_to_oldest_active_animations()
 					.with(eq(AnimationPriority::High))
 					.return_const(leak_iterator(vec![AnimationKey::Walk]));
-				mock.expect_get_active_animations::<AnimationPriority>()
+				mock.expect_youngest_to_oldest_active_animations::<AnimationPriority>()
 					.return_const(leak_iterator(vec![]));
 			}),
 			lookup,
@@ -744,7 +747,7 @@ mod tests {
 				mock.expect_animation_players()
 					.return_const(_Iter::from([animation_player]));
 
-				mock.expect_get_active_animations::<AnimationPriority>()
+				mock.expect_youngest_to_oldest_active_animations::<AnimationPriority>()
 					.return_const(leak_iterator(vec![]));
 			}),
 			lookup,
@@ -791,10 +794,10 @@ mod tests {
 			_AnimationDispatch::new().with_mock(|mock: &mut Mock_AnimationDispatch| {
 				mock.expect_animation_players()
 					.return_const(_Iter::from([animation_player]));
-				mock.expect_get_active_animations()
+				mock.expect_youngest_to_oldest_active_animations()
 					.with(eq(AnimationPriority::High))
 					.return_const(leak_iterator(vec![AnimationKey::Walk]));
-				mock.expect_get_active_animations::<AnimationPriority>()
+				mock.expect_youngest_to_oldest_active_animations::<AnimationPriority>()
 					.return_const(leak_iterator(vec![]));
 			}),
 			lookup,
@@ -837,10 +840,10 @@ mod tests {
 				_AnimationDispatch::new().with_mock(|mock: &mut Mock_AnimationDispatch| {
 					mock.expect_animation_players()
 						.return_const(_Iter::from([animation_player]));
-					mock.expect_get_active_animations()
+					mock.expect_youngest_to_oldest_active_animations()
 						.with(eq(AnimationPriority::High))
 						.return_const(leak_iterator(vec![AnimationKey::Walk]));
-					mock.expect_get_active_animations::<AnimationPriority>()
+					mock.expect_youngest_to_oldest_active_animations::<AnimationPriority>()
 						.return_const(leak_iterator(vec![]));
 				}),
 				lookup,
@@ -940,19 +943,19 @@ mod tests {
 			_AnimationDispatch::new().with_mock(|mock: &mut Mock_AnimationDispatch| {
 				mock.expect_animation_players()
 					.return_const(_Iter::from([animation_player]));
-				mock.expect_get_active_animations()
+				mock.expect_youngest_to_oldest_active_animations()
 					.with(eq(AnimationPriority::High))
 					.return_const(leak_iterator(vec![
 						AnimationKey::Skill(SlotKey(11)),
 						AnimationKey::Skill(SlotKey(12)),
 					]));
-				mock.expect_get_active_animations()
+				mock.expect_youngest_to_oldest_active_animations()
 					.with(eq(AnimationPriority::Medium))
 					.return_const(leak_iterator(vec![
 						AnimationKey::Skill(SlotKey(21)),
 						AnimationKey::Skill(SlotKey(22)),
 					]));
-				mock.expect_get_active_animations()
+				mock.expect_youngest_to_oldest_active_animations()
 					.with(eq(AnimationPriority::Low))
 					.return_const(leak_iterator(vec![
 						AnimationKey::Skill(SlotKey(31)),
@@ -1066,19 +1069,19 @@ mod tests {
 			_AnimationDispatch::new().with_mock(|mock: &mut Mock_AnimationDispatch| {
 				mock.expect_animation_players()
 					.return_const(_Iter::from([animation_player]));
-				mock.expect_get_active_animations()
+				mock.expect_youngest_to_oldest_active_animations()
 					.with(eq(AnimationPriority::High))
 					.return_const(leak_iterator(vec![
 						AnimationKey::Skill(SlotKey(11)),
 						AnimationKey::Skill(SlotKey(12)),
 					]));
-				mock.expect_get_active_animations()
+				mock.expect_youngest_to_oldest_active_animations()
 					.with(eq(AnimationPriority::Medium))
 					.return_const(leak_iterator(vec![
 						AnimationKey::Skill(SlotKey(21)),
 						AnimationKey::Skill(SlotKey(22)),
 					]));
-				mock.expect_get_active_animations()
+				mock.expect_youngest_to_oldest_active_animations()
 					.with(eq(AnimationPriority::Low))
 					.return_const(leak_iterator(vec![
 						AnimationKey::Skill(SlotKey(31)),
@@ -1172,13 +1175,13 @@ mod tests {
 			_AnimationDispatch::new().with_mock(|mock: &mut Mock_AnimationDispatch| {
 				mock.expect_animation_players()
 					.return_const(_Iter::from([animation_player]));
-				mock.expect_get_active_animations()
+				mock.expect_youngest_to_oldest_active_animations()
 					.with(eq(AnimationPriority::High))
 					.return_const(leak_iterator(vec![AnimationKey::Skill(SlotKey(1))]));
-				mock.expect_get_active_animations()
+				mock.expect_youngest_to_oldest_active_animations()
 					.with(eq(AnimationPriority::Medium))
 					.return_const(leak_iterator(vec![AnimationKey::Skill(SlotKey(2))]));
-				mock.expect_get_active_animations()
+				mock.expect_youngest_to_oldest_active_animations()
 					.with(eq(AnimationPriority::Low))
 					.return_const(leak_iterator(vec![]));
 			}),
@@ -1233,7 +1236,7 @@ mod tests {
 				mock.expect_animation_players()
 					.return_const(_Iter::from([animation_player]));
 
-				mock.expect_get_active_animations::<AnimationPriority>()
+				mock.expect_youngest_to_oldest_active_animations::<AnimationPriority>()
 					.return_const(leak_iterator(vec![]));
 			}),
 			lookup,

--- a/src/plugins/animations/src/systems/play_animation_clip.rs
+++ b/src/plugins/animations/src/systems/play_animation_clip.rs
@@ -111,27 +111,24 @@ where
 	TGraph: Asset + GetNodeMut,
 	for<'a> TAnimations: Iterate<'a, TItem = &'a AnimationNodeIndex>,
 {
-	let mut higher_priority_mask = 0;
+	let mut blocked = 0;
 	let mut active_animations = HashSet::default();
 
 	for priority in AnimationPriority::ordered_descending() {
-		let blocked_by_higher_priority = higher_priority_mask;
-
 		for key in dispatcher.youngest_to_oldest_active_animations(priority) {
 			let Some(animation_data) = lookup.animations.get(key) else {
 				continue;
 			};
+			let mask = animation_data.mask.to_animation_mask();
 
 			for id in animation_data.animation_clips.iterate() {
 				let Some(animation_node) = graph.get_node_mut(*id) else {
 					continue;
 				};
 
-				let mask = animation_data.mask.to_animation_mask();
 				active_animations.insert(*id);
 				animation_node.remove_mask(mask);
-				animation_node.add_mask(blocked_by_higher_priority);
-				add(&mut higher_priority_mask, mask);
+				animation_node.add_mask(blocked);
 
 				if player.is_playing(*id) {
 					continue;
@@ -142,6 +139,8 @@ where
 					PlayMode::Replay => player.replay(*id),
 				}
 			}
+
+			blocked |= mask;
 		}
 	}
 
@@ -162,10 +161,6 @@ fn stop<'a, TPlayer, TGraph>(
 		}
 		player.stop_animation(*animation_id);
 	}
-}
-
-fn add(dst: &mut AnimationMask, src: AnimationMask) {
-	*dst |= src;
 }
 
 #[cfg(test)]
@@ -243,19 +238,19 @@ mod tests {
 	#[derive(Clone, Default)]
 	struct _Animations(Vec<AnimationNodeIndex>);
 
+	impl _Animations {
+		fn from_indices(indices: impl IntoIterator<Item = usize>) -> Self {
+			let animations = Vec::from_iter(indices.into_iter().map(AnimationNodeIndex::new));
+			Self(animations)
+		}
+	}
+
 	impl<'a> Iterate<'a> for _Animations {
 		type TItem = &'a AnimationNodeIndex;
 		type TIter = Iter<'a, AnimationNodeIndex>;
 
 		fn iterate(&'a self) -> Iter<'a, AnimationNodeIndex> {
 			self.0.iter()
-		}
-	}
-
-	impl From<&[AnimationNodeIndex]> for _Animations {
-		fn from(animations: &[AnimationNodeIndex]) -> Self {
-			let animations = Vec::from_iter(animations.iter().copied());
-			Self(animations)
 		}
 	}
 
@@ -269,6 +264,16 @@ mod tests {
 	#[derive(Asset, TypePath, Default)]
 	struct _Graph {
 		nodes: HashMap<usize, AnimationGraphNode>,
+	}
+
+	impl _Graph {
+		fn get_masks(&self, indices: impl IntoIterator<Item = usize>) -> Vec<AnimationMask> {
+			indices
+				.into_iter()
+				.filter_map(|i| self.nodes.get(&i))
+				.map(|n| n.mask)
+				.collect()
+		}
 	}
 
 	impl WrapHandle for _Graph {
@@ -383,7 +388,7 @@ mod tests {
 	macro_rules! binary_str {
 		($a:expr) => {{
 			let values = $a
-				.into_iter()
+				.iter()
 				.map(|v| format!("{v:b}"))
 				.collect::<Vec<_>>()
 				.join(", ");
@@ -434,16 +439,11 @@ mod tests {
 	#[test]
 	fn repeat_animation() {
 		let handle = new_handle();
-		let indices = vec![
-			AnimationNodeIndex::new(1),
-			AnimationNodeIndex::new(2),
-			AnimationNodeIndex::new(3),
-		];
 		let lookup = AnimationLookup {
 			animations: HashMap::from([(
 				AnimationKey::Walk,
 				AnimationLookupData {
-					animation_clips: _Animations::from(&indices),
+					animation_clips: _Animations::from_indices([1, 2, 3]),
 					play_mode: PlayMode::Repeat,
 					..default()
 				},
@@ -453,7 +453,7 @@ mod tests {
 		let mut app = setup!(&lookup, &handle);
 		let animation_player = app
 			.world_mut()
-			.spawn(_AnimationPlayer::new().with_mock(assert_repeat(indices)))
+			.spawn(_AnimationPlayer::new().with_mock(assert_repeat([1, 2, 3])))
 			.id();
 		app.world_mut().spawn((
 			_AnimationDispatch::new().with_mock(|mock| {
@@ -471,14 +471,16 @@ mod tests {
 
 		app.update();
 
-		fn assert_repeat(indices: Vec<AnimationNodeIndex>) -> impl Fn(&mut Mock_AnimationPlayer) {
+		fn assert_repeat(
+			indices: impl Clone + IntoIterator<Item = usize>,
+		) -> impl Fn(&mut Mock_AnimationPlayer) {
 			move |mock| {
 				mock.expect_is_playing().return_const(false);
 				mock.expect_replay().never().return_const(());
 				for index in indices.clone() {
 					mock.expect_repeat()
 						.times(1)
-						.with(eq(index))
+						.with(eq(AnimationNodeIndex::new(index)))
 						.return_const(());
 				}
 				mock.expect_stop_animation().never().return_const(());
@@ -489,16 +491,11 @@ mod tests {
 	#[test]
 	fn replay_animation() {
 		let handle = new_handle();
-		let indices = vec![
-			AnimationNodeIndex::new(1),
-			AnimationNodeIndex::new(2),
-			AnimationNodeIndex::new(3),
-		];
 		let lookup = AnimationLookup {
 			animations: HashMap::from([(
 				AnimationKey::Walk,
 				AnimationLookupData {
-					animation_clips: _Animations::from(&indices),
+					animation_clips: _Animations::from_indices([1, 2, 3]),
 					play_mode: PlayMode::Replay,
 					..default()
 				},
@@ -508,7 +505,7 @@ mod tests {
 		let mut app = setup!(&lookup, &handle);
 		let animation_player = app
 			.world_mut()
-			.spawn(_AnimationPlayer::new().with_mock(assert_replay(indices)))
+			.spawn(_AnimationPlayer::new().with_mock(assert_replay([1, 2, 3])))
 			.id();
 		app.world_mut().spawn((
 			_AnimationDispatch::new().with_mock(|mock| {
@@ -526,14 +523,16 @@ mod tests {
 
 		app.update();
 
-		fn assert_replay(indices: Vec<AnimationNodeIndex>) -> impl Fn(&mut Mock_AnimationPlayer) {
+		fn assert_replay(
+			indices: impl Clone + IntoIterator<Item = usize>,
+		) -> impl Fn(&mut Mock_AnimationPlayer) {
 			move |mock| {
 				mock.expect_is_playing().return_const(false);
 				mock.expect_repeat().never().return_const(());
 				for index in indices.clone() {
 					mock.expect_replay()
 						.times(1)
-						.with(eq(index))
+						.with(eq(AnimationNodeIndex::new(index)))
 						.return_const(());
 				}
 				mock.expect_stop_animation().never().return_const(());
@@ -544,26 +543,12 @@ mod tests {
 	#[test]
 	fn play_all_animations() {
 		let handle = new_handle();
-		let indices = vec![
-			AnimationNodeIndex::new(1),
-			AnimationNodeIndex::new(2),
-			AnimationNodeIndex::new(3),
-			AnimationNodeIndex::new(4),
-			AnimationNodeIndex::new(5),
-			AnimationNodeIndex::new(6),
-			AnimationNodeIndex::new(7),
-			AnimationNodeIndex::new(8),
-			AnimationNodeIndex::new(9),
-			AnimationNodeIndex::new(10),
-			AnimationNodeIndex::new(11),
-			AnimationNodeIndex::new(12),
-		];
 		let lookup = AnimationLookup {
 			animations: HashMap::from([
 				(
 					AnimationKey::Skill(SlotKey(11)),
 					AnimationLookupData {
-						animation_clips: _Animations::from(&indices[0..=1]),
+						animation_clips: _Animations::from_indices([0, 1]),
 						play_mode: PlayMode::Replay,
 						mask: AnimationMaskBits::zero(),
 					},
@@ -571,7 +556,7 @@ mod tests {
 				(
 					AnimationKey::Skill(SlotKey(12)),
 					AnimationLookupData {
-						animation_clips: _Animations::from(&indices[2..=3]),
+						animation_clips: _Animations::from_indices([2, 3]),
 						play_mode: PlayMode::Replay,
 						mask: AnimationMaskBits::zero(),
 					},
@@ -579,7 +564,7 @@ mod tests {
 				(
 					AnimationKey::Skill(SlotKey(21)),
 					AnimationLookupData {
-						animation_clips: _Animations::from(&indices[4..=5]),
+						animation_clips: _Animations::from_indices([4, 5]),
 						play_mode: PlayMode::Replay,
 						mask: AnimationMaskBits::zero(),
 					},
@@ -587,7 +572,7 @@ mod tests {
 				(
 					AnimationKey::Skill(SlotKey(22)),
 					AnimationLookupData {
-						animation_clips: _Animations::from(&indices[6..=7]),
+						animation_clips: _Animations::from_indices([6, 7]),
 						play_mode: PlayMode::Replay,
 						mask: AnimationMaskBits::zero(),
 					},
@@ -595,7 +580,7 @@ mod tests {
 				(
 					AnimationKey::Skill(SlotKey(31)),
 					AnimationLookupData {
-						animation_clips: _Animations::from(&indices[8..=9]),
+						animation_clips: _Animations::from_indices([8, 9]),
 						play_mode: PlayMode::Replay,
 						mask: AnimationMaskBits::zero(),
 					},
@@ -603,7 +588,7 @@ mod tests {
 				(
 					AnimationKey::Skill(SlotKey(32)),
 					AnimationLookupData {
-						animation_clips: _Animations::from(&indices[10..=11]),
+						animation_clips: _Animations::from_indices([10, 11]),
 						play_mode: PlayMode::Replay,
 						mask: AnimationMaskBits::zero(),
 					},
@@ -614,7 +599,7 @@ mod tests {
 		let mut app = setup!(&lookup, &handle);
 		let animation_player = app
 			.world_mut()
-			.spawn(_AnimationPlayer::new().with_mock(assert_repeat(indices)))
+			.spawn(_AnimationPlayer::new().with_mock(assert_repeat(0..=11)))
 			.id();
 		app.world_mut().spawn((
 			_AnimationDispatch::new().with_mock(|mock: &mut Mock_AnimationDispatch| {
@@ -645,14 +630,16 @@ mod tests {
 
 		app.update();
 
-		fn assert_repeat(indices: Vec<AnimationNodeIndex>) -> impl Fn(&mut Mock_AnimationPlayer) {
+		fn assert_repeat(
+			indices: impl Clone + IntoIterator<Item = usize>,
+		) -> impl Fn(&mut Mock_AnimationPlayer) {
 			move |mock| {
 				mock.expect_is_playing().return_const(false);
 				mock.expect_repeat().never().return_const(());
-				for index in indices.clone() {
+				for index in indices.clone().into_iter() {
 					mock.expect_replay()
 						.times(1)
-						.with(eq(index))
+						.with(eq(AnimationNodeIndex::new(index)))
 						.return_const(());
 				}
 				mock.expect_stop_animation().return_const(());
@@ -663,16 +650,11 @@ mod tests {
 	#[test]
 	fn do_not_play_animation_which_is_playing() {
 		let handle = new_handle();
-		let indices = vec![
-			AnimationNodeIndex::new(1),
-			AnimationNodeIndex::new(2),
-			AnimationNodeIndex::new(3),
-		];
 		let lookup = AnimationLookup {
 			animations: HashMap::from([(
 				AnimationKey::Walk,
 				AnimationLookupData {
-					animation_clips: _Animations::from(&indices),
+					animation_clips: _Animations::from_indices([1, 2, 3]),
 					play_mode: PlayMode::Repeat,
 					..default()
 				},
@@ -682,7 +664,7 @@ mod tests {
 		let mut app = setup!(&lookup, &handle);
 		let animation_player = app
 			.world_mut()
-			.spawn(_AnimationPlayer::new().with_mock(assert_not_playing(indices)))
+			.spawn(_AnimationPlayer::new().with_mock(assert_not_playing([1, 2, 3])))
 			.id();
 		app.world_mut().spawn((
 			_AnimationDispatch::new().with_mock(|mock: &mut Mock_AnimationDispatch| {
@@ -702,13 +684,13 @@ mod tests {
 		app.update();
 
 		fn assert_not_playing(
-			indices: Vec<AnimationNodeIndex>,
+			indices: impl Clone + IntoIterator<Item = usize>,
 		) -> impl Fn(&mut Mock_AnimationPlayer) {
 			move |mock| {
-				for i in indices.clone() {
+				for index in indices.clone() {
 					mock.expect_is_playing()
 						.times(1)
-						.with(eq(i))
+						.with(eq(AnimationNodeIndex::new(index)))
 						.return_const(true);
 				}
 				mock.expect_replay().never().return_const(());
@@ -721,16 +703,11 @@ mod tests {
 	#[test]
 	fn stop_playing_animation_not_returned_in_dispatcher() {
 		let handle = new_handle();
-		let indices = vec![
-			AnimationNodeIndex::new(1),
-			AnimationNodeIndex::new(2),
-			AnimationNodeIndex::new(3),
-		];
 		let lookup = AnimationLookup {
 			animations: HashMap::from([(
 				AnimationKey::Walk,
 				AnimationLookupData {
-					animation_clips: _Animations::from(&indices),
+					animation_clips: _Animations::from_indices([1, 2, 3]),
 					play_mode: PlayMode::Repeat,
 					..default()
 				},
@@ -740,7 +717,7 @@ mod tests {
 		let mut app = setup!(&lookup, &handle);
 		let animation_player = app
 			.world_mut()
-			.spawn(_AnimationPlayer::new().with_mock(assert_stop(indices)))
+			.spawn(_AnimationPlayer::new().with_mock(assert_stop([1, 2, 3])))
 			.id();
 		app.world_mut().spawn((
 			_AnimationDispatch::new().with_mock(|mock: &mut Mock_AnimationDispatch| {
@@ -756,15 +733,17 @@ mod tests {
 
 		app.update();
 
-		fn assert_stop(indices: Vec<AnimationNodeIndex>) -> impl Fn(&mut Mock_AnimationPlayer) {
+		fn assert_stop(
+			indices: impl Clone + IntoIterator<Item = usize>,
+		) -> impl Fn(&mut Mock_AnimationPlayer) {
 			move |mock| {
 				mock.expect_is_playing().return_const(false);
 				mock.expect_replay().return_const(());
 				mock.expect_repeat().return_const(());
-				for i in indices.clone() {
+				for index in indices.clone() {
 					mock.expect_stop_animation()
 						.times(1)
-						.with(eq(i))
+						.with(eq(AnimationNodeIndex::new(index)))
 						.return_const(());
 				}
 			}
@@ -778,7 +757,7 @@ mod tests {
 			animations: HashMap::from([(
 				AnimationKey::Walk,
 				AnimationLookupData {
-					animation_clips: _Animations::from(&vec![AnimationNodeIndex::new(1)]),
+					animation_clips: _Animations::from_indices([1]),
 					play_mode: PlayMode::Repeat,
 					..default()
 				},
@@ -822,7 +801,7 @@ mod tests {
 			animations: HashMap::from([(
 				AnimationKey::Walk,
 				AnimationLookupData {
-					animation_clips: _Animations::from(&vec![AnimationNodeIndex::new(1)]),
+					animation_clips: _Animations::from_indices([1]),
 					play_mode: PlayMode::Repeat,
 					..default()
 				},
@@ -868,28 +847,14 @@ mod tests {
 	}
 
 	#[test]
-	fn mask_depending_on_priority() {
+	fn mask_depending_on_priority_and_in_layer_order() {
 		let handle = new_handle();
-		let indices = [
-			AnimationNodeIndex::new(1),
-			AnimationNodeIndex::new(2),
-			AnimationNodeIndex::new(3),
-			AnimationNodeIndex::new(4),
-			AnimationNodeIndex::new(5),
-			AnimationNodeIndex::new(6),
-			AnimationNodeIndex::new(7),
-			AnimationNodeIndex::new(8),
-			AnimationNodeIndex::new(9),
-			AnimationNodeIndex::new(10),
-			AnimationNodeIndex::new(11),
-			AnimationNodeIndex::new(12),
-		];
 		let lookup = AnimationLookup {
 			animations: HashMap::from([
 				(
 					AnimationKey::Skill(SlotKey(11)),
 					AnimationLookupData {
-						animation_clips: _Animations::from(&indices[0..=1]),
+						animation_clips: _Animations::from_indices([0, 1]),
 						play_mode: PlayMode::Replay,
 						mask: AnimationMaskBits::zero().with_set(bit_mask_index!(0)),
 					},
@@ -897,7 +862,7 @@ mod tests {
 				(
 					AnimationKey::Skill(SlotKey(12)),
 					AnimationLookupData {
-						animation_clips: _Animations::from(&indices[2..=3]),
+						animation_clips: _Animations::from_indices([2, 3]),
 						play_mode: PlayMode::Replay,
 						mask: AnimationMaskBits::zero().with_set(bit_mask_index!(1)),
 					},
@@ -905,7 +870,7 @@ mod tests {
 				(
 					AnimationKey::Skill(SlotKey(21)),
 					AnimationLookupData {
-						animation_clips: _Animations::from(&indices[4..=5]),
+						animation_clips: _Animations::from_indices([4, 5]),
 						play_mode: PlayMode::Replay,
 						mask: AnimationMaskBits::zero().with_set(bit_mask_index!(2)),
 					},
@@ -913,7 +878,7 @@ mod tests {
 				(
 					AnimationKey::Skill(SlotKey(22)),
 					AnimationLookupData {
-						animation_clips: _Animations::from(&indices[6..=7]),
+						animation_clips: _Animations::from_indices([6, 7]),
 						play_mode: PlayMode::Replay,
 						mask: AnimationMaskBits::zero().with_set(bit_mask_index!(3)),
 					},
@@ -921,7 +886,7 @@ mod tests {
 				(
 					AnimationKey::Skill(SlotKey(31)),
 					AnimationLookupData {
-						animation_clips: _Animations::from(&indices[8..=9]),
+						animation_clips: _Animations::from_indices([8, 9]),
 						play_mode: PlayMode::Replay,
 						mask: AnimationMaskBits::zero().with_set(bit_mask_index!(4)),
 					},
@@ -929,7 +894,7 @@ mod tests {
 				(
 					AnimationKey::Skill(SlotKey(32)),
 					AnimationLookupData {
-						animation_clips: _Animations::from(&indices[10..=11]),
+						animation_clips: _Animations::from_indices([10, 11]),
 						play_mode: PlayMode::Replay,
 						mask: AnimationMaskBits::zero().with_set(bit_mask_index!(5)),
 					},
@@ -973,16 +938,16 @@ mod tests {
 			.resource::<Assets<_Graph>>()
 			.get(&handle)
 			.unwrap();
-		let masks = &indices
-			.iter()
-			.map(|i| graph.nodes.get(&i.index()).unwrap().mask)
-			.collect::<Vec<_>>();
-		// each priority has 2 assets each with 2 animations
-		//   -> 4 animations masked by higher priority mask per priority
-		let expected = &std::iter::repeat_n(0b000000, 4)
-			.chain(std::iter::repeat_n(0b000011, 4))
-			.chain(std::iter::repeat_n(0b001111, 4))
-			.collect::<Vec<_>>();
+		let masks = graph.get_masks(0..=11);
+		#[rustfmt::skip]
+		let expected = vec![
+			0b000000, 0b000000, // unblocked, uses mask: `0b000001``
+			0b000001, 0b000001, // blocked by first in layer, uses mask: `0b000010`
+			0b000011, 0b000011, // blocked by high layer, uses mask: `0b000100`
+			0b000111, 0b000111, // blocked by high layer and first in layer, uses mask: `0b001000`
+			0b001111, 0b001111, // blocked by high and mid layer, uses mask: `0b010000`
+			0b011111, 0b011111, // blocked by all above
+		];
 		assert_eq!(
 			expected,
 			masks,
@@ -995,26 +960,12 @@ mod tests {
 	#[test]
 	fn unmask_depending_on_priority() {
 		let handle = new_handle();
-		let indices = [
-			AnimationNodeIndex::new(1),
-			AnimationNodeIndex::new(2),
-			AnimationNodeIndex::new(3),
-			AnimationNodeIndex::new(4),
-			AnimationNodeIndex::new(5),
-			AnimationNodeIndex::new(6),
-			AnimationNodeIndex::new(7),
-			AnimationNodeIndex::new(8),
-			AnimationNodeIndex::new(9),
-			AnimationNodeIndex::new(10),
-			AnimationNodeIndex::new(11),
-			AnimationNodeIndex::new(12),
-		];
 		let lookup = AnimationLookup {
 			animations: HashMap::from([
 				(
 					AnimationKey::Skill(SlotKey(11)),
 					AnimationLookupData {
-						animation_clips: _Animations::from(&indices[0..=1]),
+						animation_clips: _Animations::from_indices([0, 1]),
 						play_mode: PlayMode::Replay,
 						mask: AnimationMaskBits::zero().with_set(bit_mask_index!(0)),
 					},
@@ -1022,7 +973,7 @@ mod tests {
 				(
 					AnimationKey::Skill(SlotKey(12)),
 					AnimationLookupData {
-						animation_clips: _Animations::from(&indices[2..=3]),
+						animation_clips: _Animations::from_indices([2, 3]),
 						play_mode: PlayMode::Replay,
 						mask: AnimationMaskBits::zero().with_set(bit_mask_index!(1)),
 					},
@@ -1030,7 +981,7 @@ mod tests {
 				(
 					AnimationKey::Skill(SlotKey(21)),
 					AnimationLookupData {
-						animation_clips: _Animations::from(&indices[4..=5]),
+						animation_clips: _Animations::from_indices([4, 5]),
 						play_mode: PlayMode::Replay,
 						mask: AnimationMaskBits::zero().with_set(bit_mask_index!(2)),
 					},
@@ -1038,7 +989,7 @@ mod tests {
 				(
 					AnimationKey::Skill(SlotKey(22)),
 					AnimationLookupData {
-						animation_clips: _Animations::from(&indices[6..=7]),
+						animation_clips: _Animations::from_indices([6, 7]),
 						play_mode: PlayMode::Replay,
 						mask: AnimationMaskBits::zero().with_set(bit_mask_index!(3)),
 					},
@@ -1046,7 +997,7 @@ mod tests {
 				(
 					AnimationKey::Skill(SlotKey(31)),
 					AnimationLookupData {
-						animation_clips: _Animations::from(&indices[8..=9]),
+						animation_clips: _Animations::from_indices([8, 9]),
 						play_mode: PlayMode::Replay,
 						mask: AnimationMaskBits::zero().with_set(bit_mask_index!(4)),
 					},
@@ -1054,7 +1005,7 @@ mod tests {
 				(
 					AnimationKey::Skill(SlotKey(32)),
 					AnimationLookupData {
-						animation_clips: _Animations::from(&indices[10..=11]),
+						animation_clips: _Animations::from_indices([10, 11]),
 						play_mode: PlayMode::Replay,
 						mask: AnimationMaskBits::zero().with_set(bit_mask_index!(5)),
 					},
@@ -1099,13 +1050,8 @@ mod tests {
 			.resource::<Assets<_Graph>>()
 			.get(&handle)
 			.unwrap();
-		let masks = &indices
-			.iter()
-			.map(|i| graph.nodes.get(&i.index()).unwrap().mask)
-			.collect::<Vec<_>>();
-		// each asset has 2 animations
-		//   -> 2 animations masked per asset
-		let expected = &std::iter::repeat_n(0b111110, 2)
+		let masks = graph.get_masks(0..=11);
+		let expected = std::iter::repeat_n(0b111110, 2)
 			.chain(std::iter::repeat_n(0b111101, 2))
 			.chain(std::iter::repeat_n(0b111011, 2))
 			.chain(std::iter::repeat_n(0b110111, 2))
@@ -1124,18 +1070,12 @@ mod tests {
 	#[test]
 	fn set_mask_for_already_playing_animation() {
 		let handle = new_handle();
-		let indices = [
-			AnimationNodeIndex::new(1),
-			AnimationNodeIndex::new(2),
-			AnimationNodeIndex::new(3),
-			AnimationNodeIndex::new(4),
-		];
 		let lookup = AnimationLookup {
 			animations: HashMap::from([
 				(
 					AnimationKey::Skill(SlotKey(1)),
 					AnimationLookupData {
-						animation_clips: _Animations::from(&indices[0..=1]),
+						animation_clips: _Animations::from_indices([0, 1]),
 						play_mode: PlayMode::Replay,
 						mask: AnimationMaskBits::zero().with_set(bit_mask_index!(0)),
 					},
@@ -1143,7 +1083,7 @@ mod tests {
 				(
 					AnimationKey::Skill(SlotKey(2)),
 					AnimationLookupData {
-						animation_clips: _Animations::from(&indices[2..=3]),
+						animation_clips: _Animations::from_indices([2, 3]),
 						play_mode: PlayMode::Replay,
 						mask: AnimationMaskBits::zero()
 							.with_set(bit_mask_index!(0))
@@ -1160,10 +1100,10 @@ mod tests {
 			.world_mut()
 			.spawn(_AnimationPlayer::new().with_mock(|mock| {
 				mock.expect_is_playing()
-					.with(eq(indices[2]))
+					.with(eq(AnimationNodeIndex::new(2)))
 					.return_const(true);
 				mock.expect_is_playing()
-					.with(eq(indices[3]))
+					.with(eq(AnimationNodeIndex::new(3)))
 					.return_const(true);
 				mock.expect_is_playing().return_const(false);
 				mock.expect_repeat().return_const(());
@@ -1196,13 +1136,8 @@ mod tests {
 			.resource::<Assets<_Graph>>()
 			.get(&handle)
 			.unwrap();
-		let masks = &indices
-			.iter()
-			.map(|i| graph.nodes.get(&i.index()).unwrap().mask)
-			.collect::<Vec<_>>();
-		// each asset has 2 animations
-		//   -> 2 animations masked per asset
-		let expected = &std::iter::repeat_n(0b111110, 2)
+		let masks = graph.get_masks(0..=3);
+		let expected = std::iter::repeat_n(0b111110, 2)
 			.chain(std::iter::repeat_n(0b111001, 2))
 			.collect::<Vec<_>>();
 		assert_eq!(
@@ -1217,12 +1152,11 @@ mod tests {
 	#[test]
 	fn completely_mask_animations_not_returned_by_dispatcher() {
 		let handle = new_handle();
-		let indices = vec![AnimationNodeIndex::new(1), AnimationNodeIndex::new(2)];
 		let lookup = AnimationLookup {
 			animations: HashMap::from([(
 				AnimationKey::Walk,
 				AnimationLookupData {
-					animation_clips: _Animations::from(&indices),
+					animation_clips: _Animations::from_indices([1, 2]),
 					play_mode: PlayMode::Repeat,
 					..default()
 				},
@@ -1250,11 +1184,8 @@ mod tests {
 			.resource::<Assets<_Graph>>()
 			.get(&handle)
 			.unwrap();
-		let masks = &indices
-			.iter()
-			.map(|i| graph.nodes.get(&i.index()).unwrap().mask)
-			.collect::<Vec<_>>();
-		let expected = &vec![AnimationMask::MAX, AnimationMask::MAX];
+		let masks = graph.get_masks([1, 2]);
+		let expected = vec![AnimationMask::MAX, AnimationMask::MAX];
 		assert_eq!(
 			expected,
 			masks,

--- a/src/plugins/animations/src/traits.rs
+++ b/src/plugins/animations/src/traits.rs
@@ -14,12 +14,15 @@ pub(crate) trait LoadAnimationAssets<TGraph, TIndices> {
 	) -> (TGraph, HashMap<AnimationPath, TIndices>);
 }
 
-pub trait GetActiveAnimations {
+pub trait YoungestToOldestActiveAnimations {
 	type TIter<'a>: Iterator<Item = &'a AnimationKey>
 	where
 		Self: 'a;
 
-	fn get_active_animations<TPriority>(&self, priority: TPriority) -> Self::TIter<'_>
+	fn youngest_to_oldest_active_animations<TPriority>(
+		&self,
+		priority: TPriority,
+	) -> Self::TIter<'_>
 	where
 		TPriority: Into<AnimationPriority> + 'static;
 }

--- a/src/plugins/common/src/traits/handles_animations.rs
+++ b/src/plugins/common/src/traits/handles_animations.rs
@@ -15,6 +15,7 @@ use std::{
 	hash::Hash,
 	ops::{Deref, DerefMut},
 };
+use zyheeda_core::prelude::OrderedSet;
 
 pub trait HandlesAnimations {
 	type TAnimationsMut<'w, 's>: SystemParam
@@ -59,7 +60,7 @@ where
 }
 
 pub trait ActiveAnimations {
-	fn active_animations<TLayer>(&self, layer: TLayer) -> &HashSet<AnimationKey>
+	fn active_animations<TLayer>(&self, layer: TLayer) -> &OrderedSet<AnimationKey>
 	where
 		TLayer: Into<AnimationPriority>;
 }
@@ -68,7 +69,7 @@ impl<T> ActiveAnimations for T
 where
 	T: Deref<Target: ActiveAnimations>,
 {
-	fn active_animations<TLayer>(&self, layer: TLayer) -> &HashSet<AnimationKey>
+	fn active_animations<TLayer>(&self, layer: TLayer) -> &OrderedSet<AnimationKey>
 	where
 		TLayer: Into<AnimationPriority>,
 	{
@@ -77,7 +78,7 @@ where
 }
 
 pub trait ActiveAnimationsMut: ActiveAnimations {
-	fn active_animations_mut<TLayer>(&mut self, layer: TLayer) -> &mut HashSet<AnimationKey>
+	fn active_animations_mut<TLayer>(&mut self, layer: TLayer) -> &mut OrderedSet<AnimationKey>
 	where
 		TLayer: Into<AnimationPriority>;
 }
@@ -86,7 +87,7 @@ impl<T> ActiveAnimationsMut for T
 where
 	T: DerefMut<Target: ActiveAnimationsMut>,
 {
-	fn active_animations_mut<TLayer>(&mut self, layer: TLayer) -> &mut HashSet<AnimationKey>
+	fn active_animations_mut<TLayer>(&mut self, layer: TLayer) -> &mut OrderedSet<AnimationKey>
 	where
 		TLayer: Into<AnimationPriority>,
 	{


### PR DESCRIPTION
- define animation masks for player to include head in skill aim animations
- mask animations additionally by play order within a layer, where newer animations mask older animations (this prevents conflicts between animations on the same layer)