### PR TITLE
Add Target modes

### DIFF
--- a/assets/locale/en-us.ftl
+++ b/assets/locale/en-us.ftl
@@ -32,9 +32,12 @@ key-bindings-movement = Movement
 key-bindings-menus = Miscellaneous
 key-bindings-camera = Camera
 key-bindings-savegame = Save Game
+key-bindings-targeting = Targeting
 
 slot-key-hand-left = Left Hand
 slot-key-hand-right = Right Hand
+
+terrain-targeting = Terrain Targeting
 
 movement-key-forward = Move forward
 movement-key-backward = Move backward
@@ -104,6 +107,7 @@ key-code-f-12 = F12
 key-code-escape = Escape
 key-code-numpad-subtract = Numpad -
 key-code-space = Space
+key-code-shift-left = Left Shift
 
 mouse-button-left = Left Mouse Button
 mouse-button-right = Right Mouse Button

--- a/src/plugins/agents/src/systems/player/use_skills.rs
+++ b/src/plugins/agents/src/systems/player/use_skills.rs
@@ -4,11 +4,20 @@ use bevy::{
 	prelude::*,
 };
 use common::{
-	tools::action_key::slot::{HandSlot, SlotKey},
+	tools::action_key::{
+		slot::{HandSlot, SlotKey},
+		targeting::TerrainTargeting,
+	},
 	traits::{
 		accessors::get::GetContextMut,
 		handles_input::{GetAllInputStates, InputState},
-		handles_loadout::{CurrentTargetMut, HeldSkills, HeldSkillsMut, skills::Skills},
+		handles_loadout::{
+			CurrentTarget,
+			CurrentTargetMut,
+			HeldSkills,
+			HeldSkillsMut,
+			skills::Skills,
+		},
 		handles_skill_physics::{Cursor, SkillTarget},
 	},
 };
@@ -30,20 +39,35 @@ impl Player {
 					_ => None,
 				})
 		};
+		let get_cursor = || {
+			let target_terrain =
+				input
+					.get_all_input_states::<TerrainTargeting>()
+					.any(|(key, state)| {
+						matches!((key, state), (TerrainTargeting, InputState::Pressed { .. }))
+					});
+
+			if target_terrain {
+				Cursor::TerrainHover
+			} else {
+				Cursor::Direction
+			}
+		};
 
 		for entity in &players {
 			let Some(mut ctx) = TLoadout::get_context_mut(&mut skills, Skills { entity }) else {
 				continue;
 			};
 
-			let new_held_skills = held().map(SlotKey::from).collect();
-
-			if ctx.held_skills() == &new_held_skills {
-				continue;
+			let cursor = get_cursor();
+			if ctx.current_target() != Some(&SkillTarget::Cursor(cursor)) {
+				*ctx.current_target_mut() = Some(SkillTarget::Cursor(cursor));
 			}
 
-			*ctx.current_target_mut() = Some(SkillTarget::Cursor(Cursor::TerrainHover));
-			*ctx.held_skills_mut() = new_held_skills;
+			let new_held_skills = held().map(SlotKey::from).collect();
+			if ctx.held_skills() != &new_held_skills {
+				*ctx.held_skills_mut() = new_held_skills;
+			}
 		}
 	}
 }
@@ -66,23 +90,18 @@ mod tests {
 	use mockall::automock;
 	use std::collections::{HashMap, HashSet};
 	use test_case::test_case;
-	use testing::{IsChanged, SingleThreadedApp};
+	use testing::SingleThreadedApp;
 
 	#[derive(Resource)]
 	struct _Input(HashMap<ActionKey, InputState>);
 
 	impl<TAction, T> From<T> for _Input
 	where
-		TAction: TryInto<ActionKey>,
+		TAction: Into<ActionKey>,
 		T: IntoIterator<Item = (TAction, InputState)>,
 	{
 		fn from(inputs: T) -> Self {
-			Self(
-				inputs
-					.into_iter()
-					.filter_map(|(a, i)| Some((a.try_into().ok()?, i)))
-					.collect(),
-			)
+			Self(inputs.into_iter().map(|(a, i)| (a.into(), i)).collect())
 		}
 	}
 
@@ -98,7 +117,9 @@ mod tests {
 
 	#[derive(Component, Debug, PartialEq, Default)]
 	struct _Loadout {
+		slots_dereferenced: bool,
 		slots: HashSet<SlotKey>,
+		target_dereferenced: bool,
 		target: Option<SkillTarget>,
 	}
 
@@ -107,12 +128,21 @@ mod tests {
 			self.target = target;
 			self
 		}
+
+		fn reset_change_states(loadout: Query<&mut Self>) {
+			for mut loadout in loadout {
+				loadout.slots_dereferenced = false;
+				loadout.target_dereferenced = false;
+			}
+		}
 	}
 
 	impl<const N: usize> From<[SlotKey; N]> for _Loadout {
 		fn from(slots: [SlotKey; N]) -> Self {
 			Self {
+				slots_dereferenced: true,
 				slots: HashSet::from(slots),
+				target_dereferenced: true,
 				target: None,
 			}
 		}
@@ -126,6 +156,7 @@ mod tests {
 
 	impl HeldSkillsMut for _Loadout {
 		fn held_skills_mut(&mut self) -> &mut HashSet<SlotKey> {
+			self.slots_dereferenced = true;
 			&mut self.slots
 		}
 	}
@@ -138,6 +169,7 @@ mod tests {
 
 	impl CurrentTargetMut for _Loadout {
 		fn current_target_mut(&mut self) -> &mut Option<SkillTarget> {
+			self.target_dereferenced = true;
 			&mut self.target
 		}
 	}
@@ -149,8 +181,8 @@ mod tests {
 		app.add_systems(
 			Update,
 			(
+				_Loadout::reset_change_states,
 				Player::use_skills::<Res<_Input>, Query<&mut _Loadout>>,
-				IsChanged::<_Loadout>::detect,
 			)
 				.chain(),
 		);
@@ -158,41 +190,95 @@ mod tests {
 		app
 	}
 
-	#[test_case(InputState::just_pressed(); "on just pressed")]
-	#[test_case(InputState::pressed(); "on pressed")]
-	fn set_held_skills(state: InputState) {
-		let mut app = setup(_Input::from(std::iter::once((HandSlot::Left, state))));
-		let entity = app.world_mut().spawn((Player, _Loadout::default())).id();
+	mod default_targeting {
+		use super::*;
+		use test_case::test_case;
 
-		app.update();
+		#[test_case(InputState::just_pressed(); "on just pressed")]
+		#[test_case(InputState::pressed(); "on pressed")]
+		fn set_held_skills(state: InputState) {
+			let mut app = setup(_Input::from(std::iter::once((HandSlot::Left, state))));
+			let entity = app.world_mut().spawn((Player, _Loadout::default())).id();
 
-		assert_eq!(
-			Some(
-				&_Loadout::from([SlotKey::from(HandSlot::Left)])
-					.with_target(Some(SkillTarget::Cursor(Cursor::TerrainHover)))
-			),
-			app.world().entity(entity).get::<_Loadout>(),
-		);
+			app.update();
+
+			assert_eq!(
+				Some(
+					&_Loadout::from([SlotKey::from(HandSlot::Left)])
+						.with_target(Some(SkillTarget::Cursor(Cursor::Direction)))
+				),
+				app.world().entity(entity).get::<_Loadout>(),
+			);
+		}
+
+		#[test_case(InputState::just_pressed(); "on just pressed")]
+		#[test_case(InputState::pressed(); "on pressed")]
+		fn override_held_skills(state: InputState) {
+			let mut app = setup(_Input::from(std::iter::once((HandSlot::Left, state))));
+			let entity = app
+				.world_mut()
+				.spawn((Player, _Loadout::from([SlotKey::from(HandSlot::Right)])))
+				.id();
+
+			app.update();
+
+			assert_eq!(
+				Some(
+					&_Loadout::from([SlotKey::from(HandSlot::Left)])
+						.with_target(Some(SkillTarget::Cursor(Cursor::Direction)))
+				),
+				app.world().entity(entity).get::<_Loadout>(),
+			);
+		}
 	}
 
-	#[test_case(InputState::just_pressed(); "on just pressed")]
-	#[test_case(InputState::pressed(); "on pressed")]
-	fn override_held_skills(state: InputState) {
-		let mut app = setup(_Input::from(std::iter::once((HandSlot::Left, state))));
-		let entity = app
-			.world_mut()
-			.spawn((Player, _Loadout::from([SlotKey::from(HandSlot::Right)])))
-			.id();
+	mod terrain_targeting {
+		use super::*;
+		use common::tools::action_key::targeting::TerrainTargeting;
+		use test_case::test_case;
 
-		app.update();
+		#[test_case(InputState::just_pressed(); "on just pressed")]
+		#[test_case(InputState::pressed(); "on pressed")]
+		fn set_held_skills(state: InputState) {
+			let mut app = setup(_Input::from([
+				(ActionKey::from(HandSlot::Left), state),
+				(ActionKey::from(TerrainTargeting), state),
+			]));
+			let entity = app.world_mut().spawn((Player, _Loadout::default())).id();
 
-		assert_eq!(
-			Some(
-				&_Loadout::from([SlotKey::from(HandSlot::Left)])
-					.with_target(Some(SkillTarget::Cursor(Cursor::TerrainHover)))
-			),
-			app.world().entity(entity).get::<_Loadout>(),
-		);
+			app.update();
+
+			assert_eq!(
+				Some(
+					&_Loadout::from([SlotKey::from(HandSlot::Left)])
+						.with_target(Some(SkillTarget::Cursor(Cursor::TerrainHover)))
+				),
+				app.world().entity(entity).get::<_Loadout>(),
+			);
+		}
+
+		#[test_case(InputState::just_pressed(); "on just pressed")]
+		#[test_case(InputState::pressed(); "on pressed")]
+		fn override_held_skills(state: InputState) {
+			let mut app = setup(_Input::from([
+				(ActionKey::from(HandSlot::Left), state),
+				(ActionKey::from(TerrainTargeting), state),
+			]));
+			let entity = app
+				.world_mut()
+				.spawn((Player, _Loadout::from([SlotKey::from(HandSlot::Right)])))
+				.id();
+
+			app.update();
+
+			assert_eq!(
+				Some(
+					&_Loadout::from([SlotKey::from(HandSlot::Left)])
+						.with_target(Some(SkillTarget::Cursor(Cursor::TerrainHover)))
+				),
+				app.world().entity(entity).get::<_Loadout>(),
+			);
+		}
 	}
 
 	#[test]
@@ -213,7 +299,7 @@ mod tests {
 
 	#[test_case(InputState::just_pressed(); "on just pressed")]
 	#[test_case(InputState::pressed(); "on pressed")]
-	fn do_nothing_if_current_held_would_not_change(state: InputState) {
+	fn do_not_deref_slots_if_they_would_not_change(state: InputState) {
 		let mut app = setup(_Input::from(std::iter::once((HandSlot::Left, state))));
 		let entity = app
 			.world_mut()
@@ -224,8 +310,81 @@ mod tests {
 		app.update();
 
 		assert_eq!(
-			Some(&IsChanged::FALSE),
-			app.world().entity(entity).get::<IsChanged<_Loadout>>(),
+			Some(false),
+			app.world()
+				.entity(entity)
+				.get::<_Loadout>()
+				.map(|l| l.slots_dereferenced),
+		);
+	}
+
+	#[test_case(InputState::just_pressed(); "on just pressed")]
+	#[test_case(InputState::pressed(); "on pressed")]
+	fn change_slots_if_target_would_not_change(state: InputState) {
+		let mut app = setup(_Input::from(std::iter::once((HandSlot::Left, state))));
+		let entity = app
+			.world_mut()
+			.spawn((Player, _Loadout::from([SlotKey::from(HandSlot::Left)])))
+			.id();
+
+		app.update();
+		let mut input = app.world_mut().resource_mut::<_Input>();
+		input.0.insert(ActionKey::from(HandSlot::Right), state);
+		app.update();
+
+		assert_eq!(
+			Some(&HashSet::from([
+				SlotKey::from(HandSlot::Left),
+				SlotKey::from(HandSlot::Right)
+			])),
+			app.world()
+				.entity(entity)
+				.get::<_Loadout>()
+				.map(|l| &l.slots),
+		);
+	}
+
+	#[test_case(InputState::just_pressed(); "on just pressed")]
+	#[test_case(InputState::pressed(); "on pressed")]
+	fn change_target_even_if_skills_do_not_change(state: InputState) {
+		let mut app = setup(_Input::from(std::iter::once((HandSlot::Left, state))));
+		let entity = app
+			.world_mut()
+			.spawn((Player, _Loadout::from([SlotKey::from(HandSlot::Left)])))
+			.id();
+
+		app.update();
+		let mut input = app.world_mut().resource_mut::<_Input>();
+		input.0.insert(ActionKey::from(TerrainTargeting), state);
+		app.update();
+
+		assert_eq!(
+			Some(SkillTarget::Cursor(Cursor::TerrainHover)),
+			app.world()
+				.entity(entity)
+				.get::<_Loadout>()
+				.and_then(|l| l.target),
+		);
+	}
+
+	#[test_case(InputState::just_pressed(); "on just pressed")]
+	#[test_case(InputState::pressed(); "on pressed")]
+	fn do_not_deref_target_if_would_not_change(state: InputState) {
+		let mut app = setup(_Input::from(std::iter::once((HandSlot::Left, state))));
+		let entity = app
+			.world_mut()
+			.spawn((Player, _Loadout::from([SlotKey::from(HandSlot::Left)])))
+			.id();
+
+		app.update();
+		app.update();
+
+		assert_eq!(
+			Some(false),
+			app.world()
+				.entity(entity)
+				.get::<_Loadout>()
+				.map(|l| l.target_dereferenced),
 		);
 	}
 }

--- a/src/plugins/agents/src/systems/player/use_skills.rs
+++ b/src/plugins/agents/src/systems/player/use_skills.rs
@@ -9,7 +9,7 @@ use common::{
 		accessors::get::GetContextMut,
 		handles_input::{GetAllInputStates, InputState},
 		handles_loadout::{CurrentTargetMut, HeldSkills, HeldSkillsMut, skills::Skills},
-		handles_skill_physics::SkillTarget,
+		handles_skill_physics::{Cursor, SkillTarget},
 	},
 };
 
@@ -42,7 +42,7 @@ impl Player {
 				continue;
 			}
 
-			*ctx.current_target_mut() = Some(SkillTarget::Cursor);
+			*ctx.current_target_mut() = Some(SkillTarget::Cursor(Cursor::TerrainHover));
 			*ctx.held_skills_mut() = new_held_skills;
 		}
 	}
@@ -169,7 +169,7 @@ mod tests {
 		assert_eq!(
 			Some(
 				&_Loadout::from([SlotKey::from(HandSlot::Left)])
-					.with_target(Some(SkillTarget::Cursor))
+					.with_target(Some(SkillTarget::Cursor(Cursor::TerrainHover)))
 			),
 			app.world().entity(entity).get::<_Loadout>(),
 		);
@@ -189,7 +189,7 @@ mod tests {
 		assert_eq!(
 			Some(
 				&_Loadout::from([SlotKey::from(HandSlot::Left)])
-					.with_target(Some(SkillTarget::Cursor))
+					.with_target(Some(SkillTarget::Cursor(Cursor::TerrainHover)))
 			),
 			app.world().entity(entity).get::<_Loadout>(),
 		);

--- a/src/plugins/common/src/tools/action_key.rs
+++ b/src/plugins/common/src/tools/action_key.rs
@@ -2,12 +2,13 @@ pub mod camera_key;
 pub mod movement;
 pub mod save_key;
 pub mod slot;
+pub mod targeting;
 pub mod user_input;
 
 use crate::{
 	states::menu_state::MenuState,
 	tools::{
-		action_key::save_key::SaveKey,
+		action_key::{save_key::SaveKey, targeting::TerrainTargeting},
 		iter_helpers::{first, next},
 	},
 	traits::{
@@ -27,6 +28,7 @@ use user_input::UserInput;
 pub enum ActionKey {
 	Movement(MovementKey),
 	Slot(HandSlot),
+	Targeting(TerrainTargeting),
 	Menu(MenuState),
 	Camera(CameraKey),
 	Save(SaveKey),
@@ -43,6 +45,7 @@ impl From<ActionKey> for UserInput {
 		match key {
 			ActionKey::Movement(key) => Self::from(key),
 			ActionKey::Slot(key) => Self::from(key),
+			ActionKey::Targeting(key) => Self::from(key),
 			ActionKey::Menu(key) => Self::from(key),
 			ActionKey::Camera(key) => Self::from(key),
 			ActionKey::Save(key) => Self::from(key),
@@ -55,6 +58,7 @@ impl From<ActionKey> for Token {
 		match value {
 			ActionKey::Movement(key) => Self::from(key),
 			ActionKey::Slot(key) => Self::from(key),
+			ActionKey::Targeting(key) => Self::from(key),
 			ActionKey::Menu(key) => Self::from(key),
 			ActionKey::Camera(key) => Self::from(key),
 			ActionKey::Save(key) => Self::from(key),
@@ -70,7 +74,8 @@ impl IterFinite for ActionKey {
 	fn next(current: &Iter<Self>) -> Option<Self> {
 		match current.0? {
 			ActionKey::Movement(key) => next(ActionKey::Movement, key).or(first(ActionKey::Slot)),
-			ActionKey::Slot(key) => next(ActionKey::Slot, key).or(first(ActionKey::Menu)),
+			ActionKey::Slot(key) => next(ActionKey::Slot, key).or(first(ActionKey::Targeting)),
+			ActionKey::Targeting(key) => next(ActionKey::Targeting, key).or(first(ActionKey::Menu)),
 			ActionKey::Menu(key) => next(ActionKey::Menu, key).or(first(ActionKey::Camera)),
 			ActionKey::Camera(key) => next(ActionKey::Camera, key).or(first(ActionKey::Save)),
 			ActionKey::Save(key) => next(ActionKey::Save, key),
@@ -83,6 +88,7 @@ impl InvalidUserInput for ActionKey {
 		match self {
 			ActionKey::Movement(key) => key.invalid_input(),
 			ActionKey::Slot(key) => key.invalid_input(),
+			ActionKey::Targeting(key) => key.invalid_input(),
 			ActionKey::Menu(key) => key.invalid_input(),
 			ActionKey::Camera(key) => key.invalid_input(),
 			ActionKey::Save(key) => key.invalid_input(),
@@ -104,6 +110,7 @@ mod tests {
 			std::iter::empty()
 				.chain(MovementKey::iterator().map(ActionKey::from))
 				.chain(HandSlot::iterator().map(ActionKey::from))
+				.chain(TerrainTargeting::iterator().map(ActionKey::from))
 				.chain(MenuState::iterator().map(ActionKey::from))
 				.chain(CameraKey::iterator().map(ActionKey::from))
 				.chain(SaveKey::iterator().map(ActionKey::from))
@@ -118,6 +125,7 @@ mod tests {
 			std::iter::empty()
 				.chain(MovementKey::iterator().map(UserInput::from))
 				.chain(HandSlot::iterator().map(UserInput::from))
+				.chain(TerrainTargeting::iterator().map(UserInput::from))
 				.chain(MenuState::iterator().map(UserInput::from))
 				.chain(CameraKey::iterator().map(UserInput::from))
 				.chain(SaveKey::iterator().map(UserInput::from))
@@ -141,6 +149,7 @@ mod tests {
 			std::iter::empty()
 				.chain(MovementKey::iterator().map(pair_with_invalid_input))
 				.chain(HandSlot::iterator().map(pair_with_invalid_input))
+				.chain(TerrainTargeting::iterator().map(pair_with_invalid_input))
 				.chain(MenuState::iterator().map(pair_with_invalid_input))
 				.chain(CameraKey::iterator().map(pair_with_invalid_input))
 				.chain(SaveKey::iterator().map(pair_with_invalid_input))

--- a/src/plugins/common/src/tools/action_key/targeting.rs
+++ b/src/plugins/common/src/tools/action_key/targeting.rs
@@ -1,0 +1,49 @@
+use crate::{
+	tools::action_key::{ActionKey, user_input::UserInput},
+	traits::{
+		handles_input::InvalidUserInput,
+		handles_localization::Token,
+		iteration::{Iter, IterFinite},
+	},
+};
+use bevy::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(TypePath, Clone, Copy, Eq, Hash, PartialEq, Debug, Serialize, Deserialize)]
+pub struct TerrainTargeting;
+
+impl InvalidUserInput for TerrainTargeting {
+	fn invalid_input(&self) -> &[UserInput] {
+		&[]
+	}
+}
+
+impl From<TerrainTargeting> for ActionKey {
+	fn from(target: TerrainTargeting) -> Self {
+		Self::Targeting(target)
+	}
+}
+
+impl From<TerrainTargeting> for UserInput {
+	fn from(_: TerrainTargeting) -> Self {
+		Self::KeyCode(KeyCode::ShiftLeft)
+	}
+}
+
+impl From<TerrainTargeting> for Token {
+	fn from(_: TerrainTargeting) -> Self {
+		Self::from("terrain-targeting")
+	}
+}
+
+impl IterFinite for TerrainTargeting {
+	fn iterator() -> Iter<Self> {
+		Iter(Some(TerrainTargeting))
+	}
+
+	fn next(current: &Iter<Self>) -> Option<Self> {
+		match current.0? {
+			TerrainTargeting => None,
+		}
+	}
+}

--- a/src/plugins/common/src/tools/vec_not_nan.rs
+++ b/src/plugins/common/src/tools/vec_not_nan.rs
@@ -47,6 +47,12 @@ impl<const N: usize> VecNotNan<N> {
 	}
 }
 
+impl<const N: usize> Default for VecNotNan<N> {
+	fn default() -> Self {
+		Self([0.0; N])
+	}
+}
+
 impl<const N: usize> Eq for VecNotNan<N> {}
 
 impl<const N: usize> Hash for VecNotNan<N> {

--- a/src/plugins/common/src/traits/handles_orientation.rs
+++ b/src/plugins/common/src/traits/handles_orientation.rs
@@ -1,6 +1,6 @@
 use crate::{
 	components::persistent_entity::PersistentEntity,
-	traits::accessors::get::GetContextMut,
+	traits::{accessors::get::GetContextMut, handles_skill_physics::Cursor},
 };
 use bevy::{ecs::system::SystemParam, prelude::*};
 use macros::EntityKey;
@@ -37,11 +37,16 @@ where
 	}
 }
 
-#[derive(Default, Debug, PartialEq, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone, Copy, Serialize, Deserialize)]
 pub enum Face {
-	#[default]
-	Cursor,
+	Cursor(Cursor),
 	Entity(PersistentEntity),
 	Translation(Vec3),
 	Direction(Dir3),
+}
+
+impl Default for Face {
+	fn default() -> Self {
+		Self::Cursor(Cursor::default())
+	}
 }

--- a/src/plugins/common/src/traits/handles_physics.rs
+++ b/src/plugins/common/src/traits/handles_physics.rs
@@ -4,7 +4,7 @@ use crate::{
 	attributes::{effect_target::EffectTarget, health::Health},
 	effects::{force::Force, gravity::Gravity, health_damage::HealthDamage},
 	toi,
-	tools::{Units, speed::Speed},
+	tools::{Units, speed::Speed, vec_not_nan::VecNotNan},
 	traits::{
 		accessors::get::{GetContextMut, View, ViewField},
 		handles_physics::physical_bodies::{Blocker, Body},
@@ -287,7 +287,7 @@ pub struct RaycastHit {
 	pub time_of_impact: f32,
 }
 
-#[derive(Debug, PartialEq, Default)]
+#[derive(Debug, PartialEq, Eq, Hash, Default, Clone)]
 pub struct MouseHover {
 	pub mode: HoverMode,
 	pub exclude: Vec<Entity>,
@@ -316,18 +316,26 @@ impl RaycastResult for MouseHover {
 	type TResult = Option<MouseHoversOver>;
 }
 
-#[derive(Debug, PartialEq, Default)]
+#[derive(Debug, PartialEq, Eq, Hash, Default, Clone, Copy)]
 pub enum HoverMode {
 	#[default]
 	ColliderOrTerrain,
-	ColliderOrDirectionFrom(Vec3),
+	ColliderOrDirectionFrom(VecNotNan<3>),
+}
+
+impl HoverMode {
+	pub fn collider_or_direction_from(Vec3 { x, y, z }: Vec3) -> Option<Self> {
+		let vec = VecNotNan::try_from_coords([x, y, z]).ok()?;
+
+		Some(Self::ColliderOrDirectionFrom(vec))
+	}
 }
 
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum MouseHoversOver {
-	/// Hovering over terrain on the given point
-	Terrain { point: Vec3 },
-	/// Hovering an entity on the given point (which may not be the entities translation)
+	/// Hovering over a point
+	Point(Vec3),
+	/// Hovering an entity on the point (which may not be the entities translation)
 	Object { entity: Entity, point: Vec3 },
 }
 

--- a/src/plugins/common/src/traits/handles_physics.rs
+++ b/src/plugins/common/src/traits/handles_physics.rs
@@ -287,23 +287,40 @@ pub struct RaycastHit {
 	pub time_of_impact: f32,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Default)]
 pub struct MouseHover {
+	pub mode: HoverMode,
 	pub exclude: Vec<Entity>,
 }
 
 impl MouseHover {
-	pub const NO_EXCLUDES: Self = Self { exclude: vec![] };
+	pub const TERRAIN_WITHOUT_EXCLUDES: Self = Self {
+		exclude: vec![],
+		mode: HoverMode::ColliderOrTerrain,
+	};
 
 	pub fn excluding(exclude: impl IntoIterator<Item = Entity>) -> Self {
 		Self {
 			exclude: Vec::from_iter(exclude),
+			..default()
 		}
+	}
+
+	pub fn with_mode(mut self, mode: HoverMode) -> Self {
+		self.mode = mode;
+		self
 	}
 }
 
 impl RaycastResult for MouseHover {
 	type TResult = Option<MouseHoversOver>;
+}
+
+#[derive(Debug, PartialEq, Default)]
+pub enum HoverMode {
+	#[default]
+	ColliderOrTerrain,
+	ColliderOrDirectionFrom(Vec3),
 }
 
 #[derive(Debug, PartialEq, Clone, Copy)]

--- a/src/plugins/common/src/traits/handles_skill_physics.rs
+++ b/src/plugins/common/src/traits/handles_skill_physics.rs
@@ -146,17 +146,29 @@ impl Deref for SkillCaster {
 	}
 }
 
-#[derive(Debug, PartialEq, Default, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone, Copy, Serialize, Deserialize)]
 pub enum SkillTarget {
-	#[default]
-	Cursor,
+	Cursor(Cursor),
 	Entity(PersistentEntity),
+}
+
+impl Default for SkillTarget {
+	fn default() -> Self {
+		Self::Cursor(Cursor::default())
+	}
 }
 
 impl From<PersistentEntity> for SkillTarget {
 	fn from(entity: PersistentEntity) -> Self {
 		Self::Entity(entity)
 	}
+}
+
+#[derive(Debug, PartialEq, Default, Clone, Copy, Serialize, Deserialize)]
+pub enum Cursor {
+	#[default]
+	Direction,
+	TerrainHover,
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, Default, Serialize, Deserialize)]

--- a/src/plugins/menu/src/components/settings_screen.rs
+++ b/src/plugins/menu/src/components/settings_screen.rs
@@ -18,6 +18,7 @@ use common::{
 		movement::MovementKey,
 		save_key::SaveKey,
 		slot::HandSlot,
+		targeting::TerrainTargeting,
 		user_input::UserInput,
 	},
 	traits::{
@@ -157,6 +158,7 @@ impl InsertUiContent for SettingsScreen {
 			.with_children(|parent| {
 				Self::add_title(parent, localize, "key-bindings");
 				self.add_section::<HandSlot>(parent, localize, "key-bindings-slots");
+				self.add_section::<TerrainTargeting>(parent, localize, "key-bindings-targeting");
 				self.add_section::<MovementKey>(parent, localize, "key-bindings-movement");
 				self.add_section::<MenuState>(parent, localize, "key-bindings-menus");
 				self.add_section::<CameraKey>(parent, localize, "key-bindings-camera");

--- a/src/plugins/movement/src/system_param/face_param/override_face.rs
+++ b/src/plugins/movement/src/system_param/face_param/override_face.rs
@@ -19,7 +19,11 @@ mod tests {
 		app::{App, Update},
 		ecs::system::{RunSystemError, RunSystemOnce},
 	};
-	use common::traits::{accessors::get::GetContextMut, handles_orientation::Facing};
+	use common::traits::{
+		accessors::get::GetContextMut,
+		handles_orientation::Facing,
+		handles_skill_physics::Cursor,
+	};
 	use testing::SingleThreadedApp;
 
 	fn setup() -> App {
@@ -34,11 +38,11 @@ mod tests {
 		app.world_mut()
 			.run_system_once(move |mut p: FaceParamMut| {
 				let mut ctx = FaceParamMut::get_context_mut(&mut p, Facing { entity }).unwrap();
-				ctx.override_face(Face::Cursor);
+				ctx.override_face(Face::Cursor(Cursor::TerrainHover));
 			})?;
 
 		assert_eq!(
-			Some(&SetFaceOverride(Face::Cursor)),
+			Some(&SetFaceOverride(Face::Cursor(Cursor::TerrainHover))),
 			app.world().entity(entity).get::<SetFaceOverride>(),
 		);
 		Ok(())
@@ -47,7 +51,7 @@ mod tests {
 	#[test]
 	fn remove_face_components() -> Result<(), RunSystemError> {
 		let mut app = setup();
-		let entity = app.world_mut().spawn(SetFaceOverride(Face::Cursor)).id();
+		let entity = app.world_mut().spawn(SetFaceOverride(Face::default())).id();
 
 		app.world_mut()
 			.run_system_once(move |mut p: FaceParamMut| {

--- a/src/plugins/movement/src/systems/face/execute_face.rs
+++ b/src/plugins/movement/src/systems/face/execute_face.rs
@@ -60,13 +60,13 @@ where
 	let hover = hover.raycast(MouseHover {
 		exclude: vec![entity],
 		mode: match cursor {
-			Cursor::Direction => HoverMode::ColliderOrDirectionFrom(transform.translation),
+			Cursor::Direction => HoverMode::collider_or_direction_from(transform.translation)?,
 			Cursor::TerrainHover => HoverMode::ColliderOrTerrain,
 		},
 	})?;
 
 	match hover {
-		MouseHoversOver::Terrain { point } => Some(point),
+		MouseHoversOver::Point(point) => Some(point),
 		MouseHoversOver::Object { entity, .. } => transforms
 			.get(entity)
 			.map(|transform| transform.translation)
@@ -88,7 +88,9 @@ mod tests {
 	};
 	use common::{
 		components::persistent_entity::PersistentEntity,
+		tools::vec_not_nan::VecNotNan,
 		traits::register_persistent_entities::RegisterPersistentEntities,
+		vec3_not_nan,
 	};
 	use macros::NestedMocks;
 	use mockall::{automock, predicate::eq};
@@ -128,7 +130,7 @@ mod tests {
 
 	#[test_case(Cursor::Direction, HoverMode::ColliderOrDirectionFrom; "direction")]
 	#[test_case(Cursor::TerrainHover, |_| HoverMode::ColliderOrTerrain; "terrain hover")]
-	fn do_face_cursor_hover_point(cursor: Cursor, mode: fn(Vec3) -> HoverMode) {
+	fn do_face_cursor_hover_point(cursor: Cursor, mode: fn(VecNotNan<3>) -> HoverMode) {
 		let mut app = setup();
 		let agent = app
 			.world_mut()
@@ -138,11 +140,9 @@ mod tests {
 			mock.expect_raycast()
 				.with(eq(MouseHover {
 					exclude: vec![agent],
-					mode: mode(Vec3::new(4., 2., 6.)),
+					mode: mode(vec3_not_nan!(4., 2., 6.)),
 				}))
-				.return_const(MouseHoversOver::Terrain {
-					point: Vec3::new(1., 2., 3.),
-				});
+				.return_const(MouseHoversOver::Point(Vec3::new(1., 2., 3.)));
 		}));
 
 		app.update();
@@ -155,7 +155,7 @@ mod tests {
 
 	#[test_case(Cursor::Direction, HoverMode::ColliderOrDirectionFrom; "direction")]
 	#[test_case(Cursor::TerrainHover, |_| HoverMode::ColliderOrTerrain; "terrain hover")]
-	fn face_cursor_hover_entity(cursor: Cursor, mode: fn(Vec3) -> HoverMode) {
+	fn face_cursor_hover_entity(cursor: Cursor, mode: fn(VecNotNan<3>) -> HoverMode) {
 		let mut app = setup();
 		let entity = app.world_mut().spawn(Transform::from_xyz(6., 5., 20.)).id();
 		let agent = app
@@ -166,7 +166,7 @@ mod tests {
 			mock.expect_raycast()
 				.with(eq(MouseHover {
 					exclude: vec![agent],
-					mode: mode(Vec3::new(4., 5., 6.)),
+					mode: mode(vec3_not_nan!(4., 5., 6.)),
 				}))
 				.return_const(MouseHoversOver::Object {
 					entity,
@@ -184,7 +184,7 @@ mod tests {
 
 	#[test_case(Cursor::Direction, HoverMode::ColliderOrDirectionFrom; "direction")]
 	#[test_case(Cursor::TerrainHover, |_| HoverMode::ColliderOrTerrain; "terrain hover")]
-	fn face_cursor_hover_ground(cursor: Cursor, mode: fn(Vec3) -> HoverMode) {
+	fn face_cursor_hover_ground(cursor: Cursor, mode: fn(VecNotNan<3>) -> HoverMode) {
 		let mut app = setup();
 		let agent = app
 			.world_mut()
@@ -194,11 +194,9 @@ mod tests {
 			mock.expect_raycast()
 				.with(eq(MouseHover {
 					exclude: vec![agent],
-					mode: mode(Vec3::new(4., 5., 6.)),
+					mode: mode(vec3_not_nan!(4., 5., 6.)),
 				}))
-				.return_const(MouseHoversOver::Terrain {
-					point: Vec3::new(6., 3., 7.),
-				});
+				.return_const(MouseHoversOver::Point(Vec3::new(6., 3., 7.)));
 		}));
 
 		app.update();

--- a/src/plugins/movement/src/systems/face/execute_face.rs
+++ b/src/plugins/movement/src/systems/face/execute_face.rs
@@ -7,7 +7,8 @@ use common::{
 	traits::{
 		accessors::get::Get,
 		handles_orientation::Face,
-		handles_physics::{MouseHover, MouseHoversOver, Raycast},
+		handles_physics::{HoverMode, MouseHover, MouseHoversOver, Raycast},
+		handles_skill_physics::Cursor,
 	},
 	zyheeda_commands::ZyheedaCommands,
 };
@@ -24,7 +25,7 @@ pub(crate) fn execute_face<TMouseHover>(
 	for (entity, face) in faces {
 		let target = match face {
 			Face::Translation(translation) => Some(translation),
-			Face::Cursor => get_target(entity, hover.deref_mut(), &transforms),
+			Face::Cursor(cursor) => get_target(entity, cursor, hover.deref_mut(), &transforms),
 			Face::Entity(entity) => get_translation(commands.get(&entity), &transforms),
 			Face::Direction(dir) => get_translation(Some(entity), &transforms).map(|tr| tr + *dir),
 		};
@@ -48,21 +49,28 @@ fn apply_facing(transforms: &mut Query<&mut Transform>, id: Entity, target: Vec3
 
 fn get_target<TMouseHover>(
 	entity: Entity,
+	cursor: Cursor,
 	hover: &mut TMouseHover,
 	transforms: &Query<&mut Transform>,
 ) -> Option<Vec3>
 where
 	TMouseHover: Raycast<MouseHover>,
 {
+	let transform = transforms.get(entity).ok()?;
 	let hover = hover.raycast(MouseHover {
 		exclude: vec![entity],
+		mode: match cursor {
+			Cursor::Direction => HoverMode::ColliderOrDirectionFrom(transform.translation),
+			Cursor::TerrainHover => HoverMode::ColliderOrTerrain,
+		},
 	})?;
 
 	match hover {
 		MouseHoversOver::Terrain { point } => Some(point),
-		MouseHoversOver::Object { entity, .. } => {
-			transforms.get(entity).ok().map(|tr| tr.translation)
-		}
+		MouseHoversOver::Object { entity, .. } => transforms
+			.get(entity)
+			.map(|transform| transform.translation)
+			.ok(),
 	}
 }
 
@@ -84,6 +92,7 @@ mod tests {
 	};
 	use macros::NestedMocks;
 	use mockall::{automock, predicate::eq};
+	use test_case::test_case;
 	use testing::{NestedMocks, SingleThreadedApp};
 
 	#[derive(Resource, NestedMocks)]
@@ -117,17 +126,19 @@ mod tests {
 		app
 	}
 
-	#[test]
-	fn do_face_cursor_ground() {
+	#[test_case(Cursor::Direction, HoverMode::ColliderOrDirectionFrom; "direction")]
+	#[test_case(Cursor::TerrainHover, |_| HoverMode::ColliderOrTerrain; "terrain hover")]
+	fn do_face_cursor_hover_point(cursor: Cursor, mode: fn(Vec3) -> HoverMode) {
 		let mut app = setup();
 		let agent = app
 			.world_mut()
-			.spawn((Transform::from_xyz(4., 2., 6.), _Face(Face::Cursor)))
+			.spawn((Transform::from_xyz(4., 2., 6.), _Face(Face::Cursor(cursor))))
 			.id();
 		app.insert_resource(_RayCast::new().with_mock(|mock| {
 			mock.expect_raycast()
 				.with(eq(MouseHover {
 					exclude: vec![agent],
+					mode: mode(Vec3::new(4., 2., 6.)),
 				}))
 				.return_const(MouseHoversOver::Terrain {
 					point: Vec3::new(1., 2., 3.),
@@ -142,18 +153,20 @@ mod tests {
 		);
 	}
 
-	#[test]
-	fn face_cursor_hover_entity() {
+	#[test_case(Cursor::Direction, HoverMode::ColliderOrDirectionFrom; "direction")]
+	#[test_case(Cursor::TerrainHover, |_| HoverMode::ColliderOrTerrain; "terrain hover")]
+	fn face_cursor_hover_entity(cursor: Cursor, mode: fn(Vec3) -> HoverMode) {
 		let mut app = setup();
 		let entity = app.world_mut().spawn(Transform::from_xyz(6., 5., 20.)).id();
 		let agent = app
 			.world_mut()
-			.spawn((Transform::from_xyz(4., 5., 6.), _Face(Face::Cursor)))
+			.spawn((Transform::from_xyz(4., 5., 6.), _Face(Face::Cursor(cursor))))
 			.id();
 		app.insert_resource(_RayCast::new().with_mock(|mock| {
 			mock.expect_raycast()
 				.with(eq(MouseHover {
 					exclude: vec![agent],
+					mode: mode(Vec3::new(4., 5., 6.)),
 				}))
 				.return_const(MouseHoversOver::Object {
 					entity,
@@ -169,17 +182,19 @@ mod tests {
 		);
 	}
 
-	#[test]
-	fn face_cursor_hover_ground() {
+	#[test_case(Cursor::Direction, HoverMode::ColliderOrDirectionFrom; "direction")]
+	#[test_case(Cursor::TerrainHover, |_| HoverMode::ColliderOrTerrain; "terrain hover")]
+	fn face_cursor_hover_ground(cursor: Cursor, mode: fn(Vec3) -> HoverMode) {
 		let mut app = setup();
 		let agent = app
 			.world_mut()
-			.spawn((Transform::from_xyz(4., 5., 6.), _Face(Face::Cursor)))
+			.spawn((Transform::from_xyz(4., 5., 6.), _Face(Face::Cursor(cursor))))
 			.id();
 		app.insert_resource(_RayCast::new().with_mock(|mock| {
 			mock.expect_raycast()
 				.with(eq(MouseHover {
 					exclude: vec![agent],
+					mode: mode(Vec3::new(4., 5., 6.)),
 				}))
 				.return_const(MouseHoversOver::Terrain {
 					point: Vec3::new(6., 3., 7.),

--- a/src/plugins/movement/src/systems/face/get_faces.rs
+++ b/src/plugins/movement/src/systems/face/get_faces.rs
@@ -24,6 +24,7 @@ fn face_value(
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use common::traits::handles_skill_physics::Cursor;
 	use testing::SingleThreadedApp;
 
 	#[derive(Component, Debug, PartialEq)]
@@ -75,7 +76,10 @@ mod tests {
 		let face = Face::Translation(Vec3::new(1., 2., 3.));
 		let agent = app
 			.world_mut()
-			.spawn((SetFace(Face::Cursor), SetFaceOverride(face)))
+			.spawn((
+				SetFace(Face::Cursor(Cursor::default())),
+				SetFaceOverride(face),
+			))
 			.id();
 
 		app.update();
@@ -90,7 +94,7 @@ mod tests {
 		let mut app = setup();
 		let agent = app
 			.world_mut()
-			.spawn(SetFace(Face::Cursor))
+			.spawn(SetFace(Face::Cursor(Cursor::default())))
 			.remove::<CanFace>()
 			.id();
 

--- a/src/plugins/movement/src/systems/set_movement_facing.rs
+++ b/src/plugins/movement/src/systems/set_movement_facing.rs
@@ -158,7 +158,7 @@ mod tests {
 		let mut app = setup();
 		let entity = app
 			.world_mut()
-			.spawn((_Motion::stop(), SetFace(Face::Cursor)))
+			.spawn((_Motion::stop(), SetFace(Face::default())))
 			.id();
 
 		app.update();
@@ -171,7 +171,7 @@ mod tests {
 		let mut app = setup();
 		let entity = app
 			.world_mut()
-			.spawn((_Motion::direction(Dir3::NEG_X), SetFace(Face::Cursor)))
+			.spawn((_Motion::direction(Dir3::NEG_X), SetFace(Face::default())))
 			.id();
 
 		app.update();
@@ -186,7 +186,7 @@ mod tests {
 		let mut app = setup();
 		let entity = app
 			.world_mut()
-			.spawn((_Motion::direction(Dir3::NEG_X), SetFace(Face::Cursor)))
+			.spawn((_Motion::direction(Dir3::NEG_X), SetFace(Face::default())))
 			.id();
 
 		app.update();

--- a/src/plugins/physics/src/components/world_camera.rs
+++ b/src/plugins/physics/src/components/world_camera.rs
@@ -1,12 +1,10 @@
 use bevy::prelude::*;
-use common::traits::handles_physics::MouseHoversOver;
+use common::traits::handles_physics::{MouseHover, MouseHoversOver};
 use std::collections::HashMap;
 
 #[derive(Component, Debug, PartialEq, Default)]
 pub struct WorldCamera {
-	pub(crate) mouse_hover: HashMap<Excluded, MouseHoversOver>,
+	pub(crate) mouse_hover: HashMap<MouseHover, MouseHoversOver>,
 	// Tracking camera ray in this component to prevent system param overlap when using `RayCaster`
 	pub(crate) ray: Option<Ray3d>,
 }
-
-pub(crate) type Excluded = Vec<Entity>;

--- a/src/plugins/physics/src/observers/process_dirty_anchor.rs
+++ b/src/plugins/physics/src/observers/process_dirty_anchor.rs
@@ -10,10 +10,11 @@ use bevy::{
 use common::{
 	components::persistent_entity::PersistentEntity,
 	errors::{ErrorData, Level},
+	tools::vec_not_nan::VecNotNan,
 	traits::{
 		accessors::get::{Get, TryApplyOn},
 		handles_physics::{HoverMode, MouseHover, MouseHoversOver, Raycast},
-		handles_skill_physics::{SkillSpawner, SkillTarget},
+		handles_skill_physics::{Cursor, SkillSpawner, SkillTarget},
 	},
 	zyheeda_commands::ZyheedaCommands,
 };
@@ -79,12 +80,12 @@ impl AnchorDirty {
 			return Err(AnchorError::EntityWithoutTransform(mount));
 		};
 
-		let mount_translation = mount_transform.translation();
-		if mount_translation.is_nan() {
-			return Err(AnchorError::TranslationNaN(mount));
-		}
+		let mount_translation = match VecNotNan::try_from(mount_transform.translation()) {
+			Ok(v) => v,
+			Err(_) => return Err(AnchorError::TranslationNaN(mount)),
+		};
 
-		anchor_transform.translation = mount_translation;
+		anchor_transform.translation = Vec3::from(mount_translation);
 		match anchor.rotation {
 			AnchorRotation::OfAttachedTo => {
 				anchor_transform.rotation = attached_to_transform.rotation();
@@ -92,10 +93,13 @@ impl AnchorDirty {
 			AnchorRotation::OfMount => {
 				anchor_transform.rotation = mount_transform.rotation();
 			}
-			AnchorRotation::LookingAt(SkillTarget::Cursor(_)) => {
+			AnchorRotation::LookingAt(SkillTarget::Cursor(cursor)) => {
 				let hover = MouseHover {
 					exclude: vec![attached_to],
-					mode: HoverMode::ColliderOrTerrain,
+					mode: match cursor {
+						Cursor::Direction => HoverMode::ColliderOrDirectionFrom(mount_translation),
+						Cursor::TerrainHover => HoverMode::ColliderOrTerrain,
+					},
 				};
 				let Some(hit) = ray_caster.raycast(hover) else {
 					return Ok(());
@@ -177,16 +181,18 @@ mod tests {
 	use super::*;
 	use common::{
 		components::persistent_entity::PersistentEntity,
-		tools::action_key::slot::SlotKey,
+		tools::{action_key::slot::SlotKey, vec_not_nan::VecNotNan},
 		traits::{
 			handles_physics::{HoverMode, MouseHoversOver},
 			handles_skill_physics::{Cursor, SkillSpawner},
 			register_persistent_entities::RegisterPersistentEntities,
 		},
+		vec3_not_nan,
 	};
 	use macros::NestedMocks;
 	use mockall::{automock, predicate::eq};
 	use std::{collections::HashMap, sync::LazyLock};
+	use test_case::test_case;
 	use testing::{NestedMocks, SingleThreadedApp};
 
 	#[derive(Resource)]
@@ -373,8 +379,9 @@ mod tests {
 		);
 	}
 
-	#[test]
-	fn look_at_cursor_over_terrain() {
+	#[test_case(Cursor::TerrainHover, |_|HoverMode::ColliderOrTerrain; "terrain")]
+	#[test_case(Cursor::Direction ,HoverMode::ColliderOrDirectionFrom; "direction")]
+	fn look_at_cursor_over_terrain(cursor: Cursor, mode: fn(VecNotNan<3>) -> HoverMode) {
 		let mut app = setup();
 		let spawner_key = SkillSpawner::Slot(SlotKey(22));
 		let agent = app
@@ -393,7 +400,7 @@ mod tests {
 				.once()
 				.with(eq(MouseHover {
 					exclude: vec![agent],
-					mode: HoverMode::ColliderOrTerrain,
+					mode: mode(vec3_not_nan!(4., 11., 9.)),
 				}))
 				.return_const(MouseHoversOver::Point(Vec3::new(11., 22., 33.)));
 		}));
@@ -401,7 +408,7 @@ mod tests {
 		let anchor = app.world_mut().spawn(
 			Anchor::attach_to(*AGENT)
 				.on(spawner_key)
-				.looking_at(SkillTarget::Cursor(Cursor::TerrainHover)),
+				.looking_at(SkillTarget::Cursor(cursor)),
 		);
 
 		assert_eq!(
@@ -410,8 +417,9 @@ mod tests {
 		);
 	}
 
-	#[test]
-	fn look_at_cursor_over_object() {
+	#[test_case(Cursor::TerrainHover, |_|HoverMode::ColliderOrTerrain; "terrain")]
+	#[test_case(Cursor::Direction ,HoverMode::ColliderOrDirectionFrom; "direction")]
+	fn look_at_cursor_over_object(cursor: Cursor, mode: fn(VecNotNan<3>) -> HoverMode) {
 		let mut app = setup();
 		let spawner_key = SkillSpawner::Slot(SlotKey(22));
 		let agent = app
@@ -434,7 +442,7 @@ mod tests {
 				.once()
 				.with(eq(MouseHover {
 					exclude: vec![agent],
-					mode: HoverMode::ColliderOrTerrain,
+					mode: mode(vec3_not_nan!(4., 11., 9.)),
 				}))
 				.return_const(MouseHoversOver::Object {
 					entity: target,
@@ -445,7 +453,7 @@ mod tests {
 		let anchor = app.world_mut().spawn(
 			Anchor::attach_to(*AGENT)
 				.on(spawner_key)
-				.looking_at(SkillTarget::Cursor(Cursor::TerrainHover)),
+				.looking_at(SkillTarget::Cursor(cursor)),
 		);
 
 		assert_eq!(

--- a/src/plugins/physics/src/observers/process_dirty_anchor.rs
+++ b/src/plugins/physics/src/observers/process_dirty_anchor.rs
@@ -12,7 +12,7 @@ use common::{
 	errors::{ErrorData, Level},
 	traits::{
 		accessors::get::{Get, TryApplyOn},
-		handles_physics::{MouseHover, MouseHoversOver, Raycast},
+		handles_physics::{HoverMode, MouseHover, MouseHoversOver, Raycast},
 		handles_skill_physics::{SkillSpawner, SkillTarget},
 	},
 	zyheeda_commands::ZyheedaCommands,
@@ -95,6 +95,7 @@ impl AnchorDirty {
 			AnchorRotation::LookingAt(SkillTarget::Cursor(_)) => {
 				let hover = MouseHover {
 					exclude: vec![attached_to],
+					mode: HoverMode::ColliderOrTerrain,
 				};
 				let Some(hit) = ray_caster.raycast(hover) else {
 					return Ok(());
@@ -178,7 +179,7 @@ mod tests {
 		components::persistent_entity::PersistentEntity,
 		tools::action_key::slot::SlotKey,
 		traits::{
-			handles_physics::MouseHoversOver,
+			handles_physics::{HoverMode, MouseHoversOver},
 			handles_skill_physics::{Cursor, SkillSpawner},
 			register_persistent_entities::RegisterPersistentEntities,
 		},
@@ -392,6 +393,7 @@ mod tests {
 				.once()
 				.with(eq(MouseHover {
 					exclude: vec![agent],
+					mode: HoverMode::ColliderOrTerrain,
 				}))
 				.return_const(MouseHoversOver::Terrain {
 					point: Vec3::new(11., 22., 33.),
@@ -434,6 +436,7 @@ mod tests {
 				.once()
 				.with(eq(MouseHover {
 					exclude: vec![agent],
+					mode: HoverMode::ColliderOrTerrain,
 				}))
 				.return_const(MouseHoversOver::Object {
 					entity: target,

--- a/src/plugins/physics/src/observers/process_dirty_anchor.rs
+++ b/src/plugins/physics/src/observers/process_dirty_anchor.rs
@@ -101,7 +101,7 @@ impl AnchorDirty {
 					return Ok(());
 				};
 				let target = match hit {
-					MouseHoversOver::Terrain { point } => point,
+					MouseHoversOver::Point(point) => point,
 					MouseHoversOver::Object { entity, .. } => {
 						let Ok(target) = transforms.get(entity) else {
 							return Err(AnchorError::EntityWithoutTransform(entity));
@@ -395,9 +395,7 @@ mod tests {
 					exclude: vec![agent],
 					mode: HoverMode::ColliderOrTerrain,
 				}))
-				.return_const(MouseHoversOver::Terrain {
-					point: Vec3::new(11., 22., 33.),
-				});
+				.return_const(MouseHoversOver::Point(Vec3::new(11., 22., 33.)));
 		}));
 
 		let anchor = app.world_mut().spawn(

--- a/src/plugins/physics/src/observers/process_dirty_anchor.rs
+++ b/src/plugins/physics/src/observers/process_dirty_anchor.rs
@@ -92,7 +92,7 @@ impl AnchorDirty {
 			AnchorRotation::OfMount => {
 				anchor_transform.rotation = mount_transform.rotation();
 			}
-			AnchorRotation::LookingAt(SkillTarget::Cursor) => {
+			AnchorRotation::LookingAt(SkillTarget::Cursor(_)) => {
 				let hover = MouseHover {
 					exclude: vec![attached_to],
 				};
@@ -179,7 +179,7 @@ mod tests {
 		tools::action_key::slot::SlotKey,
 		traits::{
 			handles_physics::MouseHoversOver,
-			handles_skill_physics::SkillSpawner,
+			handles_skill_physics::{Cursor, SkillSpawner},
 			register_persistent_entities::RegisterPersistentEntities,
 		},
 	};
@@ -401,7 +401,7 @@ mod tests {
 		let anchor = app.world_mut().spawn(
 			Anchor::attach_to(*AGENT)
 				.on(spawner_key)
-				.looking_at(SkillTarget::Cursor),
+				.looking_at(SkillTarget::Cursor(Cursor::TerrainHover)),
 		);
 
 		assert_eq!(
@@ -444,7 +444,7 @@ mod tests {
 		let anchor = app.world_mut().spawn(
 			Anchor::attach_to(*AGENT)
 				.on(spawner_key)
-				.looking_at(SkillTarget::Cursor),
+				.looking_at(SkillTarget::Cursor(Cursor::TerrainHover)),
 		);
 
 		assert_eq!(

--- a/src/plugins/physics/src/system_params/ray_caster/mouse_hover.rs
+++ b/src/plugins/physics/src/system_params/ray_caster/mouse_hover.rs
@@ -1,14 +1,19 @@
 use crate::system_params::ray_caster::RayCaster;
 use bevy::{
 	ecs::system::SystemParam,
-	math::{Ray3d, Vec3},
+	math::{Dir3, Ray3d, Vec3, primitives::InfinitePlane3d},
 };
-use common::traits::handles_physics::{
-	MouseHover,
-	MouseHoversOver,
-	Raycast,
-	SolidObjects,
-	Terrain,
+use common::{
+	tools::vec_not_nan::VecNotNan,
+	traits::handles_physics::{
+		HoverMode,
+		MouseHover,
+		MouseHoversOver,
+		Raycast,
+		SolidObjects,
+		Terrain,
+		TimeOfImpact,
+	},
 };
 
 impl<T> Raycast<MouseHover> for RayCaster<'_, '_, T>
@@ -16,40 +21,41 @@ where
 	T: SystemParam + 'static,
 	Self: Raycast<SolidObjects> + Raycast<Terrain>,
 {
-	fn raycast(&mut self, MouseHover { exclude, .. }: MouseHover) -> Option<MouseHoversOver> {
-		let cam = self.world_cams.single_mut().ok()?;
+	fn raycast(&mut self, mouse_hover: MouseHover) -> Option<MouseHoversOver> {
+		let cam = self.world_cams.single().ok()?;
 		let ray = cam.ray?;
 
-		if let Some(cached) = cam.mouse_hover.get(&exclude) {
+		if let Some(cached) = cam.mouse_hover.get(&mouse_hover) {
 			return Some(*cached);
 		}
 
 		let object_hit = self.raycast(SolidObjects {
 			ray,
-			exclude: exclude.clone(),
+			exclude: mouse_hover.exclude.clone(),
 			only_hoverable: true,
 		});
+		let plane_hit = match mouse_hover.mode {
+			HoverMode::ColliderOrTerrain => None,
+			HoverMode::ColliderOrDirectionFrom(plane) => intersect_horizontal_plane(ray, plane),
+		};
 		let ground_hit = self.raycast(Terrain { ray });
-		let hover = match (object_hit, ground_hit) {
-			(None, None) => return None,
-			(None, Some(time_of_impact)) => MouseHoversOver::Terrain {
-				point: point(ray, *time_of_impact),
-			},
-			(Some(object), Some(ground_time_of_impact))
-				if object.time_of_impact > *ground_time_of_impact =>
-			{
-				MouseHoversOver::Terrain {
-					point: point(ray, *ground_time_of_impact),
-				}
+		let hover = match (object_hit, plane_hit, ground_hit) {
+			(None, None, None) => return None,
+			(None, Some(toi), _) | (None, _, Some(toi)) => MouseHoversOver::Point(point(ray, *toi)),
+			(Some(object), Some(toi), Some(ground_toi)) if object.time_of_impact > *ground_toi => {
+				MouseHoversOver::Point(point(ray, *toi))
 			}
-			(Some(object), _) => MouseHoversOver::Object {
+			(Some(object), None, Some(toi)) if object.time_of_impact > *toi => {
+				MouseHoversOver::Point(point(ray, *toi))
+			}
+			(Some(object), ..) => MouseHoversOver::Object {
 				entity: object.entity,
 				point: point(ray, object.time_of_impact),
 			},
 		};
 
 		let mut cam = self.world_cams.single_mut().ok()?;
-		cam.mouse_hover.insert(exclude, hover);
+		cam.mouse_hover.insert(mouse_hover.clone(), hover);
 
 		Some(hover)
 	}
@@ -57,6 +63,12 @@ where
 
 fn point(ray: Ray3d, toi: f32) -> Vec3 {
 	ray.origin + ray.direction * toi
+}
+
+fn intersect_horizontal_plane(ray: Ray3d, plane_origin: VecNotNan<3>) -> Option<TimeOfImpact> {
+	let toi = ray.intersect_plane(plane_origin.into(), InfinitePlane3d { normal: Dir3::Y })?;
+
+	TimeOfImpact::try_from_f32(toi).ok()
 }
 
 #[cfg(test)]
@@ -74,7 +86,9 @@ mod tests {
 	};
 	use common::{
 		toi,
+		tools::Units,
 		traits::handles_physics::{HoverMode, RaycastHit, TimeOfImpact},
+		vec3_not_nan,
 	};
 	use macros::NestedMocks;
 	use mockall::{automock, predicate::eq};
@@ -137,228 +151,365 @@ mod tests {
 		(app, cam)
 	}
 
-	#[test]
-	fn return_object_hit() -> Result<(), RunSystemError> {
-		let ray = Ray3d {
-			origin: Vec3::new(1., 2., 3.),
-			direction: Dir3::NEG_Y,
-		};
-		let exclude = fake_entity!(444);
-		let (mut app, _) = setup(
-			ray,
-			_Objects::new().with_mock(|mock| {
-				mock.expect_raycast()
-					.with(eq(SolidObjects {
-						ray,
+	mod terrain_mode {
+		use super::*;
+
+		#[test]
+		fn return_object_hit() -> Result<(), RunSystemError> {
+			let ray = Ray3d {
+				origin: Vec3::new(1., 2., 3.),
+				direction: Dir3::NEG_Y,
+			};
+			let exclude = fake_entity!(444);
+			let (mut app, _) = setup(
+				ray,
+				_Objects::new().with_mock(|mock| {
+					mock.expect_raycast()
+						.with(eq(SolidObjects {
+							ray,
+							exclude: vec![exclude],
+							only_hoverable: true,
+						}))
+						.return_const(RaycastHit {
+							entity: fake_entity!(123),
+							time_of_impact: 42.,
+						});
+				}),
+				_Ground::new().with_mock(|mock| {
+					mock.expect_raycast()
+						.with(eq(Terrain { ray }))
+						.return_const(toi!(44.));
+				}),
+			);
+
+			app.world_mut()
+				.run_system_once(move |mut ray_caster: _RayCaster| {
+					let hit = ray_caster.raycast(MouseHover {
 						exclude: vec![exclude],
-						only_hoverable: true,
-					}))
-					.return_const(RaycastHit {
-						entity: fake_entity!(123),
-						time_of_impact: 42.,
+						mode: HoverMode::ColliderOrTerrain,
 					});
-			}),
-			_Ground::new().with_mock(|mock| {
-				mock.expect_raycast()
-					.with(eq(Terrain { ray }))
-					.return_const(toi!(44.));
-			}),
-		);
 
-		app.world_mut()
-			.run_system_once(move |mut ray_caster: _RayCaster| {
-				let hit = ray_caster.raycast(MouseHover {
-					exclude: vec![exclude],
-					mode: HoverMode::ColliderOrTerrain,
-				});
+					assert_eq!(
+						Some(MouseHoversOver::Object {
+							entity: fake_entity!(123),
+							point: Vec3::new(1., -40., 3.),
+						}),
+						hit,
+					);
+				})
+		}
 
-				assert_eq!(
-					Some(MouseHoversOver::Object {
-						entity: fake_entity!(123),
-						point: Vec3::new(1., -40., 3.),
-					}),
-					hit,
-				);
-			})
-	}
+		#[test]
+		fn return_ground_hit_when_no_object_hit() -> Result<(), RunSystemError> {
+			let ray = Ray3d {
+				origin: Vec3::new(1., 2., 3.),
+				direction: Dir3::NEG_Y,
+			};
+			let exclude = fake_entity!(444);
+			let (mut app, _) = setup(
+				ray,
+				_Objects::new().with_mock(|mock| {
+					mock.expect_raycast()
+						.with(eq(SolidObjects {
+							ray,
+							exclude: vec![exclude],
+							only_hoverable: true,
+						}))
+						.return_const(None);
+				}),
+				_Ground::new().with_mock(|mock| {
+					mock.expect_raycast()
+						.with(eq(Terrain { ray }))
+						.return_const(toi!(44.));
+				}),
+			);
 
-	#[test]
-	fn return_ground_hit_when_no_object_hit() -> Result<(), RunSystemError> {
-		let ray = Ray3d {
-			origin: Vec3::new(1., 2., 3.),
-			direction: Dir3::NEG_Y,
-		};
-		let exclude = fake_entity!(444);
-		let (mut app, _) = setup(
-			ray,
-			_Objects::new().with_mock(|mock| {
-				mock.expect_raycast()
-					.with(eq(SolidObjects {
-						ray,
+			app.world_mut()
+				.run_system_once(move |mut ray_caster: _RayCaster| {
+					let hit = ray_caster.raycast(MouseHover {
 						exclude: vec![exclude],
-						only_hoverable: true,
-					}))
-					.return_const(None);
-			}),
-			_Ground::new().with_mock(|mock| {
-				mock.expect_raycast()
-					.with(eq(Terrain { ray }))
-					.return_const(toi!(44.));
-			}),
-		);
-
-		app.world_mut()
-			.run_system_once(move |mut ray_caster: _RayCaster| {
-				let hit = ray_caster.raycast(MouseHover {
-					exclude: vec![exclude],
-					mode: HoverMode::ColliderOrTerrain,
-				});
-
-				assert_eq!(
-					Some(MouseHoversOver::Terrain {
-						point: Vec3::new(1., -42., 3.)
-					}),
-					hit,
-				);
-			})
-	}
-
-	#[test]
-	fn return_ground_hit_when_no_object_further_away_than_ground() -> Result<(), RunSystemError> {
-		let ray = Ray3d {
-			origin: Vec3::new(1., 2., 3.),
-			direction: Dir3::NEG_Y,
-		};
-		let exclude = fake_entity!(444);
-		let (mut app, _) = setup(
-			ray,
-			_Objects::new().with_mock(|mock| {
-				mock.expect_raycast()
-					.with(eq(SolidObjects {
-						ray,
-						exclude: vec![exclude],
-						only_hoverable: true,
-					}))
-					.return_const(RaycastHit {
-						entity: fake_entity!(123),
-						time_of_impact: 100.,
+						mode: HoverMode::ColliderOrTerrain,
 					});
-			}),
-			_Ground::new().with_mock(|mock| {
-				mock.expect_raycast()
-					.with(eq(Terrain { ray }))
-					.return_const(toi!(44.));
-			}),
-		);
 
-		app.world_mut()
-			.run_system_once(move |mut ray_caster: _RayCaster| {
-				let hit = ray_caster.raycast(MouseHover {
-					exclude: vec![exclude],
-					mode: HoverMode::ColliderOrTerrain,
-				});
+					assert_eq!(Some(MouseHoversOver::Point(Vec3::new(1., -42., 3.))), hit,);
+				})
+		}
 
-				assert_eq!(
-					Some(MouseHoversOver::Terrain {
-						point: Vec3::new(1., -42., 3.)
-					}),
-					hit,
-				);
-			})
-	}
+		#[test]
+		fn return_ground_hit_when_no_object_further_away_than_ground() -> Result<(), RunSystemError>
+		{
+			let ray = Ray3d {
+				origin: Vec3::new(1., 2., 3.),
+				direction: Dir3::NEG_Y,
+			};
+			let exclude = fake_entity!(444);
+			let (mut app, _) = setup(
+				ray,
+				_Objects::new().with_mock(|mock| {
+					mock.expect_raycast()
+						.with(eq(SolidObjects {
+							ray,
+							exclude: vec![exclude],
+							only_hoverable: true,
+						}))
+						.return_const(RaycastHit {
+							entity: fake_entity!(123),
+							time_of_impact: 100.,
+						});
+				}),
+				_Ground::new().with_mock(|mock| {
+					mock.expect_raycast()
+						.with(eq(Terrain { ray }))
+						.return_const(toi!(44.));
+				}),
+			);
 
-	#[test]
-	fn return_cached_mouse_hover() -> Result<(), RunSystemError> {
-		let ray = Ray3d {
-			origin: Vec3::new(1., 2., 3.),
-			direction: Dir3::NEG_Y,
-		};
-		let exclude = fake_entity!(444);
-		let (mut app, cam) = setup(
-			ray,
-			_Objects::new().with_mock(|mock| {
-				mock.expect_raycast().never();
-			}),
-			_Ground::new().with_mock(|mock| {
-				mock.expect_raycast().never();
-			}),
-		);
-		let mut cam = app.world_mut().entity_mut(cam);
-		let mut cam = cam.get_mut::<WorldCamera>().unwrap();
-		cam.mouse_hover.insert(
-			vec![exclude],
-			MouseHoversOver::Object {
-				entity: fake_entity!(321),
-				point: Vec3::new(4., 11., 2.),
-			},
-		);
-
-		app.world_mut()
-			.run_system_once(move |mut ray_caster: _RayCaster| {
-				let hit = ray_caster.raycast(MouseHover {
-					exclude: vec![exclude],
-					mode: HoverMode::ColliderOrTerrain,
-				});
-
-				assert_eq!(
-					Some(MouseHoversOver::Object {
-						entity: fake_entity!(321),
-						point: Vec3::new(4., 11., 2.),
-					}),
-					hit,
-				);
-			})
-	}
-
-	#[test]
-	fn store_new_hit_in_world_camera() -> Result<(), RunSystemError> {
-		let ray = Ray3d {
-			origin: Vec3::new(1., 2., 3.),
-			direction: Dir3::NEG_Y,
-		};
-		let exclude = fake_entity!(444);
-		let (mut app, cam) = setup(
-			ray,
-			_Objects::new().with_mock(|mock| {
-				mock.expect_raycast()
-					.with(eq(SolidObjects {
-						ray,
+			app.world_mut()
+				.run_system_once(move |mut ray_caster: _RayCaster| {
+					let hit = ray_caster.raycast(MouseHover {
 						exclude: vec![exclude],
-						only_hoverable: true,
-					}))
-					.return_const(RaycastHit {
-						entity: fake_entity!(123),
-						time_of_impact: 42.,
+						mode: HoverMode::ColliderOrTerrain,
 					});
-			}),
-			_Ground::new().with_mock(|mock| {
-				mock.expect_raycast()
-					.with(eq(Terrain { ray }))
-					.return_const(toi!(44.));
-			}),
-		);
 
-		app.world_mut()
-			.run_system_once(move |mut ray_caster: _RayCaster| {
-				ray_caster.raycast(MouseHover {
+					assert_eq!(Some(MouseHoversOver::Point(Vec3::new(1., -42., 3.))), hit,);
+				})
+		}
+	}
+
+	mod direction_mode {
+		use super::*;
+
+		#[test]
+		fn return_direction_hit() -> Result<(), RunSystemError> {
+			let ray = Ray3d {
+				origin: Vec3::new(1., 20., 3.),
+				direction: Dir3::NEG_Y,
+			};
+			let exclude = fake_entity!(444);
+			let (mut app, _) = setup(
+				ray,
+				_Objects::new().with_mock(|mock| {
+					mock.expect_raycast().return_const(None);
+				}),
+				_Ground::new().with_mock(|mock| {
+					mock.expect_raycast().return_const(None);
+				}),
+			);
+
+			app.world_mut()
+				.run_system_once(move |mut ray_caster: _RayCaster| {
+					let hit = ray_caster.raycast(MouseHover {
+						exclude: vec![exclude],
+						mode: HoverMode::ColliderOrDirectionFrom(vec3_not_nan!(0., 10., 0.)),
+					});
+
+					assert_eq!(Some(MouseHoversOver::Point(Vec3::new(1., 10., 3.))), hit);
+				})
+		}
+
+		#[test]
+		fn return_direction_hit_when_ground_hit() -> Result<(), RunSystemError> {
+			let ray = Ray3d {
+				origin: Vec3::new(1., 20., 3.),
+				direction: Dir3::NEG_Y,
+			};
+			let exclude = fake_entity!(444);
+			let (mut app, _) = setup(
+				ray,
+				_Objects::new().with_mock(|mock| {
+					mock.expect_raycast().return_const(None);
+				}),
+				_Ground::new().with_mock(|mock| {
+					mock.expect_raycast()
+						.return_const(Some(TimeOfImpact::from(Units::from(1.))));
+				}),
+			);
+
+			app.world_mut()
+				.run_system_once(move |mut ray_caster: _RayCaster| {
+					let hit = ray_caster.raycast(MouseHover {
+						exclude: vec![exclude],
+						mode: HoverMode::ColliderOrDirectionFrom(vec3_not_nan!(0., 10., 0.)),
+					});
+
+					assert_eq!(Some(MouseHoversOver::Point(Vec3::new(1., 10., 3.))), hit);
+				})
+		}
+
+		#[test]
+		fn return_object_hit_when_ground_hit_further_away() -> Result<(), RunSystemError> {
+			let ray = Ray3d {
+				origin: Vec3::new(1., 20., 3.),
+				direction: Dir3::NEG_Y,
+			};
+			let exclude = fake_entity!(444);
+			let (mut app, _) = setup(
+				ray,
+				_Objects::new().with_mock(|mock| {
+					mock.expect_raycast().return_const(Some(RaycastHit {
+						entity: fake_entity!(555),
+						time_of_impact: 12.,
+					}));
+				}),
+				_Ground::new().with_mock(|mock| {
+					mock.expect_raycast()
+						.return_const(Some(TimeOfImpact::from(Units::from(15.))));
+				}),
+			);
+
+			app.world_mut()
+				.run_system_once(move |mut ray_caster: _RayCaster| {
+					let hit = ray_caster.raycast(MouseHover {
+						exclude: vec![exclude],
+						mode: HoverMode::ColliderOrDirectionFrom(vec3_not_nan!(0., 10., 0.)),
+					});
+
+					assert_eq!(
+						Some(MouseHoversOver::Object {
+							entity: fake_entity!(555),
+							point: Vec3::new(1., 8., 3.)
+						}),
+						hit
+					);
+				})
+		}
+
+		#[test]
+		fn return_direction_hit_when_object_hit_further_away_than_ground_hit()
+		-> Result<(), RunSystemError> {
+			let ray = Ray3d {
+				origin: Vec3::new(1., 20., 3.),
+				direction: Dir3::NEG_Y,
+			};
+			let exclude = fake_entity!(444);
+			let (mut app, _) = setup(
+				ray,
+				_Objects::new().with_mock(|mock| {
+					mock.expect_raycast().return_const(Some(RaycastHit {
+						entity: fake_entity!(555),
+						time_of_impact: 15.,
+					}));
+				}),
+				_Ground::new().with_mock(|mock| {
+					mock.expect_raycast()
+						.return_const(Some(TimeOfImpact::from(Units::from(12.))));
+				}),
+			);
+
+			app.world_mut()
+				.run_system_once(move |mut ray_caster: _RayCaster| {
+					let hit = ray_caster.raycast(MouseHover {
+						exclude: vec![exclude],
+						mode: HoverMode::ColliderOrDirectionFrom(vec3_not_nan!(0., 10., 0.)),
+					});
+
+					assert_eq!(Some(MouseHoversOver::Point(Vec3::new(1., 10., 3.))), hit);
+				})
+		}
+	}
+
+	mod cache {
+		use super::*;
+
+		#[test]
+		fn return_cached_mouse_hover() -> Result<(), RunSystemError> {
+			let ray = Ray3d {
+				origin: Vec3::new(1., 2., 3.),
+				direction: Dir3::NEG_Y,
+			};
+			let exclude = fake_entity!(444);
+			let (mut app, cam) = setup(
+				ray,
+				_Objects::new().with_mock(|mock| {
+					mock.expect_raycast().never();
+				}),
+				_Ground::new().with_mock(|mock| {
+					mock.expect_raycast().never();
+				}),
+			);
+			let mut cam = app.world_mut().entity_mut(cam);
+			let mut cam = cam.get_mut::<WorldCamera>().unwrap();
+			cam.mouse_hover.insert(
+				MouseHover {
 					exclude: vec![exclude],
 					mode: HoverMode::ColliderOrTerrain,
-				});
-			})?;
+				},
+				MouseHoversOver::Object {
+					entity: fake_entity!(321),
+					point: Vec3::new(4., 11., 2.),
+				},
+			);
 
-		assert_eq!(
-			Some(&WorldCamera {
-				mouse_hover: HashMap::from([(
-					vec![exclude],
-					MouseHoversOver::Object {
-						entity: fake_entity!(123),
-						point: Vec3::new(1., -40., 3.),
-					}
-				)]),
-				ray: Some(ray),
-			}),
-			app.world().entity(cam).get::<WorldCamera>(),
-		);
-		Ok(())
+			app.world_mut()
+				.run_system_once(move |mut ray_caster: _RayCaster| {
+					let hit = ray_caster.raycast(MouseHover {
+						exclude: vec![exclude],
+						mode: HoverMode::ColliderOrTerrain,
+					});
+
+					assert_eq!(
+						Some(MouseHoversOver::Object {
+							entity: fake_entity!(321),
+							point: Vec3::new(4., 11., 2.),
+						}),
+						hit,
+					);
+				})
+		}
+
+		#[test]
+		fn store_new_hit_in_world_camera() -> Result<(), RunSystemError> {
+			let ray = Ray3d {
+				origin: Vec3::new(1., 2., 3.),
+				direction: Dir3::NEG_Y,
+			};
+			let exclude = fake_entity!(444);
+			let (mut app, cam) = setup(
+				ray,
+				_Objects::new().with_mock(|mock| {
+					mock.expect_raycast()
+						.with(eq(SolidObjects {
+							ray,
+							exclude: vec![exclude],
+							only_hoverable: true,
+						}))
+						.return_const(RaycastHit {
+							entity: fake_entity!(123),
+							time_of_impact: 42.,
+						});
+				}),
+				_Ground::new().with_mock(|mock| {
+					mock.expect_raycast()
+						.with(eq(Terrain { ray }))
+						.return_const(toi!(44.));
+				}),
+			);
+
+			app.world_mut()
+				.run_system_once(move |mut ray_caster: _RayCaster| {
+					ray_caster.raycast(MouseHover {
+						exclude: vec![exclude],
+						mode: HoverMode::ColliderOrTerrain,
+					});
+				})?;
+
+			assert_eq!(
+				Some(&WorldCamera {
+					mouse_hover: HashMap::from([(
+						MouseHover {
+							exclude: vec![exclude],
+							mode: HoverMode::ColliderOrTerrain,
+						},
+						MouseHoversOver::Object {
+							entity: fake_entity!(123),
+							point: Vec3::new(1., -40., 3.),
+						}
+					)]),
+					ray: Some(ray),
+				}),
+				app.world().entity(cam).get::<WorldCamera>(),
+			);
+			Ok(())
+		}
 	}
 }

--- a/src/plugins/physics/src/system_params/ray_caster/mouse_hover.rs
+++ b/src/plugins/physics/src/system_params/ray_caster/mouse_hover.rs
@@ -16,7 +16,7 @@ where
 	T: SystemParam + 'static,
 	Self: Raycast<SolidObjects> + Raycast<Terrain>,
 {
-	fn raycast(&mut self, MouseHover { exclude }: MouseHover) -> Option<MouseHoversOver> {
+	fn raycast(&mut self, MouseHover { exclude, .. }: MouseHover) -> Option<MouseHoversOver> {
 		let cam = self.world_cams.single_mut().ok()?;
 		let ray = cam.ray?;
 
@@ -74,7 +74,7 @@ mod tests {
 	};
 	use common::{
 		toi,
-		traits::handles_physics::{RaycastHit, TimeOfImpact},
+		traits::handles_physics::{HoverMode, RaycastHit, TimeOfImpact},
 	};
 	use macros::NestedMocks;
 	use mockall::{automock, predicate::eq};
@@ -169,6 +169,7 @@ mod tests {
 			.run_system_once(move |mut ray_caster: _RayCaster| {
 				let hit = ray_caster.raycast(MouseHover {
 					exclude: vec![exclude],
+					mode: HoverMode::ColliderOrTerrain,
 				});
 
 				assert_eq!(
@@ -210,6 +211,7 @@ mod tests {
 			.run_system_once(move |mut ray_caster: _RayCaster| {
 				let hit = ray_caster.raycast(MouseHover {
 					exclude: vec![exclude],
+					mode: HoverMode::ColliderOrTerrain,
 				});
 
 				assert_eq!(
@@ -253,6 +255,7 @@ mod tests {
 			.run_system_once(move |mut ray_caster: _RayCaster| {
 				let hit = ray_caster.raycast(MouseHover {
 					exclude: vec![exclude],
+					mode: HoverMode::ColliderOrTerrain,
 				});
 
 				assert_eq!(
@@ -294,6 +297,7 @@ mod tests {
 			.run_system_once(move |mut ray_caster: _RayCaster| {
 				let hit = ray_caster.raycast(MouseHover {
 					exclude: vec![exclude],
+					mode: HoverMode::ColliderOrTerrain,
 				});
 
 				assert_eq!(
@@ -338,6 +342,7 @@ mod tests {
 			.run_system_once(move |mut ray_caster: _RayCaster| {
 				ray_caster.raycast(MouseHover {
 					exclude: vec![exclude],
+					mode: HoverMode::ColliderOrTerrain,
 				});
 			})?;
 

--- a/src/plugins/physics/src/systems/ground_target/set_position.rs
+++ b/src/plugins/physics/src/systems/ground_target/set_position.rs
@@ -78,7 +78,7 @@ fn mouse_hover_translation(
 	transforms: Query<&Transform>,
 ) -> impl Fn(MouseHoversOver) -> Option<Vec3> {
 	move |mouse_hover| match mouse_hover {
-		MouseHoversOver::Terrain { point } => Some(point),
+		MouseHoversOver::Point(point) => Some(point),
 		MouseHoversOver::Object { entity, .. } => {
 			transforms.get(entity).map(|t| t.translation).ok()
 		}
@@ -143,9 +143,7 @@ mod tests {
 		app.insert_resource(_RayCaster::new().with_mock(|mock| {
 			mock.expect_raycast()
 				.once()
-				.return_const(MouseHoversOver::Terrain {
-					point: Vec3::new(1., 2., 3.),
-				});
+				.return_const(MouseHoversOver::Point(Vec3::new(1., 2., 3.)));
 		}));
 		let entity = app
 			.world_mut()

--- a/src/plugins/physics/src/systems/ground_target/set_position.rs
+++ b/src/plugins/physics/src/systems/ground_target/set_position.rs
@@ -48,7 +48,7 @@ impl GroundTarget {
 	) -> Option<Transform> {
 		match self.target {
 			SkillTarget::Cursor(_) => ray_caster
-				.raycast(MouseHover::NO_EXCLUDES)
+				.raycast(MouseHover::TERRAIN_WITHOUT_EXCLUDES)
 				.and_then(mouse_hover_translation(transforms))
 				.map(Transform::from_translation),
 			SkillTarget::Entity(persistent_entity) => commands

--- a/src/plugins/physics/src/systems/ground_target/set_position.rs
+++ b/src/plugins/physics/src/systems/ground_target/set_position.rs
@@ -47,7 +47,7 @@ impl GroundTarget {
 		ray_caster: &mut impl Raycast<MouseHover>,
 	) -> Option<Transform> {
 		match self.target {
-			SkillTarget::Cursor => ray_caster
+			SkillTarget::Cursor(_) => ray_caster
 				.raycast(MouseHover::NO_EXCLUDES)
 				.and_then(mouse_hover_translation(transforms))
 				.map(Transform::from_translation),
@@ -94,13 +94,14 @@ mod tests {
 		tools::Units,
 		traits::{
 			handles_physics::MouseHoversOver,
-			handles_skill_physics::SkillCaster,
+			handles_skill_physics::{Cursor, SkillCaster},
 			register_persistent_entities::RegisterPersistentEntities,
 		},
 	};
 	use macros::NestedMocks;
 	use mockall::automock;
 	use std::f32::consts::PI;
+	use test_case::test_case;
 	use testing::{NestedMocks, SingleThreadedApp, assert_eq_approx};
 
 	#[derive(Resource, NestedMocks)]
@@ -133,8 +134,9 @@ mod tests {
 		app
 	}
 
-	#[test]
-	fn set_to_cursor_terrain() {
+	#[test_case(Cursor::Direction; "cursor direction")]
+	#[test_case(Cursor::TerrainHover; "cursor terrain hover")]
+	fn set_to_cursor_terrain(cursor: Cursor) {
 		let mut app = setup();
 		let caster = SkillCaster::default();
 		app.world_mut().spawn((Transform::default(), *caster));
@@ -147,7 +149,7 @@ mod tests {
 		}));
 		let entity = app
 			.world_mut()
-			.spawn(GroundTarget::with_caster(caster).with_target(SkillTarget::Cursor))
+			.spawn(GroundTarget::with_caster(caster).with_target(SkillTarget::Cursor(cursor)))
 			.id();
 
 		app.update();
@@ -158,8 +160,9 @@ mod tests {
 		)
 	}
 
-	#[test]
-	fn set_to_cursor_entity_translation() {
+	#[test_case(Cursor::Direction; "cursor direction")]
+	#[test_case(Cursor::TerrainHover; "cursor terrain hover")]
+	fn set_to_cursor_entity_translation(cursor: Cursor) {
 		let mut app = setup();
 		let caster = SkillCaster::default();
 		let cursor_entity = app
@@ -181,7 +184,7 @@ mod tests {
 		}));
 		let entity = app
 			.world_mut()
-			.spawn(GroundTarget::with_caster(caster).with_target(SkillTarget::Cursor))
+			.spawn(GroundTarget::with_caster(caster).with_target(SkillTarget::Cursor(cursor)))
 			.id();
 
 		app.update();

--- a/src/plugins/physics/src/systems/world_camera/reset_camera.rs
+++ b/src/plugins/physics/src/systems/world_camera/reset_camera.rs
@@ -15,7 +15,7 @@ impl WorldCamera {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use common::traits::handles_physics::MouseHoversOver;
+	use common::traits::handles_physics::{MouseHover, MouseHoversOver};
 	use std::collections::HashMap;
 	use testing::{IsChanged, SingleThreadedApp};
 
@@ -37,10 +37,8 @@ mod tests {
 			.world_mut()
 			.spawn(WorldCamera {
 				mouse_hover: HashMap::from([(
-					vec![],
-					MouseHoversOver::Terrain {
-						point: Vec3::default(),
-					},
+					MouseHover::default(),
+					MouseHoversOver::Point(Vec3::default()),
 				)]),
 				..default()
 			})

--- a/src/plugins/skills/src/systems/schedule_active_skill.rs
+++ b/src/plugins/skills/src/systems/schedule_active_skill.rs
@@ -82,7 +82,7 @@ where
 
 	if states.contains(&StateMeta::Entering(SkillState::Aim)) {
 		match skill_target {
-			SkillTarget::Cursor(..) => facing.override_face(Face::Cursor),
+			SkillTarget::Cursor(cursor) => facing.override_face(Face::Cursor(*cursor)),
 			SkillTarget::Entity(target) => facing.override_face(Face::Entity(*target)),
 		}
 		schedule_start(&mut skill_executer, skill, try_run_on_aim);
@@ -518,8 +518,8 @@ mod tests {
 	}
 
 	#[test_case(SkillTarget::Entity(*TARGET), Face::Entity(*TARGET); "target")]
-	#[test_case(SkillTarget::Cursor(Cursor::Direction), Face::Cursor; "cursor direction")]
-	#[test_case(SkillTarget::Cursor(Cursor::TerrainHover), Face::Cursor; "cursor terrain hover")]
+	#[test_case(SkillTarget::Cursor(Cursor::Direction), Face::Cursor(Cursor::Direction); "cursor direction")]
+	#[test_case(SkillTarget::Cursor(Cursor::TerrainHover), Face::Cursor(Cursor::TerrainHover); "cursor terrain hover")]
 	fn apply_facing(target: SkillTarget, face: Face) -> Result<(), MissingLastUpdate> {
 		let (mut app, agent) = setup()?;
 		app.world_mut().entity_mut(agent).insert((
@@ -581,8 +581,8 @@ mod tests {
 	}
 
 	#[test_case(SkillTarget::Entity(*TARGET), Face::Entity(*TARGET); "target")]
-	#[test_case(SkillTarget::Cursor(Cursor::Direction), Face::Cursor; "cursor direction")]
-	#[test_case(SkillTarget::Cursor(Cursor::TerrainHover), Face::Cursor; "cursor terrain override")]
+	#[test_case(SkillTarget::Cursor(Cursor::Direction), Face::Cursor(Cursor::Direction); "cursor direction")]
+	#[test_case(SkillTarget::Cursor(Cursor::TerrainHover), Face::Cursor(Cursor::TerrainHover); "cursor terrain override")]
 	fn apply_facing_override_when_beginning_to_aim(
 		target: SkillTarget,
 		face: Face,

--- a/src/plugins/skills/src/systems/schedule_active_skill.rs
+++ b/src/plugins/skills/src/systems/schedule_active_skill.rs
@@ -80,11 +80,16 @@ where
 	let skill = &mut skill;
 	let states = skill.updated_states(delta);
 
-	if states.contains(&StateMeta::Entering(SkillState::Aim)) {
+	if states.contains(&StateMeta::Entering(SkillState::Aim))
+		|| states.contains(&StateMeta::In(SkillState::Aim))
+	{
 		match skill_target {
 			SkillTarget::Cursor(cursor) => facing.override_face(Face::Cursor(*cursor)),
 			SkillTarget::Entity(target) => facing.override_face(Face::Entity(*target)),
 		}
+	}
+
+	if states.contains(&StateMeta::Entering(SkillState::Aim)) {
 		schedule_start(&mut skill_executer, skill, try_run_on_aim);
 	}
 
@@ -517,22 +522,27 @@ mod tests {
 		Ok(())
 	}
 
-	#[test_case(SkillTarget::Entity(*TARGET), Face::Entity(*TARGET); "target")]
-	#[test_case(SkillTarget::Cursor(Cursor::Direction), Face::Cursor(Cursor::Direction); "cursor direction")]
-	#[test_case(SkillTarget::Cursor(Cursor::TerrainHover), Face::Cursor(Cursor::TerrainHover); "cursor terrain hover")]
-	fn apply_facing(target: SkillTarget, face: Face) -> Result<(), MissingLastUpdate> {
+	#[test_case(SkillTarget::Entity(*TARGET), Face::Entity(*TARGET), StateMeta::Entering; "target on enter aim")]
+	#[test_case(SkillTarget::Cursor(Cursor::Direction), Face::Cursor(Cursor::Direction), StateMeta::Entering; "cursor direction on enter aim")]
+	#[test_case(SkillTarget::Cursor(Cursor::TerrainHover), Face::Cursor(Cursor::TerrainHover), StateMeta::Entering; "cursor terrain hover on enter aim")]
+	#[test_case(SkillTarget::Entity(*TARGET), Face::Entity(*TARGET), StateMeta::In; "target on in aim")]
+	#[test_case(SkillTarget::Cursor(Cursor::Direction), Face::Cursor(Cursor::Direction), StateMeta::In; "cursor direction on in aim")]
+	#[test_case(SkillTarget::Cursor(Cursor::TerrainHover), Face::Cursor(Cursor::TerrainHover), StateMeta::In; "cursor terrain hover on in aim")]
+	fn apply_facing(
+		target: SkillTarget,
+		face: Face,
+		meta: fn(SkillState) -> StateMeta<SkillState>,
+	) -> Result<(), MissingLastUpdate> {
 		let (mut app, agent) = setup()?;
 		app.world_mut().entity_mut(agent).insert((
 			Target(Some(target)),
 			_Dequeue {
-				active: Some(Box::new(|| {
+				active: Some(Box::new(move || {
 					Mock_Skill::new_mock(|mock| {
 						mock.expect_behavior()
 							.return_const((SlotKey(0), RunSkillBehavior::default()));
 						mock.expect_updated_states().return_const(
-							HashSet::<StateMeta<SkillState>>::from([StateMeta::Entering(
-								SkillState::Aim,
-							)]),
+							HashSet::<StateMeta<SkillState>>::from([meta(SkillState::Aim)]),
 						);
 					})
 				})),
@@ -551,54 +561,27 @@ mod tests {
 		Ok(())
 	}
 
-	#[test]
-	fn do_not_apply_facing_when_not_beginning_to_aim() -> Result<(), MissingLastUpdate> {
-		let (mut app, agent) = setup()?;
-		app.world_mut().entity_mut(agent).insert((
-			Target(Some(SkillTarget::Cursor(Cursor::Direction))),
-			_Dequeue {
-				active: Some(Box::new(|| {
-					Mock_Skill::new_mock(|mock| {
-						mock.expect_behavior()
-							.return_const((SlotKey(0), RunSkillBehavior::default()));
-						mock.expect_updated_states().return_const(
-							HashSet::<StateMeta<SkillState>>::from([StateMeta::In(
-								SkillState::Aim,
-							)]),
-						);
-					})
-				})),
-			},
-			Transform::default(),
-			_Facing::new().with_mock(|mock| {
-				mock.expect_override_face().never();
-				mock.expect_stop_override_face().never();
-			}),
-		));
-
-		app.update();
-		Ok(())
-	}
-
-	#[test_case(SkillTarget::Entity(*TARGET), Face::Entity(*TARGET); "target")]
-	#[test_case(SkillTarget::Cursor(Cursor::Direction), Face::Cursor(Cursor::Direction); "cursor direction")]
-	#[test_case(SkillTarget::Cursor(Cursor::TerrainHover), Face::Cursor(Cursor::TerrainHover); "cursor terrain override")]
+	#[test_case(SkillTarget::Entity(*TARGET), Face::Entity(*TARGET), StateMeta::Entering; "target on enter aim")]
+	#[test_case(SkillTarget::Cursor(Cursor::Direction), Face::Cursor(Cursor::Direction), StateMeta::Entering; "cursor direction on enter aim")]
+	#[test_case(SkillTarget::Cursor(Cursor::TerrainHover), Face::Cursor(Cursor::TerrainHover), StateMeta::Entering; "cursor terrain hover on enter aim")]
+	#[test_case(SkillTarget::Entity(*TARGET), Face::Entity(*TARGET), StateMeta::In; "target on in aim")]
+	#[test_case(SkillTarget::Cursor(Cursor::Direction), Face::Cursor(Cursor::Direction), StateMeta::In; "cursor direction on in aim")]
+	#[test_case(SkillTarget::Cursor(Cursor::TerrainHover), Face::Cursor(Cursor::TerrainHover), StateMeta::In; "cursor terrain hover on in aim")]
 	fn apply_facing_override_when_beginning_to_aim(
 		target: SkillTarget,
 		face: Face,
+		meta: fn(SkillState) -> StateMeta<SkillState>,
 	) -> Result<(), MissingLastUpdate> {
 		let (mut app, agent) = setup()?;
 		app.world_mut().entity_mut(agent).insert((
 			Target(Some(target)),
 			_Dequeue {
-				active: Some(Box::new(|| {
+				active: Some(Box::new(move || {
 					Mock_Skill::new_mock(|mock| {
 						mock.expect_behavior()
 							.return_const((SlotKey(0), RunSkillBehavior::default()));
 						mock.expect_updated_states().return_const(
-							HashSet::<StateMeta<SkillState>>::from([StateMeta::Entering(
-								SkillState::Aim,
-							)]),
+							HashSet::<StateMeta<SkillState>>::from([meta(SkillState::Aim)]),
 						);
 					})
 				})),

--- a/src/plugins/skills/src/systems/schedule_active_skill.rs
+++ b/src/plugins/skills/src/systems/schedule_active_skill.rs
@@ -82,7 +82,7 @@ where
 
 	if states.contains(&StateMeta::Entering(SkillState::Aim)) {
 		match skill_target {
-			SkillTarget::Cursor => facing.override_face(Face::Cursor),
+			SkillTarget::Cursor(..) => facing.override_face(Face::Cursor),
 			SkillTarget::Entity(target) => facing.override_face(Face::Entity(*target)),
 		}
 		schedule_start(&mut skill_executer, skill, try_run_on_aim);
@@ -143,7 +143,7 @@ mod tests {
 	use common::{
 		components::persistent_entity::PersistentEntity,
 		tools::action_key::slot::HandSlot,
-		traits::handles_skill_physics::{SkillShape, shield::Shield},
+		traits::handles_skill_physics::{Cursor, SkillShape, shield::Shield},
 	};
 	use macros::{NestedMocks, simple_mock};
 	use mockall::{automock, mock, predicate::eq};
@@ -268,7 +268,7 @@ mod tests {
 	fn call_update_with_delta() -> Result<(), MissingLastUpdate> {
 		let (mut app, agent) = setup()?;
 		app.world_mut().entity_mut(agent).insert((
-			Target(Some(SkillTarget::Cursor)),
+			Target(Some(SkillTarget::Cursor(Cursor::Direction))),
 			_Dequeue {
 				active: Some(Box::new(|| {
 					Mock_Skill::new_mock(|mock| {
@@ -294,7 +294,7 @@ mod tests {
 	fn clear_queue_of_active() -> Result<(), MissingLastUpdate> {
 		let (mut app, agent) = setup()?;
 		app.world_mut().entity_mut(agent).insert((
-			Target(Some(SkillTarget::Cursor)),
+			Target(Some(SkillTarget::Cursor(Cursor::Direction))),
 			_Dequeue {
 				active: Some(Box::new(|| {
 					Mock_Skill::new_mock(|mock| {
@@ -322,7 +322,7 @@ mod tests {
 	fn do_not_remove_skill_when_not_done() -> Result<(), MissingLastUpdate> {
 		let (mut app, agent) = setup()?;
 		app.world_mut().entity_mut(agent).insert((
-			Target(Some(SkillTarget::Cursor)),
+			Target(Some(SkillTarget::Cursor(Cursor::Direction))),
 			_Dequeue {
 				active: Some(Box::new(|| {
 					Mock_Skill::new_mock(|mock| {
@@ -352,7 +352,7 @@ mod tests {
 	fn run_on_active() -> Result<(), MissingLastUpdate> {
 		let (mut app, agent) = setup()?;
 		app.world_mut().entity_mut(agent).insert((
-			Target(Some(SkillTarget::Cursor)),
+			Target(Some(SkillTarget::Cursor(Cursor::Direction))),
 			_Executor::new().with_mock(|mock| {
 				mock.expect_flush().return_const(());
 				mock.expect_schedule()
@@ -394,7 +394,7 @@ mod tests {
 	fn run_on_aim() -> Result<(), MissingLastUpdate> {
 		let (mut app, agent) = setup()?;
 		app.world_mut().entity_mut(agent).insert((
-			Target(Some(SkillTarget::Cursor)),
+			Target(Some(SkillTarget::Cursor(Cursor::Direction))),
 			_Executor::new().with_mock(|mock| {
 				mock.expect_flush().return_const(());
 				mock.expect_schedule()
@@ -436,7 +436,7 @@ mod tests {
 	fn do_not_run_when_not_activating_this_frame() -> Result<(), MissingLastUpdate> {
 		let (mut app, agent) = setup()?;
 		app.world_mut().entity_mut(agent).insert((
-			Target(Some(SkillTarget::Cursor)),
+			Target(Some(SkillTarget::Cursor(Cursor::Direction))),
 			_Dequeue {
 				active: Some(Box::new(|| {
 					Mock_Skill::new_mock(|mock| {
@@ -463,7 +463,7 @@ mod tests {
 	fn flush() -> Result<(), MissingLastUpdate> {
 		let (mut app, agent) = setup()?;
 		app.world_mut().entity_mut(agent).insert((
-			Target(Some(SkillTarget::Cursor)),
+			Target(Some(SkillTarget::Cursor(Cursor::Direction))),
 			_Executor::new().with_mock(|mock| {
 				mock.expect_schedule().return_const(());
 				mock.expect_flush().times(1).return_const(());
@@ -491,7 +491,7 @@ mod tests {
 	fn do_not_stop_when_not_done() -> Result<(), MissingLastUpdate> {
 		let (mut app, agent) = setup()?;
 		app.world_mut().entity_mut(agent).insert((
-			Target(Some(SkillTarget::Cursor)),
+			Target(Some(SkillTarget::Cursor(Cursor::Direction))),
 			_Executor::new().with_mock(|mock| {
 				mock.expect_schedule().return_const(());
 				mock.expect_flush().never().return_const(());
@@ -518,7 +518,8 @@ mod tests {
 	}
 
 	#[test_case(SkillTarget::Entity(*TARGET), Face::Entity(*TARGET); "target")]
-	#[test_case(SkillTarget::Cursor, Face::Cursor; "cursor")]
+	#[test_case(SkillTarget::Cursor(Cursor::Direction), Face::Cursor; "cursor direction")]
+	#[test_case(SkillTarget::Cursor(Cursor::TerrainHover), Face::Cursor; "cursor terrain hover")]
 	fn apply_facing(target: SkillTarget, face: Face) -> Result<(), MissingLastUpdate> {
 		let (mut app, agent) = setup()?;
 		app.world_mut().entity_mut(agent).insert((
@@ -554,7 +555,7 @@ mod tests {
 	fn do_not_apply_facing_when_not_beginning_to_aim() -> Result<(), MissingLastUpdate> {
 		let (mut app, agent) = setup()?;
 		app.world_mut().entity_mut(agent).insert((
-			Target(Some(SkillTarget::Cursor)),
+			Target(Some(SkillTarget::Cursor(Cursor::Direction))),
 			_Dequeue {
 				active: Some(Box::new(|| {
 					Mock_Skill::new_mock(|mock| {
@@ -580,7 +581,8 @@ mod tests {
 	}
 
 	#[test_case(SkillTarget::Entity(*TARGET), Face::Entity(*TARGET); "target")]
-	#[test_case(SkillTarget::Cursor, Face::Cursor; "cursor")]
+	#[test_case(SkillTarget::Cursor(Cursor::Direction), Face::Cursor; "cursor direction")]
+	#[test_case(SkillTarget::Cursor(Cursor::TerrainHover), Face::Cursor; "cursor terrain override")]
 	fn apply_facing_override_when_beginning_to_aim(
 		target: SkillTarget,
 		face: Face,
@@ -619,7 +621,7 @@ mod tests {
 	fn stop_facing_override_when_no_skills_active() -> Result<(), MissingLastUpdate> {
 		let (mut app, agent) = setup()?;
 		app.world_mut().entity_mut(agent).insert((
-			Target(Some(SkillTarget::Cursor)),
+			Target(Some(SkillTarget::Cursor(Cursor::Direction))),
 			_Dequeue { active: None },
 			Transform::from_xyz(-1., -2., -3.),
 			_Facing::new().with_mock(|mock| {

--- a/src/plugins/skills/src/systems/update_target_pitch.rs
+++ b/src/plugins/skills/src/systems/update_target_pitch.rs
@@ -51,7 +51,7 @@ impl Target {
 				let target = transforms.get(target).ok()?.translation();
 				get_pitch(transform, target)
 			}
-			SkillTarget::Cursor => match ray_cast.raycast(MouseHover::excluding([entity]))? {
+			SkillTarget::Cursor(_) => match ray_cast.raycast(MouseHover::excluding([entity]))? {
 				MouseHoversOver::Terrain { point } => get_pitch(transform, point),
 				MouseHoversOver::Object { entity, .. } => {
 					let target = transforms.get(entity).ok()?.translation();
@@ -82,7 +82,7 @@ mod tests {
 		components::persistent_entity::PersistentEntity,
 		traits::{
 			handles_animations::{ForwardPitch, GetForwardPitch},
-			handles_skill_physics::SkillTarget,
+			handles_skill_physics::{Cursor, SkillTarget},
 		},
 	};
 	use macros::NestedMocks;
@@ -232,7 +232,7 @@ mod tests {
 		let entity = app
 			.world_mut()
 			.spawn((
-				Target(Some(SkillTarget::Cursor)),
+				Target(Some(SkillTarget::Cursor(Cursor::TerrainHover))),
 				GlobalTransform::from_translation(translation),
 				_Animations {
 					forward_pitch: None,
@@ -273,7 +273,7 @@ mod tests {
 		let entity = app
 			.world_mut()
 			.spawn((
-				Target(Some(SkillTarget::Cursor)),
+				Target(Some(SkillTarget::Cursor(Cursor::TerrainHover))),
 				GlobalTransform::from_translation(translation),
 				_Animations {
 					forward_pitch: None,
@@ -306,7 +306,7 @@ mod tests {
 		let entity = app
 			.world_mut()
 			.spawn((
-				Target(Some(SkillTarget::Cursor)),
+				Target(Some(SkillTarget::Cursor(Cursor::TerrainHover))),
 				GlobalTransform::from_translation(translation),
 				_Animations {
 					forward_pitch: None,

--- a/src/plugins/skills/src/systems/update_target_pitch.rs
+++ b/src/plugins/skills/src/systems/update_target_pitch.rs
@@ -8,7 +8,7 @@ use common::{
 		accessors::get::{Get, GetContextMut},
 		handles_animations::{Animations, DirForwardPitch, ForwardPitch, GetForwardPitchMut},
 		handles_physics::{MouseHover, MouseHoversOver, Raycast},
-		handles_skill_physics::SkillTarget,
+		handles_skill_physics::{Cursor, SkillTarget},
 	},
 	zyheeda_commands::ZyheedaCommands,
 };
@@ -51,13 +51,16 @@ impl Target {
 				let target = transforms.get(target).ok()?.translation();
 				get_pitch(transform, target)
 			}
-			SkillTarget::Cursor(_) => match ray_cast.raycast(MouseHover::excluding([entity]))? {
-				MouseHoversOver::Point(point) => get_pitch(transform, point),
-				MouseHoversOver::Object { entity, .. } => {
-					let target = transforms.get(entity).ok()?.translation();
-					get_pitch(transform, target)
+			SkillTarget::Cursor(Cursor::TerrainHover) => {
+				match ray_cast.raycast(MouseHover::excluding([entity]))? {
+					MouseHoversOver::Point(point) => get_pitch(transform, point),
+					MouseHoversOver::Object { entity, .. } => {
+						let target = transforms.get(entity).ok()?.translation();
+						get_pitch(transform, target)
+					}
 				}
-			},
+			}
+			SkillTarget::Cursor(Cursor::Direction) => None,
 		}
 	}
 }
@@ -291,6 +294,35 @@ mod tests {
 		assert_eq_approx!(
 			Some(&_Animations {
 				forward_pitch: forward_pitch.into()
+			}),
+			app.world().entity(entity).get::<_Animations>(),
+			1e-5,
+		);
+	}
+
+	#[test]
+	fn set_not_pitch_for_directional_cursor() {
+		let mut app = setup();
+		let entity = app
+			.world_mut()
+			.spawn((
+				Target(Some(SkillTarget::Cursor(Cursor::Direction))),
+				GlobalTransform::default(),
+				_Animations {
+					forward_pitch: Some(DirForwardPitch::Up(ForwardPitch::MAX)),
+				},
+			))
+			.id();
+		app.insert_resource(_RayCast::new().with_mock(|mock| {
+			mock.expect_raycast()
+				.return_const(Some(MouseHoversOver::Point(Vec3::new(1., 2., 3.))));
+		}));
+
+		app.update();
+
+		assert_eq_approx!(
+			Some(&_Animations {
+				forward_pitch: None
 			}),
 			app.world().entity(entity).get::<_Animations>(),
 			1e-5,

--- a/src/plugins/skills/src/systems/update_target_pitch.rs
+++ b/src/plugins/skills/src/systems/update_target_pitch.rs
@@ -52,7 +52,7 @@ impl Target {
 				get_pitch(transform, target)
 			}
 			SkillTarget::Cursor(_) => match ray_cast.raycast(MouseHover::excluding([entity]))? {
-				MouseHoversOver::Terrain { point } => get_pitch(transform, point),
+				MouseHoversOver::Point(point) => get_pitch(transform, point),
 				MouseHoversOver::Object { entity, .. } => {
 					let target = transforms.get(entity).ok()?.translation();
 					get_pitch(transform, target)
@@ -241,9 +241,7 @@ mod tests {
 			.id();
 		app.insert_resource(_RayCast::new().with_mock(|mock| {
 			mock.expect_raycast()
-				.return_const(Some(MouseHoversOver::Terrain {
-					point: translation + offset,
-				}));
+				.return_const(Some(MouseHoversOver::Point(translation + offset)));
 		}));
 
 		app.update();


### PR DESCRIPTION
Now 2 target modes are available:
- default targeting: horizontal direction towards mouse cursor or snaps to a hovered target
- terrain targeting: terrain point over mouse cursor or snaps to a hovered target

There are still some issues:
- spawned skills in the `physics` plugin don't receive an updated skill target, which kinda makes beams act weird when switching target mode while using a beam
- default targeting close to the player acts odd, because of the difference between skill spawn locations and player translation

Both will need to be addressed in the future, but for now we have a basic functionality for targeting modes.