### PR TITLE
Derive`Deserialize`  for `InRange`

### DIFF
--- a/src/macros/src/lib.rs
+++ b/src/macros/src/lib.rs
@@ -16,6 +16,7 @@ use syn::{
 	braced,
 	parse::{Parse, ParseStream},
 	parse_macro_input,
+	parse_quote,
 	spanned::Spanned,
 };
 
@@ -283,7 +284,7 @@ pub fn derive_in_range(input: TokenStream) -> TokenStream {
 		Err(error) => return error,
 	};
 	let name = &input.ident;
-	let (impl_generics, type_generics, where_clause) = &input.generics.split_for_impl();
+	let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
 	let Some([field]) = get_unnamed_fields(&input) else {
 		return TokenStream::from(
@@ -377,8 +378,22 @@ pub fn derive_in_range(input: TokenStream) -> TokenStream {
 	};
 	let high = high.expr;
 
+	let mut de_generics = input.generics.clone();
+	de_generics.params.insert(0, parse_quote!('de));
+	de_generics
+		.where_clause
+		.get_or_insert(syn::WhereClause {
+			where_token: Default::default(),
+			predicates: syn::punctuated::Punctuated::new(),
+		})
+		.predicates
+		.push(syn::parse_quote! {
+			#ty: serde::Deserialize<'de>
+		});
+	let (de_impl_generics, _, de_where_clause) = de_generics.split_for_impl();
+
 	TokenStream::from(quote! {
-		impl #impl_generics #name #type_generics #where_clause {
+		impl #impl_generics #name #ty_generics #where_clause {
 			const LIMITS: (#ty, #ty) = match (#low, #high) {
 				(l, h) if l < h => (l, h),
 				_ => panic!("`InBetween: low` must be lesser than `high`")
@@ -405,7 +420,7 @@ pub fn derive_in_range(input: TokenStream) -> TokenStream {
 			}
 		}
 
-		impl #impl_generics TryFrom<#ty> for #name #type_generics #where_clause {
+		impl #impl_generics TryFrom<#ty> for #name #ty_generics #where_clause {
 			type Error = #core::errors::NotInRange<#ty>;
 
 			fn try_from(value: #ty) -> Result<Self, Self::Error> {
@@ -413,11 +428,24 @@ pub fn derive_in_range(input: TokenStream) -> TokenStream {
 			}
 		}
 
-		impl #impl_generics std::ops::Deref for #name #type_generics #where_clause {
+		impl #impl_generics std::ops::Deref for #name #ty_generics #where_clause {
 			type Target = #ty;
 
 			fn deref(&self) -> &Self::Target {
 				&self.0
+			}
+		}
+
+		impl #de_impl_generics serde::Deserialize<'de> for #name #ty_generics #de_where_clause {
+			fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+			where
+				D: serde::Deserializer<'de> {
+				let inner = #ty::deserialize(deserializer)?;
+
+				Self::try_from(inner).map_err(|_| serde::de::Error::custom(format!(
+					"value outside of accepted range for {}",
+					std::any::type_name::<Self>(),
+				)))
 			}
 		}
 	})

--- a/src/plugins/common/src/traits/handles_animations.rs
+++ b/src/plugins/common/src/traits/handles_animations.rs
@@ -175,7 +175,7 @@ pub struct PitchedForward {
 	pub down: (ForwardPitch, Path),
 }
 
-#[derive(InRange, Debug, PartialEq, Clone, Copy, Serialize, Deserialize)]
+#[derive(InRange, Debug, PartialEq, Clone, Copy, Serialize)]
 #[in_range(low = >0., high = 1.)]
 pub struct ForwardPitch(f32);
 

--- a/src/zyheeda_core/src/tests/derive_in_range.rs
+++ b/src/zyheeda_core/src/tests/derive_in_range.rs
@@ -1,5 +1,6 @@
 use crate::errors::{Limit, NotInRange};
 use macros::{InRange, new_valid};
+use serde_json::{Error, Value, from_value, json};
 use std::{fmt::Debug, ops::Deref};
 use test_case::test_case;
 
@@ -152,4 +153,40 @@ fn too_small_display() {
 #[test]
 fn new_valid_ok() {
 	assert_eq!(_Exclusive10To100(12), new_valid!(_Exclusive10To100, 12));
+}
+
+#[test_case(json!(10), 10; "10")]
+#[test_case(json!(50), 50; "50")]
+#[test_case(json!(100), 100; "100")]
+fn deserialize_inclusive(json: Value, inner: i32) -> Result<(), Error> {
+	let value = from_value::<_Inclusive10To100>(json)?;
+
+	assert_eq!(_Inclusive10To100(inner), value);
+	Ok(())
+}
+
+#[test_case(json!(9); "9")]
+#[test_case(json!(101); "101")]
+fn deserialize_inclusive_error(json: Value) {
+	let value = from_value::<_Inclusive10To100>(json);
+
+	assert!(value.is_err());
+}
+
+#[test_case(json!(11), 11; "11")]
+#[test_case(json!(50), 50; "50")]
+#[test_case(json!(99), 99; "99")]
+fn deserialize_exclusive(json: Value, inner: i32) -> Result<(), Error> {
+	let value = from_value::<_Exclusive10To100>(json)?;
+
+	assert_eq!(_Exclusive10To100(inner), value);
+	Ok(())
+}
+
+#[test_case(json!(10); "10")]
+#[test_case(json!(100); "100")]
+fn deserialize_exclusive_error(json: Value) {
+	let value = from_value::<_Exclusive10To100>(json);
+
+	assert!(value.is_err());
 }


### PR DESCRIPTION
fixes: #742

`Deserialize` is now derived automatically for `InRange` derives, validating the parsed data to be in a valid range.