### PR TITLE
add F32 not nan tooling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3581,6 +3581,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libyaml-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e126dda6f34391ab7b444f9922055facc83c07a910da3eb16f1e4d9c45dc777"
+
+[[package]]
 name = "light"
 version = "0.1.0"
 dependencies = [
@@ -4817,6 +4823,7 @@ dependencies = [
  "tracing",
  "unic-langid",
  "uuid",
+ "yaml_serde",
  "zyheeda_core",
 ]
 
@@ -6994,6 +7001,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a62ce76d9b56901b19a74f19431b0d8b3bc7ca4ad685a746dfd78ca8f4fc6bda"
 
 [[package]]
+name = "yaml_serde"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c7c1b1a6a7c8a6b2741a6c21a4f8918e51899b111cfa08d1288202656e3975"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "libyaml-rs",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "yazi"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7051,4 +7071,5 @@ dependencies = [
  "test-case",
  "testing",
  "tracing",
+ "yaml_serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ tracing = "0.1.41"
 unic-langid = { version = "0.9.6", features = ["macros"] }
 uuid = "1.16.0"
 test-case = "3.3.1"
+yaml_serde = "0.10"
 
 # internal
 common = { path = "src/plugins/common" }
@@ -82,6 +83,7 @@ zyheeda_core.workspace = true
 # external
 mockall.workspace = true
 test-case.workspace = true
+yaml_serde.workspace = true
 
 # internal
 testing.workspace = true

--- a/src/plugins/common/src/tools/vec_not_nan.rs
+++ b/src/plugins/common/src/tools/vec_not_nan.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use std::{cmp::Ordering, hash::Hash, ops::Deref};
+use std::{cmp::Ordering, hash::Hash};
 use zyheeda_core::prelude::*;
 
 #[macro_export]
@@ -16,23 +16,6 @@ pub struct VecNotNan<const N: usize>(pub [F32NotNan; N]);
 
 impl<const N: usize> VecNotNan<N> {
 	pub const ZERO: Self = Self([F32NotNan::ZERO; N]);
-
-	pub const fn try_from_array(array: [f32; N]) -> Result<Self, IsNaN<N>> {
-		let mut vec = [F32NotNan::ZERO; N];
-		let mut i = 0;
-
-		while i < N {
-			let Ok(value) = F32NotNan::try_from_f32(array[i]) else {
-				return Err(IsNaN(array));
-			};
-
-			vec[i] = value;
-
-			i += 1;
-		}
-
-		Ok(Self(vec))
-	}
 }
 
 impl<const N: usize> Default for VecNotNan<N> {
@@ -71,17 +54,35 @@ impl<const N: usize> PartialOrd for VecNotNan<N> {
 	}
 }
 
+impl<const N: usize> TryFrom<[f32; N]> for VecNotNan<N> {
+	type Error = IsNaN<N>;
+
+	fn try_from(array: [f32; N]) -> Result<Self, Self::Error> {
+		let mut vec = [F32NotNan::ZERO; N];
+
+		for i in 0..N {
+			let Ok(value) = F32NotNan::try_from_f32(array[i]) else {
+				return Err(IsNaN(array));
+			};
+
+			vec[i] = value;
+		}
+
+		Ok(Self(vec))
+	}
+}
+
 impl TryFrom<Vec3> for VecNotNan<3> {
 	type Error = IsNaN<3>;
 
 	fn try_from(vec: Vec3) -> Result<Self, Self::Error> {
-		Self::try_from_array(vec.to_array())
+		Self::try_from(vec.to_array())
 	}
 }
 
 impl From<VecNotNan<3>> for Vec3 {
-	fn from(VecNotNan(vec): VecNotNan<3>) -> Self {
-		Vec3::from_array(vec.map(|v| *v.deref()))
+	fn from(VecNotNan([x, y, z]): VecNotNan<3>) -> Self {
+		Vec3::new(*x, *y, *z)
 	}
 }
 
@@ -92,8 +93,8 @@ impl From<&'_ VecNotNan<3>> for Vec3 {
 }
 
 impl From<VecNotNan<2>> for Vec2 {
-	fn from(VecNotNan(vec): VecNotNan<2>) -> Self {
-		Vec2::from_array(vec.map(|v| *v.deref()))
+	fn from(VecNotNan([x, y]): VecNotNan<2>) -> Self {
+		Vec2::new(*x, *y)
 	}
 }
 
@@ -136,10 +137,10 @@ mod tests {
 
 	#[test]
 	fn crate_node() {
-		let node = VecNotNan::try_from(Vec3::new(1., 2., 3.));
+		let node = VecNotNan::try_from([1., 2., 3.]);
 
 		assert_eq!(
-			Ok(const { VecNotNan([f32_not_nan!(1.), f32_not_nan!(2.), f32_not_nan!(3.),]) }),
+			Ok(const { VecNotNan([f32_not_nan!(1.), f32_not_nan!(2.), f32_not_nan!(3.)]) }),
 			node
 		);
 	}

--- a/src/plugins/common/src/tools/vec_not_nan.rs
+++ b/src/plugins/common/src/tools/vec_not_nan.rs
@@ -1,11 +1,12 @@
 use bevy::prelude::*;
-use std::{cmp::Ordering, hash::Hash};
+use std::{cmp::Ordering, hash::Hash, ops::Deref};
+use zyheeda_core::prelude::F32NotNan;
 
 #[macro_export]
 macro_rules! vec3_not_nan {
 	($x:literal, $y:literal, $z:literal $(,)?) => {{
 		const VEC: $crate::tools::vec_not_nan::VecNotNan<3> =
-			match $crate::tools::vec_not_nan::VecNotNan::try_from_coords([$x, $y, $z]) {
+			match $crate::tools::vec_not_nan::VecNotNan::try_from_array([$x, $y, $z]) {
 				Ok(vec) => vec,
 				Err(_) => panic!("Vector is `NaN`"),
 			};
@@ -17,7 +18,7 @@ macro_rules! vec3_not_nan {
 macro_rules! vec2_not_nan {
 	($x:literal, $y:literal $(,)?) => {{
 		const VEC: $crate::tools::vec_not_nan::VecNotNan<2> =
-			match $crate::tools::vec_not_nan::VecNotNan::try_from_coords([$x, $y]) {
+			match $crate::tools::vec_not_nan::VecNotNan::try_from_array([$x, $y]) {
 				Ok(vec) => vec,
 				Err(_) => panic!("Vector is `NaN`"),
 			};
@@ -27,18 +28,21 @@ macro_rules! vec2_not_nan {
 }
 
 #[derive(Debug, PartialEq, Clone, Copy)]
-pub struct VecNotNan<const N: usize>([f32; N]);
+pub struct VecNotNan<const N: usize>(pub [F32NotNan; N]);
 
 impl<const N: usize> VecNotNan<N> {
-	pub const ZERO: Self = Self([0.; N]);
+	pub const ZERO: Self = Self([F32NotNan::ZERO; N]);
 
-	pub const fn try_from_coords(vec: [f32; N]) -> Result<Self, IsNaN<N>> {
+	pub const fn try_from_array(array: [f32; N]) -> Result<Self, IsNaN<N>> {
+		let mut vec = [F32NotNan::ZERO; N];
 		let mut i = 0;
 
 		while i < N {
-			if vec[i].is_nan() {
-				return Err(IsNaN(vec));
-			}
+			let Ok(value) = F32NotNan::try_from_f32(array[i]) else {
+				return Err(IsNaN(array));
+			};
+
+			vec[i] = value;
 
 			i += 1;
 		}
@@ -49,7 +53,7 @@ impl<const N: usize> VecNotNan<N> {
 
 impl<const N: usize> Default for VecNotNan<N> {
 	fn default() -> Self {
-		Self([0.0; N])
+		Self([F32NotNan::ZERO; N])
 	}
 }
 
@@ -59,7 +63,7 @@ impl<const N: usize> Hash for VecNotNan<N> {
 	fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
 		for v in self.0 {
 			let bits = match v {
-				0.0 => 0,
+				F32NotNan::ZERO => 0,
 				v => v.to_bits(),
 			};
 
@@ -87,31 +91,31 @@ impl TryFrom<Vec3> for VecNotNan<3> {
 	type Error = IsNaN<3>;
 
 	fn try_from(vec: Vec3) -> Result<Self, Self::Error> {
-		Self::try_from_coords(vec.to_array())
+		Self::try_from_array(vec.to_array())
 	}
 }
 
 impl From<VecNotNan<3>> for Vec3 {
 	fn from(VecNotNan(vec): VecNotNan<3>) -> Self {
-		Vec3::from_array(vec)
+		Vec3::from_array(vec.map(|v| *v.deref()))
 	}
 }
 
 impl From<&'_ VecNotNan<3>> for Vec3 {
-	fn from(VecNotNan(vec): &VecNotNan<3>) -> Self {
-		Vec3::from_array(*vec)
+	fn from(vec: &VecNotNan<3>) -> Self {
+		Vec3::from(*vec)
 	}
 }
 
 impl From<VecNotNan<2>> for Vec2 {
 	fn from(VecNotNan(vec): VecNotNan<2>) -> Self {
-		Vec2::from_array(vec)
+		Vec2::from_array(vec.map(|v| *v.deref()))
 	}
 }
 
 impl From<&'_ VecNotNan<2>> for Vec2 {
-	fn from(VecNotNan(vec): &VecNotNan<2>) -> Self {
-		Vec2::from_array(*vec)
+	fn from(vec: &VecNotNan<2>) -> Self {
+		Vec2::from(*vec)
 	}
 }
 
@@ -135,6 +139,7 @@ impl<const N: usize> PartialEq for IsNaN<N> {
 
 #[cfg(test)]
 mod tests {
+	#![allow(clippy::unwrap_used)]
 	use super::*;
 	use std::hash::{DefaultHasher, Hasher};
 	use test_case::test_case;
@@ -149,7 +154,14 @@ mod tests {
 	fn crate_node() {
 		let node = VecNotNan::try_from(Vec3::new(1., 2., 3.));
 
-		assert_eq!(Ok(VecNotNan([1., 2., 3.])), node);
+		assert_eq!(
+			Ok(VecNotNan([
+				F32NotNan::try_from_f32(1.).unwrap(),
+				F32NotNan::try_from_f32(2.).unwrap(),
+				F32NotNan::try_from_f32(3.).unwrap(),
+			])),
+			node
+		);
 	}
 
 	#[test]

--- a/src/plugins/common/src/tools/vec_not_nan.rs
+++ b/src/plugins/common/src/tools/vec_not_nan.rs
@@ -1,29 +1,13 @@
 use bevy::prelude::*;
 use std::{cmp::Ordering, hash::Hash, ops::Deref};
-use zyheeda_core::prelude::F32NotNan;
+use zyheeda_core::prelude::*;
 
 #[macro_export]
-macro_rules! vec3_not_nan {
-	($x:literal, $y:literal, $z:literal $(,)?) => {{
-		const VEC: $crate::tools::vec_not_nan::VecNotNan<3> =
-			match $crate::tools::vec_not_nan::VecNotNan::try_from_array([$x, $y, $z]) {
-				Ok(vec) => vec,
-				Err(_) => panic!("Vector is `NaN`"),
-			};
-
-		VEC
-	}};
-}
-#[macro_export]
-macro_rules! vec2_not_nan {
-	($x:literal, $y:literal $(,)?) => {{
-		const VEC: $crate::tools::vec_not_nan::VecNotNan<2> =
-			match $crate::tools::vec_not_nan::VecNotNan::try_from_array([$x, $y]) {
-				Ok(vec) => vec,
-				Err(_) => panic!("Vector is `NaN`"),
-			};
-
-		VEC
+macro_rules! vec_not_nan {
+	($($c:literal),+ $(,)?) => {{
+		$crate::tools::vec_not_nan::VecNotNan([
+			$(zyheeda_core::prelude::f32_not_nan!($c),)+
+		])
 	}};
 }
 
@@ -155,11 +139,7 @@ mod tests {
 		let node = VecNotNan::try_from(Vec3::new(1., 2., 3.));
 
 		assert_eq!(
-			Ok(VecNotNan([
-				F32NotNan::try_from_f32(1.).unwrap(),
-				F32NotNan::try_from_f32(2.).unwrap(),
-				F32NotNan::try_from_f32(3.).unwrap(),
-			])),
+			Ok(const { VecNotNan([f32_not_nan!(1.), f32_not_nan!(2.), f32_not_nan!(3.),]) }),
 			node
 		);
 	}

--- a/src/plugins/common/src/tools/vec_not_nan.rs
+++ b/src/plugins/common/src/tools/vec_not_nan.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use std::{cmp::Ordering, hash::Hash};
+use std::hash::Hash;
 use zyheeda_core::prelude::*;
 
 #[macro_export]
@@ -11,7 +11,7 @@ macro_rules! vec_not_nan {
 	}};
 }
 
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Clone, Copy)]
 pub struct VecNotNan<const N: usize>(pub [F32NotNan; N]);
 
 impl<const N: usize> VecNotNan<N> {
@@ -21,36 +21,6 @@ impl<const N: usize> VecNotNan<N> {
 impl<const N: usize> Default for VecNotNan<N> {
 	fn default() -> Self {
 		Self([F32NotNan::ZERO; N])
-	}
-}
-
-impl<const N: usize> Eq for VecNotNan<N> {}
-
-impl<const N: usize> Hash for VecNotNan<N> {
-	fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-		for v in self.0 {
-			let bits = match v {
-				F32NotNan::ZERO => 0,
-				v => v.to_bits(),
-			};
-
-			bits.hash(state);
-		}
-	}
-}
-
-impl<const N: usize> Ord for VecNotNan<N> {
-	fn cmp(&self, other: &Self) -> Ordering {
-		self.0
-			.iter()
-			.zip(other.0)
-			.fold(Ordering::Equal, |acc, (a, b)| acc.then(a.total_cmp(&b)))
-	}
-}
-
-impl<const N: usize> PartialOrd for VecNotNan<N> {
-	fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-		Some(self.cmp(other))
 	}
 }
 
@@ -126,14 +96,6 @@ impl<const N: usize> PartialEq for IsNaN<N> {
 mod tests {
 	#![allow(clippy::unwrap_used)]
 	use super::*;
-	use std::hash::{DefaultHasher, Hasher};
-	use test_case::test_case;
-
-	fn hash<const N: usize>(node: VecNotNan<N>) -> u64 {
-		let mut hasher = DefaultHasher::new();
-		node.hash(&mut hasher);
-		hasher.finish()
-	}
 
 	#[test]
 	fn crate_node() {
@@ -150,36 +112,5 @@ mod tests {
 		let node = VecNotNan::try_from(Vec3::NAN);
 
 		assert_eq!(Err(IsNaN([f32::NAN, f32::NAN, f32::NAN])), node);
-	}
-
-	#[test_case(Vec3::new(1., 2., 3.), Vec3::new(-1., 2., 3.); "x differs")]
-	#[test_case(Vec3::new(1., 2., 3.), Vec3::new(1., -2., 3.); "y differs")]
-	#[test_case(Vec3::new(1., 2., 3.), Vec3::new(1., 2., -3.); "z differs")]
-	fn hashes_differ(a: Vec3, b: Vec3) -> Result<(), IsNaN<3>> {
-		let a = VecNotNan::try_from(a)?;
-		let b = VecNotNan::try_from(b)?;
-
-		assert_ne!(hash(a), hash(b));
-		Ok(())
-	}
-
-	#[test]
-	fn hashes_match() -> Result<(), IsNaN<3>> {
-		let a = VecNotNan::try_from(Vec3::new(1., 2., 3.))?;
-		let b = VecNotNan::try_from(Vec3::new(1., 2., 3.))?;
-
-		assert_eq!(hash(a), hash(b));
-		Ok(())
-	}
-
-	#[test_case(Vec3::new(-0., 2., 3.); "x zero")]
-	#[test_case(Vec3::new(1., -0., 3.); "y zero")]
-	#[test_case(Vec3::new(1., 2., -0.); "z zero")]
-	fn hashes_match_with_zero(v: Vec3) -> Result<(), IsNaN<3>> {
-		let a = VecNotNan::try_from(v)?;
-		let b = VecNotNan::try_from(v.abs())?;
-
-		assert_eq!(hash(a), hash(b));
-		Ok(())
 	}
 }

--- a/src/plugins/common/src/traits/handles_physics.rs
+++ b/src/plugins/common/src/traits/handles_physics.rs
@@ -324,10 +324,8 @@ pub enum HoverMode {
 }
 
 impl HoverMode {
-	pub fn collider_or_direction_from(Vec3 { x, y, z }: Vec3) -> Option<Self> {
-		let vec = VecNotNan::try_from_array([x, y, z]).ok()?;
-
-		Some(Self::ColliderOrDirectionFrom(vec))
+	pub fn collider_or_direction_from(vec: Vec3) -> Option<Self> {
+		Some(Self::ColliderOrDirectionFrom(vec.try_into().ok()?))
 	}
 }
 

--- a/src/plugins/common/src/traits/handles_physics.rs
+++ b/src/plugins/common/src/traits/handles_physics.rs
@@ -325,7 +325,7 @@ pub enum HoverMode {
 
 impl HoverMode {
 	pub fn collider_or_direction_from(Vec3 { x, y, z }: Vec3) -> Option<Self> {
-		let vec = VecNotNan::try_from_coords([x, y, z]).ok()?;
+		let vec = VecNotNan::try_from_array([x, y, z]).ok()?;
 
 		Some(Self::ColliderOrDirectionFrom(vec))
 	}

--- a/src/plugins/map_generation/src/mesh_grid_graph.rs
+++ b/src/plugins/map_generation/src/mesh_grid_graph.rs
@@ -314,7 +314,7 @@ impl Display for TriangleEdgeError {
 mod test {
 	#![allow(clippy::unwrap_used)]
 	use super::*;
-	use common::vec3_not_nan;
+	use common::vec_not_nan;
 
 	macro_rules! neighbors {
 		(node($($n:expr),* $(,)?)) => {
@@ -372,9 +372,9 @@ mod test {
 		/// ```
 		#[test]
 		fn set_nodes_of_one_triangle() {
-			let a = vec3_not_nan!(0., 0., 0.);
-			let b = vec3_not_nan!(1., 0., 0.);
-			let c = vec3_not_nan!(1., 0., 1.);
+			let a = vec_not_nan!(0., 0., 0.);
+			let b = vec_not_nan!(1., 0., 0.);
+			let c = vec_not_nan!(1., 0., 1.);
 
 			let graph = MeshGridGraph::try_from_triangles([[a, b, c]].into_iter());
 
@@ -396,10 +396,10 @@ mod test {
 		/// ```
 		#[test]
 		fn set_nodes_of_two_connected_triangles() {
-			let a = vec3_not_nan!(0., 0., 0.);
-			let b = vec3_not_nan!(1., 0., 0.);
-			let c = vec3_not_nan!(1., 0., 1.);
-			let d = vec3_not_nan!(0., 0., 1.);
+			let a = vec_not_nan!(0., 0., 0.);
+			let b = vec_not_nan!(1., 0., 0.);
+			let c = vec_not_nan!(1., 0., 1.);
+			let d = vec_not_nan!(0., 0., 1.);
 
 			let graph = MeshGridGraph::try_from_triangles([[a, b, c], [a, c, d]].into_iter());
 
@@ -421,10 +421,10 @@ mod test {
 		/// ```
 		#[test]
 		fn set_nodes_of_two_connected_triangles_when_edge_reversed() {
-			let a = vec3_not_nan!(0., 0., 0.);
-			let b = vec3_not_nan!(1., 0., 0.);
-			let c = vec3_not_nan!(1., 0., 1.);
-			let d = vec3_not_nan!(0., 0., 1.);
+			let a = vec_not_nan!(0., 0., 0.);
+			let b = vec_not_nan!(1., 0., 0.);
+			let c = vec_not_nan!(1., 0., 1.);
+			let d = vec_not_nan!(0., 0., 1.);
 
 			let graph = MeshGridGraph::try_from_triangles([[a, b, c], [c, a, d]].into_iter());
 
@@ -446,8 +446,8 @@ mod test {
 		/// ```
 		#[test]
 		fn prevent_node_neighbor_self_reference() {
-			let a = vec3_not_nan!(0., 0., 0.);
-			let b = vec3_not_nan!(1., 0., 0.);
+			let a = vec_not_nan!(0., 0., 0.);
+			let b = vec_not_nan!(1., 0., 0.);
 
 			let graph = MeshGridGraph::try_from_triangles([[a, b, b]].into_iter());
 
@@ -471,10 +471,10 @@ mod test {
 		/// ```
 		#[test]
 		fn do_not_connect_across_shared_edge_when_concave() {
-			let a = vec3_not_nan!(0., 0., 0.);
-			let b = vec3_not_nan!(1., 0., 0.1);
-			let c = vec3_not_nan!(1., 0., 1.1);
-			let d = vec3_not_nan!(2., 0., 0.);
+			let a = vec_not_nan!(0., 0., 0.);
+			let b = vec_not_nan!(1., 0., 0.1);
+			let c = vec_not_nan!(1., 0., 1.1);
+			let d = vec_not_nan!(2., 0., 0.);
 
 			let graph = MeshGridGraph::try_from_triangles([[a, b, c], [b, c, d]].into_iter());
 
@@ -498,10 +498,10 @@ mod test {
 		/// ```
 		#[test]
 		fn do_not_connect_across_shared_edge_when_concave_reversed() {
-			let a = vec3_not_nan!(0., 0., 1.1);
-			let b = vec3_not_nan!(1., 0., 0.);
-			let c = vec3_not_nan!(1., 0., 1.);
-			let d = vec3_not_nan!(2., 0., 1.1);
+			let a = vec_not_nan!(0., 0., 1.1);
+			let b = vec_not_nan!(1., 0., 0.);
+			let c = vec_not_nan!(1., 0., 1.);
+			let d = vec_not_nan!(2., 0., 1.1);
 
 			let graph = MeshGridGraph::try_from_triangles([[a, b, c], [b, c, d]].into_iter());
 
@@ -538,12 +538,12 @@ mod test {
 		/// ```
 		#[test]
 		fn do_not_connect_nodes_on_acute_angles() {
-			let a = vec3_not_nan!(0., 0., 0.);
-			let b = vec3_not_nan!(1., 0., 0.);
-			let c = vec3_not_nan!(1., 0., 1.);
-			let d = vec3_not_nan!(0., 0., 1.);
-			let e = vec3_not_nan!(2., 0., 0.);
-			let f = vec3_not_nan!(2., 0., 1.);
+			let a = vec_not_nan!(0., 0., 0.);
+			let b = vec_not_nan!(1., 0., 0.);
+			let c = vec_not_nan!(1., 0., 1.);
+			let d = vec_not_nan!(0., 0., 1.);
+			let e = vec_not_nan!(2., 0., 0.);
+			let f = vec_not_nan!(2., 0., 1.);
 
 			let graph = MeshGridGraph::try_from_triangles(
 				[[a, b, c], [a, d, c], [b, e, f], [b, c, f]].into_iter(),
@@ -574,10 +574,10 @@ mod test {
 		/// ```
 		#[test]
 		fn set_nodes_of_two_connected_triangles_within_minimal_error() {
-			let a = vec3_not_nan!(0., 0., 0.);
-			let b = vec3_not_nan!(1., 0., -1e-6);
-			let c = vec3_not_nan!(1., 0., 1.);
-			let d = vec3_not_nan!(0., 0., 1.);
+			let a = vec_not_nan!(0., 0., 0.);
+			let b = vec_not_nan!(1., 0., -1e-6);
+			let c = vec_not_nan!(1., 0., 1.);
+			let d = vec_not_nan!(0., 0., 1.);
 
 			let graph = MeshGridGraph::try_from_triangles([[a, b, c], [a, c, d]].into_iter());
 
@@ -601,12 +601,12 @@ mod test {
 		/// ```
 		#[test]
 		fn identify_clearance() {
-			let inner = vec3_not_nan!(0., 0., 0.);
+			let inner = vec_not_nan!(0., 0., 0.);
 			let boundary_vertices = [
-				vec3_not_nan!(-1., 0., 0.),
-				vec3_not_nan!(0., 0., -1.),
-				vec3_not_nan!(1., 0., 0.),
-				vec3_not_nan!(0., 0., 1.),
+				vec_not_nan!(-1., 0., 0.),
+				vec_not_nan!(0., 0., -1.),
+				vec_not_nan!(1., 0., 0.),
+				vec_not_nan!(0., 0., 1.),
 			];
 			let triangles = [
 				[inner, boundary_vertices[0], boundary_vertices[1]],
@@ -655,91 +655,91 @@ mod test {
 			let triangles = [
 				// A0
 				[
-					vec3_not_nan!(0., 0., 0.),
-					vec3_not_nan!(0., 0., 1.),
-					vec3_not_nan!(1., 0., 0.),
+					vec_not_nan!(0., 0., 0.),
+					vec_not_nan!(0., 0., 1.),
+					vec_not_nan!(1., 0., 0.),
 				],
 				[
-					vec3_not_nan!(0., 0., 1.),
-					vec3_not_nan!(1., 0., 0.),
-					vec3_not_nan!(1., 0., 1.),
+					vec_not_nan!(0., 0., 1.),
+					vec_not_nan!(1., 0., 0.),
+					vec_not_nan!(1., 0., 1.),
 				],
 				// B0
 				[
-					vec3_not_nan!(1., 0., 0.),
-					vec3_not_nan!(1., 0., 1.),
-					vec3_not_nan!(2., 0., 0.),
+					vec_not_nan!(1., 0., 0.),
+					vec_not_nan!(1., 0., 1.),
+					vec_not_nan!(2., 0., 0.),
 				],
 				[
-					vec3_not_nan!(1., 0., 1.),
-					vec3_not_nan!(2., 0., 0.),
-					vec3_not_nan!(2., 0., 1.),
+					vec_not_nan!(1., 0., 1.),
+					vec_not_nan!(2., 0., 0.),
+					vec_not_nan!(2., 0., 1.),
 				],
 				// C0
 				[
-					vec3_not_nan!(2., 0., 0.),
-					vec3_not_nan!(2., 0., 1.),
-					vec3_not_nan!(3., 0., 0.),
+					vec_not_nan!(2., 0., 0.),
+					vec_not_nan!(2., 0., 1.),
+					vec_not_nan!(3., 0., 0.),
 				],
 				[
-					vec3_not_nan!(2., 0., 1.),
-					vec3_not_nan!(3., 0., 0.),
-					vec3_not_nan!(3., 0., 1.),
+					vec_not_nan!(2., 0., 1.),
+					vec_not_nan!(3., 0., 0.),
+					vec_not_nan!(3., 0., 1.),
 				],
 				// A1
 				[
-					vec3_not_nan!(0., 0., 1.),
-					vec3_not_nan!(0., 0., 2.),
-					vec3_not_nan!(1., 0., 1.),
+					vec_not_nan!(0., 0., 1.),
+					vec_not_nan!(0., 0., 2.),
+					vec_not_nan!(1., 0., 1.),
 				],
 				[
-					vec3_not_nan!(0., 0., 2.),
-					vec3_not_nan!(1., 0., 1.),
-					vec3_not_nan!(1., 0., 2.),
+					vec_not_nan!(0., 0., 2.),
+					vec_not_nan!(1., 0., 1.),
+					vec_not_nan!(1., 0., 2.),
 				],
 				// B1
 				[
-					vec3_not_nan!(1., 0., 1.),
-					vec3_not_nan!(1., 0., 2.),
-					vec3_not_nan!(2., 0., 1.),
+					vec_not_nan!(1., 0., 1.),
+					vec_not_nan!(1., 0., 2.),
+					vec_not_nan!(2., 0., 1.),
 				],
 				[
-					vec3_not_nan!(1., 0., 2.),
-					vec3_not_nan!(2., 0., 1.),
-					vec3_not_nan!(2., 0., 2.),
+					vec_not_nan!(1., 0., 2.),
+					vec_not_nan!(2., 0., 1.),
+					vec_not_nan!(2., 0., 2.),
 				],
 				// C1
 				[
-					vec3_not_nan!(2., 0., 1.),
-					vec3_not_nan!(2., 0., 2.),
-					vec3_not_nan!(3., 0., 1.),
+					vec_not_nan!(2., 0., 1.),
+					vec_not_nan!(2., 0., 2.),
+					vec_not_nan!(3., 0., 1.),
 				],
 				[
-					vec3_not_nan!(2., 0., 2.),
-					vec3_not_nan!(3., 0., 1.),
-					vec3_not_nan!(3., 0., 2.),
+					vec_not_nan!(2., 0., 2.),
+					vec_not_nan!(3., 0., 1.),
+					vec_not_nan!(3., 0., 2.),
 				],
 				// A2
 				[
-					vec3_not_nan!(0., 0., 2.),
-					vec3_not_nan!(0., 0., 3.),
-					vec3_not_nan!(1., 0., 2.),
+					vec_not_nan!(0., 0., 2.),
+					vec_not_nan!(0., 0., 3.),
+					vec_not_nan!(1., 0., 2.),
 				],
 				[
-					vec3_not_nan!(0., 0., 3.),
-					vec3_not_nan!(1., 0., 2.),
-					vec3_not_nan!(1., 0., 3.),
+					vec_not_nan!(0., 0., 3.),
+					vec_not_nan!(1., 0., 2.),
+					vec_not_nan!(1., 0., 3.),
 				],
 				// C2
 				[
-					vec3_not_nan!(2., 0., 2.),
-					vec3_not_nan!(3., 0., 2.),
-					vec3_not_nan!(2., 0., 3.),
+					vec_not_nan!(2., 0., 2.),
+					vec_not_nan!(3., 0., 2.),
+					vec_not_nan!(2., 0., 3.),
 				],
 				[
-					vec3_not_nan!(3., 0., 2.),
-					vec3_not_nan!(2., 0., 3.),
-					vec3_not_nan!(3., 0., 3.),
+					vec_not_nan!(3., 0., 2.),
+					vec_not_nan!(2., 0., 3.),
+					vec_not_nan!(3., 0., 3.),
 				],
 			];
 
@@ -788,179 +788,179 @@ mod test {
 			let triangles = [
 				// A0
 				[
-					vec3_not_nan!(0., 0., 0.),
-					vec3_not_nan!(0., 0., 1.),
-					vec3_not_nan!(1., 0., 0.),
+					vec_not_nan!(0., 0., 0.),
+					vec_not_nan!(0., 0., 1.),
+					vec_not_nan!(1., 0., 0.),
 				],
 				[
-					vec3_not_nan!(0., 0., 1.),
-					vec3_not_nan!(1., 0., 0.),
-					vec3_not_nan!(1., 0., 1.),
+					vec_not_nan!(0., 0., 1.),
+					vec_not_nan!(1., 0., 0.),
+					vec_not_nan!(1., 0., 1.),
 				],
 				// B0
 				[
-					vec3_not_nan!(1., 0., 0.),
-					vec3_not_nan!(1., 0., 1.),
-					vec3_not_nan!(2., 0., 0.),
+					vec_not_nan!(1., 0., 0.),
+					vec_not_nan!(1., 0., 1.),
+					vec_not_nan!(2., 0., 0.),
 				],
 				[
-					vec3_not_nan!(1., 0., 1.),
-					vec3_not_nan!(2., 0., 0.),
-					vec3_not_nan!(2., 0., 1.),
+					vec_not_nan!(1., 0., 1.),
+					vec_not_nan!(2., 0., 0.),
+					vec_not_nan!(2., 0., 1.),
 				],
 				// C0
 				[
-					vec3_not_nan!(2., 0., 0.),
-					vec3_not_nan!(2., 0., 1.),
-					vec3_not_nan!(3., 0., 0.),
+					vec_not_nan!(2., 0., 0.),
+					vec_not_nan!(2., 0., 1.),
+					vec_not_nan!(3., 0., 0.),
 				],
 				[
-					vec3_not_nan!(2., 0., 1.),
-					vec3_not_nan!(3., 0., 0.),
-					vec3_not_nan!(3., 0., 1.),
+					vec_not_nan!(2., 0., 1.),
+					vec_not_nan!(3., 0., 0.),
+					vec_not_nan!(3., 0., 1.),
 				],
 				// D0
 				[
-					vec3_not_nan!(3., 0., 0.),
-					vec3_not_nan!(3., 0., 1.),
-					vec3_not_nan!(4., 0., 0.),
+					vec_not_nan!(3., 0., 0.),
+					vec_not_nan!(3., 0., 1.),
+					vec_not_nan!(4., 0., 0.),
 				],
 				[
-					vec3_not_nan!(3., 0., 1.),
-					vec3_not_nan!(4., 0., 0.),
-					vec3_not_nan!(4., 0., 1.),
+					vec_not_nan!(3., 0., 1.),
+					vec_not_nan!(4., 0., 0.),
+					vec_not_nan!(4., 0., 1.),
 				],
 				// A1
 				[
-					vec3_not_nan!(0., 0., 1.),
-					vec3_not_nan!(0., 0., 2.),
-					vec3_not_nan!(1., 0., 1.),
+					vec_not_nan!(0., 0., 1.),
+					vec_not_nan!(0., 0., 2.),
+					vec_not_nan!(1., 0., 1.),
 				],
 				[
-					vec3_not_nan!(0., 0., 2.),
-					vec3_not_nan!(1., 0., 1.),
-					vec3_not_nan!(1., 0., 2.),
+					vec_not_nan!(0., 0., 2.),
+					vec_not_nan!(1., 0., 1.),
+					vec_not_nan!(1., 0., 2.),
 				],
 				// B1
 				[
-					vec3_not_nan!(1., 0., 1.),
-					vec3_not_nan!(1., 0., 2.),
-					vec3_not_nan!(2., 0., 1.),
+					vec_not_nan!(1., 0., 1.),
+					vec_not_nan!(1., 0., 2.),
+					vec_not_nan!(2., 0., 1.),
 				],
 				[
-					vec3_not_nan!(1., 0., 2.),
-					vec3_not_nan!(2., 0., 1.),
-					vec3_not_nan!(2., 0., 2.),
+					vec_not_nan!(1., 0., 2.),
+					vec_not_nan!(2., 0., 1.),
+					vec_not_nan!(2., 0., 2.),
 				],
 				// C1
 				[
-					vec3_not_nan!(2., 0., 1.),
-					vec3_not_nan!(2., 0., 2.),
-					vec3_not_nan!(3., 0., 1.),
+					vec_not_nan!(2., 0., 1.),
+					vec_not_nan!(2., 0., 2.),
+					vec_not_nan!(3., 0., 1.),
 				],
 				[
-					vec3_not_nan!(2., 0., 2.),
-					vec3_not_nan!(3., 0., 1.),
-					vec3_not_nan!(3., 0., 2.),
+					vec_not_nan!(2., 0., 2.),
+					vec_not_nan!(3., 0., 1.),
+					vec_not_nan!(3., 0., 2.),
 				],
 				// D1
 				[
-					vec3_not_nan!(3., 0., 1.),
-					vec3_not_nan!(3., 0., 2.),
-					vec3_not_nan!(4., 0., 1.),
+					vec_not_nan!(3., 0., 1.),
+					vec_not_nan!(3., 0., 2.),
+					vec_not_nan!(4., 0., 1.),
 				],
 				[
-					vec3_not_nan!(3., 0., 2.),
-					vec3_not_nan!(4., 0., 1.),
-					vec3_not_nan!(4., 0., 2.),
+					vec_not_nan!(3., 0., 2.),
+					vec_not_nan!(4., 0., 1.),
+					vec_not_nan!(4., 0., 2.),
 				],
 				// A2
 				[
-					vec3_not_nan!(0., 0., 2.),
-					vec3_not_nan!(0., 0., 3.),
-					vec3_not_nan!(1., 0., 2.),
+					vec_not_nan!(0., 0., 2.),
+					vec_not_nan!(0., 0., 3.),
+					vec_not_nan!(1., 0., 2.),
 				],
 				[
-					vec3_not_nan!(0., 0., 3.),
-					vec3_not_nan!(1., 0., 2.),
-					vec3_not_nan!(1., 0., 3.),
+					vec_not_nan!(0., 0., 3.),
+					vec_not_nan!(1., 0., 2.),
+					vec_not_nan!(1., 0., 3.),
 				],
 				// B2
 				[
-					vec3_not_nan!(1., 0., 2.),
-					vec3_not_nan!(1., 0., 3.),
-					vec3_not_nan!(2., 0., 2.),
+					vec_not_nan!(1., 0., 2.),
+					vec_not_nan!(1., 0., 3.),
+					vec_not_nan!(2., 0., 2.),
 				],
 				[
-					vec3_not_nan!(1., 0., 3.),
-					vec3_not_nan!(2., 0., 2.),
-					vec3_not_nan!(2., 0., 3.),
+					vec_not_nan!(1., 0., 3.),
+					vec_not_nan!(2., 0., 2.),
+					vec_not_nan!(2., 0., 3.),
 				],
 				// C2
 				[
-					vec3_not_nan!(2., 0., 2.),
-					vec3_not_nan!(2., 0., 3.),
-					vec3_not_nan!(3., 0., 2.),
+					vec_not_nan!(2., 0., 2.),
+					vec_not_nan!(2., 0., 3.),
+					vec_not_nan!(3., 0., 2.),
 				],
 				[
-					vec3_not_nan!(2., 0., 3.),
-					vec3_not_nan!(3., 0., 2.),
-					vec3_not_nan!(3., 0., 3.),
+					vec_not_nan!(2., 0., 3.),
+					vec_not_nan!(3., 0., 2.),
+					vec_not_nan!(3., 0., 3.),
 				],
 				// D2
 				[
-					vec3_not_nan!(3., 0., 2.),
-					vec3_not_nan!(3., 0., 3.),
-					vec3_not_nan!(4., 0., 2.),
+					vec_not_nan!(3., 0., 2.),
+					vec_not_nan!(3., 0., 3.),
+					vec_not_nan!(4., 0., 2.),
 				],
 				[
-					vec3_not_nan!(3., 0., 3.),
-					vec3_not_nan!(4., 0., 2.),
-					vec3_not_nan!(4., 0., 3.),
+					vec_not_nan!(3., 0., 3.),
+					vec_not_nan!(4., 0., 2.),
+					vec_not_nan!(4., 0., 3.),
 				],
 				// A3
 				[
-					vec3_not_nan!(0., 0., 3.),
-					vec3_not_nan!(0., 0., 4.),
-					vec3_not_nan!(1., 0., 3.),
+					vec_not_nan!(0., 0., 3.),
+					vec_not_nan!(0., 0., 4.),
+					vec_not_nan!(1., 0., 3.),
 				],
 				[
-					vec3_not_nan!(0., 0., 4.),
-					vec3_not_nan!(1., 0., 3.),
-					vec3_not_nan!(1., 0., 4.),
+					vec_not_nan!(0., 0., 4.),
+					vec_not_nan!(1., 0., 3.),
+					vec_not_nan!(1., 0., 4.),
 				],
 				// B3
 				[
-					vec3_not_nan!(1., 0., 3.),
-					vec3_not_nan!(1., 0., 4.),
-					vec3_not_nan!(2., 0., 3.),
+					vec_not_nan!(1., 0., 3.),
+					vec_not_nan!(1., 0., 4.),
+					vec_not_nan!(2., 0., 3.),
 				],
 				[
-					vec3_not_nan!(1., 0., 4.),
-					vec3_not_nan!(2., 0., 3.),
-					vec3_not_nan!(2., 0., 4.),
+					vec_not_nan!(1., 0., 4.),
+					vec_not_nan!(2., 0., 3.),
+					vec_not_nan!(2., 0., 4.),
 				],
 				// C3
 				[
-					vec3_not_nan!(2., 0., 3.),
-					vec3_not_nan!(2., 0., 4.),
-					vec3_not_nan!(3., 0., 3.),
+					vec_not_nan!(2., 0., 3.),
+					vec_not_nan!(2., 0., 4.),
+					vec_not_nan!(3., 0., 3.),
 				],
 				[
-					vec3_not_nan!(2., 0., 4.),
-					vec3_not_nan!(3., 0., 3.),
-					vec3_not_nan!(3., 0., 4.),
+					vec_not_nan!(2., 0., 4.),
+					vec_not_nan!(3., 0., 3.),
+					vec_not_nan!(3., 0., 4.),
 				],
 				// D3
 				[
-					vec3_not_nan!(3., 0., 3.),
-					vec3_not_nan!(3., 0., 4.),
-					vec3_not_nan!(4., 0., 3.),
+					vec_not_nan!(3., 0., 3.),
+					vec_not_nan!(3., 0., 4.),
+					vec_not_nan!(4., 0., 3.),
 				],
 				[
-					vec3_not_nan!(3., 0., 4.),
-					vec3_not_nan!(4., 0., 3.),
-					vec3_not_nan!(4., 0., 4.),
+					vec_not_nan!(3., 0., 4.),
+					vec_not_nan!(4., 0., 3.),
+					vec_not_nan!(4., 0., 4.),
 				],
 			];
 
@@ -1002,20 +1002,20 @@ mod test {
 			);
 		}
 
-		#[test_case([vec3_not_nan!(1., 2., 5.), vec3_not_nan!(1., 2., 6.), vec3_not_nan!(1., 2., 7.)]; "3")]
-		#[test_case([vec3_not_nan!(1., 2., 5.), vec3_not_nan!(1., 2., 6.), vec3_not_nan!(1., 2., 7.), vec3_not_nan!(1., 2., 8.)]; "4")]
+		#[test_case([vec_not_nan!(1., 2., 5.), vec_not_nan!(1., 2., 6.), vec_not_nan!(1., 2., 7.)]; "3")]
+		#[test_case([vec_not_nan!(1., 2., 5.), vec_not_nan!(1., 2., 6.), vec_not_nan!(1., 2., 7.), vec_not_nan!(1., 2., 8.)]; "4")]
 		fn return_error_when_more_than_2_triangles_share_same_edge<const N: usize>(
 			other_vertices: [VecNotNan<3>; N],
 		) {
-			let edge = (vec3_not_nan!(1., 2., 3.), vec3_not_nan!(1., 2., 4.));
+			let edge = (vec_not_nan!(1., 2., 3.), vec_not_nan!(1., 2., 4.));
 			let triangles = other_vertices.map(|o| [edge.0, edge.1, o]);
 
 			let graph = MeshGridGraph::try_from_triangles(triangles.into_iter());
 
 			assert_eq!(
 				Err(TriangleEdgeError(
-					vec3_not_nan!(1., 2., 3.),
-					vec3_not_nan!(1., 2., 4.)
+					vec_not_nan!(1., 2., 3.),
+					vec_not_nan!(1., 2., 4.)
 				)),
 				graph,
 			);
@@ -1028,7 +1028,7 @@ mod test {
 		#[test]
 		fn get_exact_translation() {
 			let graph = MeshGridGraph {
-				vertices: vec![vec3_not_nan!(1., 2., 3.), vec3_not_nan!(4., 5., 6.)],
+				vertices: vec![vec_not_nan!(1., 2., 3.), vec_not_nan!(4., 5., 6.)],
 				neighbors: neighbors![[], []],
 				clearance: vec![Clearance::INFINITY; 2],
 				..default()
@@ -1042,7 +1042,7 @@ mod test {
 		#[test]
 		fn get_closest_translation() {
 			let graph = MeshGridGraph {
-				vertices: vec![vec3_not_nan!(10., 2., 3.), vec3_not_nan!(1., 2., 3.)],
+				vertices: vec![vec_not_nan!(10., 2., 3.), vec_not_nan!(1., 2., 3.)],
 				neighbors: neighbors![[], []],
 				clearance: vec![Clearance::INFINITY; 2],
 				..default()
@@ -1057,9 +1057,9 @@ mod test {
 		fn get_closest_translation_with_non_zero_clearance() {
 			let graph = MeshGridGraph {
 				vertices: vec![
-					vec3_not_nan!(10., 2., 3.),
-					vec3_not_nan!(1., 2., 3.),
-					vec3_not_nan!(1., 2., 2.),
+					vec_not_nan!(10., 2., 3.),
+					vec_not_nan!(1., 2., 3.),
+					vec_not_nan!(1., 2., 2.),
 				],
 				neighbors: neighbors![[], [], []],
 				clearance: vec![Clearance::INFINITY, Clearance::NONE, Clearance::INFINITY],
@@ -1078,7 +1078,7 @@ mod test {
 		#[test]
 		fn neighbors_as_successors() {
 			let graph = MeshGridGraph {
-				vertices: vec![vec3_not_nan!(1., 2., 3.)],
+				vertices: vec![vec_not_nan!(1., 2., 3.)],
 				neighbors: neighbors![[1, 2]],
 				clearance: vec![Clearance::INFINITY; 2],
 				..default()
@@ -1096,9 +1096,9 @@ mod test {
 	fn setup_graph(max_los_fn: fn(LoSParams, &MeshGridGraph) -> Option<NodeId>) -> MeshGridGraph {
 		MeshGridGraph {
 			vertices: vec![
-				vec3_not_nan!(0., 0., 0.),
-				vec3_not_nan!(1., 0., 0.),
-				vec3_not_nan!(1., 0., 1.),
+				vec_not_nan!(0., 0., 0.),
+				vec_not_nan!(1., 0., 0.),
+				vec_not_nan!(1., 0., 1.),
 			],
 			neighbors: vec![vec![]; 3],
 			clearance: vec![Clearance::INFINITY; 3],

--- a/src/plugins/map_generation/src/mesh_grid_graph/clearance.rs
+++ b/src/plugins/map_generation/src/mesh_grid_graph/clearance.rs
@@ -117,16 +117,16 @@ mod tests {
 	#![allow(clippy::unwrap_used)]
 	use super::*;
 	use crate::mesh_grid_graph::test::neighbors;
-	use common::vec3_not_nan;
+	use common::vec_not_nan;
 
 	#[test]
 	fn set_first_border_node() {
 		let mut graph = MeshGridGraph {
 			vertices: vec![
-				vec3_not_nan!(0., 0., 0.),
-				vec3_not_nan!(0., 0., 1.),
-				vec3_not_nan!(1., 0., 0.),
-				vec3_not_nan!(1., 0., 1.),
+				vec_not_nan!(0., 0., 0.),
+				vec_not_nan!(0., 0., 1.),
+				vec_not_nan!(1., 0., 0.),
+				vec_not_nan!(1., 0., 1.),
 			],
 			neighbors: neighbors![[], [], [], []],
 			clearance: vec![
@@ -144,10 +144,10 @@ mod tests {
 		assert_eq!(
 			MeshGridGraph {
 				vertices: vec![
-					vec3_not_nan!(0., 0., 0.),
-					vec3_not_nan!(0., 0., 1.),
-					vec3_not_nan!(1., 0., 0.),
-					vec3_not_nan!(1., 0., 1.),
+					vec_not_nan!(0., 0., 0.),
+					vec_not_nan!(0., 0., 1.),
+					vec_not_nan!(1., 0., 0.),
+					vec_not_nan!(1., 0., 1.),
 				],
 				neighbors: neighbors![[], [], [], []],
 				clearance: vec![
@@ -166,10 +166,10 @@ mod tests {
 	fn set_all_border_nodes() {
 		let mut graph = MeshGridGraph {
 			vertices: vec![
-				vec3_not_nan!(0., 0., 0.),
-				vec3_not_nan!(0., 0., 1.),
-				vec3_not_nan!(1., 0., 0.),
-				vec3_not_nan!(1., 0., 1.),
+				vec_not_nan!(0., 0., 0.),
+				vec_not_nan!(0., 0., 1.),
+				vec_not_nan!(1., 0., 0.),
+				vec_not_nan!(1., 0., 1.),
 			],
 			neighbors: neighbors![[], [], [], []],
 			clearance: vec![
@@ -188,10 +188,10 @@ mod tests {
 		assert_eq!(
 			MeshGridGraph {
 				vertices: vec![
-					vec3_not_nan!(0., 0., 0.),
-					vec3_not_nan!(0., 0., 1.),
-					vec3_not_nan!(1., 0., 0.),
-					vec3_not_nan!(1., 0., 1.),
+					vec_not_nan!(0., 0., 0.),
+					vec_not_nan!(0., 0., 1.),
+					vec_not_nan!(1., 0., 0.),
+					vec_not_nan!(1., 0., 1.),
 				],
 				neighbors: neighbors![[], [], [], []],
 				clearance: vec![
@@ -210,10 +210,10 @@ mod tests {
 	fn set_neighbors() {
 		let mut graph = MeshGridGraph {
 			vertices: vec![
-				vec3_not_nan!(0., 0., 0.),
-				vec3_not_nan!(0., 0., 1.),
-				vec3_not_nan!(1., 0., 0.),
-				vec3_not_nan!(1., 0., 1.),
+				vec_not_nan!(0., 0., 0.),
+				vec_not_nan!(0., 0., 1.),
+				vec_not_nan!(1., 0., 0.),
+				vec_not_nan!(1., 0., 1.),
 			],
 			neighbors: neighbors![[1, 3], [0], [], []],
 			clearance: vec![
@@ -234,10 +234,10 @@ mod tests {
 		assert_eq!(
 			MeshGridGraph {
 				vertices: vec![
-					vec3_not_nan!(0., 0., 0.),
-					vec3_not_nan!(0., 0., 1.),
-					vec3_not_nan!(1., 0., 0.),
-					vec3_not_nan!(1., 0., 1.),
+					vec_not_nan!(0., 0., 0.),
+					vec_not_nan!(0., 0., 1.),
+					vec_not_nan!(1., 0., 0.),
+					vec_not_nan!(1., 0., 1.),
 				],
 				neighbors: neighbors![[1, 3], [0], [], []],
 				clearance: vec![
@@ -256,10 +256,10 @@ mod tests {
 	fn set_neighbors_from_all_borders() {
 		let mut graph = MeshGridGraph {
 			vertices: vec![
-				vec3_not_nan!(0., 0., 0.),
-				vec3_not_nan!(0., 0., 1.),
-				vec3_not_nan!(1., 0., 0.),
-				vec3_not_nan!(1., 0., 1.),
+				vec_not_nan!(0., 0., 0.),
+				vec_not_nan!(0., 0., 1.),
+				vec_not_nan!(1., 0., 0.),
+				vec_not_nan!(1., 0., 1.),
 			],
 			neighbors: neighbors![[1, 3], [0, 2], [1, 3], [0, 2]],
 			clearance: vec![
@@ -282,10 +282,10 @@ mod tests {
 		assert_eq!(
 			MeshGridGraph {
 				vertices: vec![
-					vec3_not_nan!(0., 0., 0.),
-					vec3_not_nan!(0., 0., 1.),
-					vec3_not_nan!(1., 0., 0.),
-					vec3_not_nan!(1., 0., 1.),
+					vec_not_nan!(0., 0., 0.),
+					vec_not_nan!(0., 0., 1.),
+					vec_not_nan!(1., 0., 0.),
+					vec_not_nan!(1., 0., 1.),
 				],
 				neighbors: neighbors![[1, 3], [0, 2], [1, 3], [0, 2]],
 				clearance: vec![
@@ -304,10 +304,10 @@ mod tests {
 	fn set_neighbors_of_neighbors_of_border() {
 		let mut graph = MeshGridGraph {
 			vertices: vec![
-				vec3_not_nan!(0., 0., 0.),
-				vec3_not_nan!(0., 0., 1.),
-				vec3_not_nan!(1., 0., 0.),
-				vec3_not_nan!(1., 0., 1.),
+				vec_not_nan!(0., 0., 0.),
+				vec_not_nan!(0., 0., 1.),
+				vec_not_nan!(1., 0., 0.),
+				vec_not_nan!(1., 0., 1.),
 			],
 			neighbors: neighbors![[1], [0, 2], [1, 3], [2]],
 			clearance: vec![
@@ -327,10 +327,10 @@ mod tests {
 		assert_eq!(
 			MeshGridGraph {
 				vertices: vec![
-					vec3_not_nan!(0., 0., 0.),
-					vec3_not_nan!(0., 0., 1.),
-					vec3_not_nan!(1., 0., 0.),
-					vec3_not_nan!(1., 0., 1.),
+					vec_not_nan!(0., 0., 0.),
+					vec_not_nan!(0., 0., 1.),
+					vec_not_nan!(1., 0., 0.),
+					vec_not_nan!(1., 0., 1.),
 				],
 				neighbors: neighbors![[1], [0, 2], [1, 3], [2]],
 				clearance: vec![
@@ -349,10 +349,10 @@ mod tests {
 	fn preemptive_disregard_of_stale_values() {
 		let mut graph = MeshGridGraph {
 			vertices: vec![
-				vec3_not_nan!(0., 0., 0.),
-				vec3_not_nan!(0., 0., 1.),
-				vec3_not_nan!(1., 0., 0.),
-				vec3_not_nan!(1., 0., 1.),
+				vec_not_nan!(0., 0., 0.),
+				vec_not_nan!(0., 0., 1.),
+				vec_not_nan!(1., 0., 0.),
+				vec_not_nan!(1., 0., 1.),
 			],
 			neighbors: neighbors![[1, 3], [0, 2], [1, 3], [0, 2]],
 			clearance: vec![
@@ -379,10 +379,10 @@ mod tests {
 	fn use_best_value_first() {
 		let mut graph = MeshGridGraph {
 			vertices: vec![
-				vec3_not_nan!(0., 0., 0.),
-				vec3_not_nan!(0., 0., 1.),
-				vec3_not_nan!(0., 0., 2.),
-				vec3_not_nan!(0., 0., 3.),
+				vec_not_nan!(0., 0., 0.),
+				vec_not_nan!(0., 0., 1.),
+				vec_not_nan!(0., 0., 2.),
+				vec_not_nan!(0., 0., 3.),
 			],
 			neighbors: neighbors![[3], [3], [3], [0, 1, 2]],
 			clearance: vec![
@@ -403,10 +403,10 @@ mod tests {
 		assert_eq!(
 			MeshGridGraph {
 				vertices: vec![
-					vec3_not_nan!(0., 0., 0.),
-					vec3_not_nan!(0., 0., 1.),
-					vec3_not_nan!(0., 0., 2.),
-					vec3_not_nan!(0., 0., 3.),
+					vec_not_nan!(0., 0., 0.),
+					vec_not_nan!(0., 0., 1.),
+					vec_not_nan!(0., 0., 2.),
+					vec_not_nan!(0., 0., 3.),
 				],
 				neighbors: neighbors![[3], [3], [3], [0, 1, 2]],
 				clearance: vec![

--- a/src/plugins/map_generation/src/mesh_grid_graph/line.rs
+++ b/src/plugins/map_generation/src/mesh_grid_graph/line.rs
@@ -122,7 +122,7 @@ impl Iterator for IterSuccessorsOrdered {
 mod tests {
 	use super::*;
 	use crate::mesh_grid_graph::test::neighbors;
-	use common::vec3_not_nan;
+	use common::vec_not_nan;
 
 	/// ```
 	/// a — n1
@@ -133,12 +133,12 @@ mod tests {
 	/// ```
 	#[test]
 	fn line_walks_towards_target() {
-		let a = vec3_not_nan!(0., 0., 0.);
-		let n1 = vec3_not_nan!(1., 0., 0.);
-		let n2 = vec3_not_nan!(1., 0., 1.);
-		let n3 = vec3_not_nan!(2., 0., 1.);
-		let n4 = vec3_not_nan!(2., 0., 2.);
-		let b = vec3_not_nan!(3., 0., 2.);
+		let a = vec_not_nan!(0., 0., 0.);
+		let n1 = vec_not_nan!(1., 0., 0.);
+		let n2 = vec_not_nan!(1., 0., 1.);
+		let n3 = vec_not_nan!(2., 0., 1.);
+		let n4 = vec_not_nan!(2., 0., 2.);
+		let b = vec_not_nan!(3., 0., 2.);
 		let graph = MeshGridGraph {
 			vertices: vec![a, n1, n2, n3, n4, b],
 			neighbors: neighbors![
@@ -187,26 +187,26 @@ mod tests {
 	#[test]
 	fn line_uses_closest_wedge_towards_target_with_surrounding_nodes() {
 		let vertices = [
-			vec3_not_nan!(0., 0., 0.),
-			vec3_not_nan!(1., 0., 0.),
-			vec3_not_nan!(2., 0., 0.),
-			vec3_not_nan!(3., 0., 0.),
-			vec3_not_nan!(4., 0., 0.),
-			vec3_not_nan!(0., 0., 1.),
-			vec3_not_nan!(1., 0., 1.),
-			vec3_not_nan!(2., 0., 1.),
-			vec3_not_nan!(3., 0., 1.),
-			vec3_not_nan!(4., 0., 1.),
-			vec3_not_nan!(0., 0., 2.),
-			vec3_not_nan!(1., 0., 2.),
-			vec3_not_nan!(2., 0., 2.),
-			vec3_not_nan!(3., 0., 2.),
-			vec3_not_nan!(4., 0., 2.),
-			vec3_not_nan!(0., 0., 3.),
-			vec3_not_nan!(1., 0., 3.),
-			vec3_not_nan!(2., 0., 3.),
-			vec3_not_nan!(3., 0., 3.),
-			vec3_not_nan!(4., 0., 3.),
+			vec_not_nan!(0., 0., 0.),
+			vec_not_nan!(1., 0., 0.),
+			vec_not_nan!(2., 0., 0.),
+			vec_not_nan!(3., 0., 0.),
+			vec_not_nan!(4., 0., 0.),
+			vec_not_nan!(0., 0., 1.),
+			vec_not_nan!(1., 0., 1.),
+			vec_not_nan!(2., 0., 1.),
+			vec_not_nan!(3., 0., 1.),
+			vec_not_nan!(4., 0., 1.),
+			vec_not_nan!(0., 0., 2.),
+			vec_not_nan!(1., 0., 2.),
+			vec_not_nan!(2., 0., 2.),
+			vec_not_nan!(3., 0., 2.),
+			vec_not_nan!(4., 0., 2.),
+			vec_not_nan!(0., 0., 3.),
+			vec_not_nan!(1., 0., 3.),
+			vec_not_nan!(2., 0., 3.),
+			vec_not_nan!(3., 0., 3.),
+			vec_not_nan!(4., 0., 3.),
 		];
 		let graph = MeshGridGraph {
 			vertices: Vec::from(vertices),
@@ -264,11 +264,11 @@ mod tests {
 	/// ```
 	#[test]
 	fn line_disregards_stale_nodes() {
-		let a = vec3_not_nan!(0., 0., 0.);
-		let n1 = vec3_not_nan!(1., 0., 0.3);
-		let n2 = vec3_not_nan!(1., 0., -0.3);
-		let n3 = vec3_not_nan!(2., 0., -0.5);
-		let b = vec3_not_nan!(2., 0., 0.);
+		let a = vec_not_nan!(0., 0., 0.);
+		let n1 = vec_not_nan!(1., 0., 0.3);
+		let n2 = vec_not_nan!(1., 0., -0.3);
+		let n3 = vec_not_nan!(2., 0., -0.5);
+		let b = vec_not_nan!(2., 0., 0.);
 		let graph = MeshGridGraph {
 			vertices: vec![a, n1, n2, n3, b],
 			neighbors: neighbors![[1, 2], [0, 2, 4], [0, 1, 3], [2], [1]],
@@ -297,12 +297,12 @@ mod tests {
 	/// ```
 	#[test]
 	fn stop_line_when_clearance_too_low() {
-		let a = vec3_not_nan!(0., 0., 0.);
-		let n1 = vec3_not_nan!(1., 0., 0.);
-		let n2 = vec3_not_nan!(1., 0., 1.);
-		let n3 = vec3_not_nan!(2., 0., 1.);
-		let n4 = vec3_not_nan!(2., 0., 2.);
-		let b = vec3_not_nan!(3., 0., 2.);
+		let a = vec_not_nan!(0., 0., 0.);
+		let n1 = vec_not_nan!(1., 0., 0.);
+		let n2 = vec_not_nan!(1., 0., 1.);
+		let n3 = vec_not_nan!(2., 0., 1.);
+		let n4 = vec_not_nan!(2., 0., 2.);
+		let b = vec_not_nan!(3., 0., 2.);
 		let graph = MeshGridGraph {
 			vertices: vec![a, n1, n2, n3, n4, b],
 			neighbors: neighbors![
@@ -348,10 +348,10 @@ mod tests {
 	/// ```
 	#[test]
 	fn explore_all_nodes_if_multiple_are_valid() {
-		let a = vec3_not_nan!(0., 0., 0.);
-		let n1 = vec3_not_nan!(1., 0., -1.);
-		let n2 = vec3_not_nan!(1., 0., 1.);
-		let b = vec3_not_nan!(2., 0., 0.);
+		let a = vec_not_nan!(0., 0., 0.);
+		let n1 = vec_not_nan!(1., 0., -1.);
+		let n2 = vec_not_nan!(1., 0., 1.);
+		let b = vec_not_nan!(2., 0., 0.);
 		let graph = MeshGridGraph {
 			vertices: vec![a, n1, n2, b],
 			neighbors: neighbors![[1, 2], [0, 2, 3], [0, 1, 3], [1, 2]],
@@ -388,10 +388,10 @@ mod tests {
 	/// ```
 	#[test]
 	fn explore_all_nodes_if_multiple_are_valid_allowing_for_some_epsilon() {
-		let a = vec3_not_nan!(0., 0., 0.);
-		let n1 = vec3_not_nan!(1., 0., -1.0000001);
-		let n2 = vec3_not_nan!(1., 0., 1.);
-		let b = vec3_not_nan!(2., 0., 0.);
+		let a = vec_not_nan!(0., 0., 0.);
+		let n1 = vec_not_nan!(1., 0., -1.0000001);
+		let n2 = vec_not_nan!(1., 0., 1.);
+		let b = vec_not_nan!(2., 0., 0.);
 		let graph = MeshGridGraph {
 			vertices: vec![a, n1, n2, b],
 			neighbors: neighbors![[1, 2], [0, 2, 3], [0, 1, 3], [1, 2]],
@@ -428,11 +428,11 @@ mod tests {
 	/// ```
 	#[test]
 	fn do_not_revisit_nodes() {
-		let a = vec3_not_nan!(0., 0., 0.);
-		let n1 = vec3_not_nan!(1., 0., -1.);
-		let n2 = vec3_not_nan!(1., 0., 1.);
-		let n3 = vec3_not_nan!(2., 0., 0.);
-		let b = vec3_not_nan!(3., 0., 0.);
+		let a = vec_not_nan!(0., 0., 0.);
+		let n1 = vec_not_nan!(1., 0., -1.);
+		let n2 = vec_not_nan!(1., 0., 1.);
+		let n3 = vec_not_nan!(2., 0., 0.);
+		let b = vec_not_nan!(3., 0., 0.);
 		let graph = MeshGridGraph {
 			vertices: vec![a, n1, n2, n3, b],
 			neighbors: neighbors![[1, 2], [0, 2, 3], [0, 1, 3], [1, 2, 4], [3]],
@@ -464,12 +464,12 @@ mod tests {
 	/// ```
 	#[test]
 	fn no_line_when_no_clearance_even_when_zero_clearance_required() {
-		let a = vec3_not_nan!(0., 0., 0.);
-		let n1 = vec3_not_nan!(1., 0., 0.);
-		let n2 = vec3_not_nan!(1., 0., 1.);
-		let n3 = vec3_not_nan!(2., 0., 1.);
-		let n4 = vec3_not_nan!(2., 0., 2.);
-		let b = vec3_not_nan!(3., 0., 2.);
+		let a = vec_not_nan!(0., 0., 0.);
+		let n1 = vec_not_nan!(1., 0., 0.);
+		let n2 = vec_not_nan!(1., 0., 1.);
+		let n3 = vec_not_nan!(2., 0., 1.);
+		let n4 = vec_not_nan!(2., 0., 2.);
+		let b = vec_not_nan!(3., 0., 2.);
 		let graph = MeshGridGraph {
 			vertices: vec![a, n1, n2, n3, n4, b],
 			neighbors: neighbors![

--- a/src/plugins/map_generation/src/systems/spawn_grid.rs
+++ b/src/plugins/map_generation/src/systems/spawn_grid.rs
@@ -153,7 +153,7 @@ mod tests {
 		asset::RenderAssetUsages,
 		mesh::{Indices, MeshAccessError, PrimitiveTopology},
 	};
-	use common::{tools::vec_not_nan::VecNotNan, vec3_not_nan};
+	use common::{tools::vec_not_nan::VecNotNan, vec_not_nan};
 	use testing::{IsChanged, SingleThreadedApp, new_handle};
 
 	impl<TError> PartialEq for NavMeshError<TError>
@@ -299,14 +299,14 @@ mod tests {
 				Some(&Grid::from(_Graph {
 					triangles: vec![
 						[
-							vec3_not_nan!(0.5, 0., -0.5),
-							vec3_not_nan!(-0.5, 0., 0.5),
-							vec3_not_nan!(-0.5, 0., -0.5),
+							vec_not_nan!(0.5, 0., -0.5),
+							vec_not_nan!(-0.5, 0., 0.5),
+							vec_not_nan!(-0.5, 0., -0.5),
 						],
 						[
-							vec3_not_nan!(0.5, 0., 0.5),
-							vec3_not_nan!(0.5, 0., -0.5),
-							vec3_not_nan!(-0.5, 0., 0.5),
+							vec_not_nan!(0.5, 0., 0.5),
+							vec_not_nan!(0.5, 0., -0.5),
+							vec_not_nan!(-0.5, 0., 0.5),
 						],
 					]
 				})),
@@ -350,9 +350,9 @@ mod tests {
 			(
 				Some(&Grid::from(_Graph {
 					triangles: vec![[
-						vec3_not_nan!(0.5, 0., -0.5),
-						vec3_not_nan!(-0.5, 0., 0.5),
-						vec3_not_nan!(-0.5, 0., -0.5),
+						vec_not_nan!(0.5, 0., -0.5),
+						vec_not_nan!(-0.5, 0., 0.5),
+						vec_not_nan!(-0.5, 0., -0.5),
 					]]
 				})),
 				&_Result(Err(vec![NavMeshError::HasNaNVertices { entity }]))

--- a/src/plugins/movement/src/systems/face/execute_face.rs
+++ b/src/plugins/movement/src/systems/face/execute_face.rs
@@ -101,7 +101,7 @@ mod tests {
 		components::persistent_entity::PersistentEntity,
 		tools::vec_not_nan::VecNotNan,
 		traits::register_persistent_entities::RegisterPersistentEntities,
-		vec3_not_nan,
+		vec_not_nan,
 	};
 	use macros::NestedMocks;
 	use mockall::{automock, predicate::eq};
@@ -167,7 +167,7 @@ mod tests {
 			mock.expect_raycast()
 				.with(eq(MouseHover {
 					exclude: vec![agent],
-					mode: mode(vec3_not_nan!(4., 2., 6.)),
+					mode: mode(vec_not_nan!(4., 2., 6.)),
 				}))
 				.return_const(MouseHoversOver::Point(Vec3::new(1., 2., 3.)));
 		}));
@@ -197,7 +197,7 @@ mod tests {
 			mock.expect_raycast()
 				.with(eq(MouseHover {
 					exclude: vec![agent],
-					mode: mode(vec3_not_nan!(4., 5., 6.)),
+					mode: mode(vec_not_nan!(4., 5., 6.)),
 				}))
 				.return_const(MouseHoversOver::Object {
 					entity,
@@ -229,7 +229,7 @@ mod tests {
 			mock.expect_raycast()
 				.with(eq(MouseHover {
 					exclude: vec![agent],
-					mode: mode(vec3_not_nan!(4., 5., 6.)),
+					mode: mode(vec_not_nan!(4., 5., 6.)),
 				}))
 				.return_const(MouseHoversOver::Point(Vec3::new(6., 3., 7.)));
 		}));

--- a/src/plugins/physics/src/observers/process_dirty_anchor.rs
+++ b/src/plugins/physics/src/observers/process_dirty_anchor.rs
@@ -220,7 +220,7 @@ mod tests {
 			handles_skill_physics::{Cursor, SkillMount},
 			register_persistent_entities::RegisterPersistentEntities,
 		},
-		vec3_not_nan,
+		vec_not_nan,
 	};
 	use macros::NestedMocks;
 	use mockall::{automock, predicate::eq};
@@ -442,7 +442,7 @@ mod tests {
 				.once()
 				.with(eq(MouseHover {
 					exclude: vec![agent],
-					mode: mode(vec3_not_nan!(4., 11., 9.)),
+					mode: mode(vec_not_nan!(4., 11., 9.)),
 				}))
 				.return_const(MouseHoversOver::Point(Vec3::new(11., 22., 33.)));
 		}));
@@ -488,7 +488,7 @@ mod tests {
 				.once()
 				.with(eq(MouseHover {
 					exclude: vec![agent],
-					mode: mode(vec3_not_nan!(4., 11., 9.)),
+					mode: mode(vec_not_nan!(4., 11., 9.)),
 				}))
 				.return_const(MouseHoversOver::Object {
 					entity: target,

--- a/src/plugins/physics/src/system_params/ray_caster/mouse_hover.rs
+++ b/src/plugins/physics/src/system_params/ray_caster/mouse_hover.rs
@@ -88,7 +88,7 @@ mod tests {
 		toi,
 		tools::Units,
 		traits::handles_physics::{HoverMode, RaycastHit, TimeOfImpact},
-		vec3_not_nan,
+		vec_not_nan,
 	};
 	use macros::NestedMocks;
 	use mockall::{automock, predicate::eq};
@@ -300,7 +300,7 @@ mod tests {
 				.run_system_once(move |mut ray_caster: _RayCaster| {
 					let hit = ray_caster.raycast(MouseHover {
 						exclude: vec![exclude],
-						mode: HoverMode::ColliderOrDirectionFrom(vec3_not_nan!(0., 10., 0.)),
+						mode: HoverMode::ColliderOrDirectionFrom(vec_not_nan!(0., 10., 0.)),
 					});
 
 					assert_eq!(Some(MouseHoversOver::Point(Vec3::new(1., 10., 3.))), hit);
@@ -329,7 +329,7 @@ mod tests {
 				.run_system_once(move |mut ray_caster: _RayCaster| {
 					let hit = ray_caster.raycast(MouseHover {
 						exclude: vec![exclude],
-						mode: HoverMode::ColliderOrDirectionFrom(vec3_not_nan!(0., 10., 0.)),
+						mode: HoverMode::ColliderOrDirectionFrom(vec_not_nan!(0., 10., 0.)),
 					});
 
 					assert_eq!(Some(MouseHoversOver::Point(Vec3::new(1., 10., 3.))), hit);
@@ -361,7 +361,7 @@ mod tests {
 				.run_system_once(move |mut ray_caster: _RayCaster| {
 					let hit = ray_caster.raycast(MouseHover {
 						exclude: vec![exclude],
-						mode: HoverMode::ColliderOrDirectionFrom(vec3_not_nan!(0., 10., 0.)),
+						mode: HoverMode::ColliderOrDirectionFrom(vec_not_nan!(0., 10., 0.)),
 					});
 
 					assert_eq!(
@@ -400,7 +400,7 @@ mod tests {
 				.run_system_once(move |mut ray_caster: _RayCaster| {
 					let hit = ray_caster.raycast(MouseHover {
 						exclude: vec![exclude],
-						mode: HoverMode::ColliderOrDirectionFrom(vec3_not_nan!(0., 10., 0.)),
+						mode: HoverMode::ColliderOrDirectionFrom(vec_not_nan!(0., 10., 0.)),
 					});
 
 					assert_eq!(Some(MouseHoversOver::Point(Vec3::new(1., 10., 3.))), hit);

--- a/src/zyheeda_core/Cargo.toml
+++ b/src/zyheeda_core/Cargo.toml
@@ -17,3 +17,4 @@ mockall.workspace = true
 serde_json.workspace = true
 test-case.workspace = true
 testing.workspace = true
+yaml_serde.workspace = true

--- a/src/zyheeda_core/src/lib.rs
+++ b/src/zyheeda_core/src/lib.rs
@@ -2,6 +2,7 @@ pub mod collections;
 pub mod errors;
 pub mod logger;
 pub mod macros;
+pub mod math;
 pub mod prelude;
 pub mod serialization;
 pub mod yields;

--- a/src/zyheeda_core/src/math.rs
+++ b/src/zyheeda_core/src/math.rs
@@ -1,0 +1,1 @@
+pub mod f32_not_nan;

--- a/src/zyheeda_core/src/math/f32_not_nan.rs
+++ b/src/zyheeda_core/src/math/f32_not_nan.rs
@@ -16,6 +16,20 @@ impl F32NotNan {
 	}
 }
 
+#[macro_export]
+macro_rules! f32_not_nan {
+	($value:literal) => {{
+		const F32_NOT_NAN: $crate::prelude::F32NotNan =
+			match $crate::prelude::F32NotNan::try_from_f32($value) {
+				Ok(v) => v,
+				Err(_) => panic!("The f32 value is not a number"),
+			};
+		F32_NOT_NAN
+	}};
+}
+
+pub use f32_not_nan;
+
 impl TryFrom<f32> for F32NotNan {
 	type Error = IsNaN;
 
@@ -96,5 +110,12 @@ mod tests {
 		let value = yaml_serde::from_str::<F32NotNan>(yaml);
 
 		assert!(value.is_err());
+	}
+
+	#[test]
+	fn macro_ok() {
+		const V: F32NotNan = f32_not_nan!(11.);
+
+		assert_eq!(F32NotNan(11.), V);
 	}
 }

--- a/src/zyheeda_core/src/math/f32_not_nan.rs
+++ b/src/zyheeda_core/src/math/f32_not_nan.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::{fmt::Display, ops::Deref};
+use std::{cmp::Ordering, fmt::Display, hash::Hash, ops::Deref};
 
 #[derive(Debug, PartialEq, Clone, Copy, Default, Serialize)]
 pub struct F32NotNan(f32);
@@ -57,6 +57,34 @@ impl Deref for F32NotNan {
 	}
 }
 
+impl Eq for F32NotNan {}
+
+impl Hash for F32NotNan {
+	fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+		let bits = match self.0 {
+			0. => 0,
+			v => v.to_bits(),
+		};
+
+		bits.hash(state);
+	}
+}
+
+impl Ord for F32NotNan {
+	fn cmp(&self, other: &Self) -> Ordering {
+		match (self.0, other.0) {
+			(0., 0.) => Ordering::Equal,
+			(a, b) => a.total_cmp(&b),
+		}
+	}
+}
+
+impl PartialOrd for F32NotNan {
+	fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+		Some(self.cmp(other))
+	}
+}
+
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub struct IsNaN;
 
@@ -78,6 +106,11 @@ impl Display for IsNaN {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use std::{
+		cmp::Ordering,
+		hash::{DefaultHasher, Hasher},
+	};
+	use test_case::test_case;
 
 	#[test]
 	fn try_from_ok() {
@@ -117,5 +150,29 @@ mod tests {
 		const V: F32NotNan = f32_not_nan!(11.);
 
 		assert_eq!(F32NotNan(11.), V);
+	}
+
+	fn hash(node: impl Hash) -> u64 {
+		let mut hasher = DefaultHasher::new();
+		node.hash(&mut hasher);
+		hasher.finish()
+	}
+
+	#[test]
+	fn hash_value() {
+		assert_eq!(hash(11f32.to_bits()), hash(F32NotNan(11.)));
+	}
+
+	#[test]
+	fn hash_zero() {
+		assert_eq!(hash(F32NotNan(-0.)), hash(F32NotNan(0.)));
+	}
+
+	#[test_case(F32NotNan(11.), F32NotNan(10.), Ordering::Greater; "11 greater 10")]
+	#[test_case(F32NotNan(10.), F32NotNan(11.), Ordering::Less; "10 less 11")]
+	#[test_case(F32NotNan(11.), F32NotNan(11.), Ordering::Equal; "11 equal 11")]
+	#[test_case(F32NotNan(-0.), F32NotNan(0.), Ordering::Equal; "0 equal 0")]
+	fn order(a: F32NotNan, b: F32NotNan, ordering: Ordering) {
+		assert_eq!(ordering, a.cmp(&b))
 	}
 }

--- a/src/zyheeda_core/src/math/f32_not_nan.rs
+++ b/src/zyheeda_core/src/math/f32_not_nan.rs
@@ -1,0 +1,84 @@
+use serde::{Deserialize, Serialize};
+use std::fmt::Display;
+
+#[derive(Debug, PartialEq, Clone, Copy, Serialize)]
+pub struct F32NotNan(f32);
+
+impl TryFrom<f32> for F32NotNan {
+	type Error = IsNaN;
+
+	fn try_from(value: f32) -> Result<Self, Self::Error> {
+		if value.is_nan() {
+			return Err(IsNaN);
+		}
+
+		Ok(Self(value))
+	}
+}
+
+impl<'de> Deserialize<'de> for F32NotNan {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: serde::Deserializer<'de>,
+	{
+		let value = f32::deserialize(deserializer)?;
+
+		F32NotNan::try_from(value).map_err(IsNaN::into_serde_error)
+	}
+}
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub struct IsNaN;
+
+impl IsNaN {
+	fn into_serde_error<TError>(self) -> TError
+	where
+		TError: serde::de::Error,
+	{
+		TError::custom(self)
+	}
+}
+
+impl Display for IsNaN {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		write!(f, "The f32 value is not a number")
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn try_from_ok() {
+		let v = F32NotNan::try_from(11.);
+
+		assert_eq!(Ok(F32NotNan(11.)), v);
+	}
+
+	#[test]
+	fn try_from_error() {
+		let v = F32NotNan::try_from(f32::NAN);
+
+		assert_eq!(Err(IsNaN), v);
+	}
+
+	#[test]
+	fn deserialize() -> Result<(), yaml_serde::Error> {
+		let yaml = "42";
+
+		let value = yaml_serde::from_str::<F32NotNan>(yaml)?;
+
+		assert_eq!(F32NotNan(42.), value);
+		Ok(())
+	}
+
+	#[test]
+	fn deserialize_nan() {
+		let yaml = ".NAN";
+
+		let value = yaml_serde::from_str::<F32NotNan>(yaml);
+
+		assert!(value.is_err());
+	}
+}

--- a/src/zyheeda_core/src/math/f32_not_nan.rs
+++ b/src/zyheeda_core/src/math/f32_not_nan.rs
@@ -1,18 +1,26 @@
 use serde::{Deserialize, Serialize};
-use std::fmt::Display;
+use std::{fmt::Display, ops::Deref};
 
-#[derive(Debug, PartialEq, Clone, Copy, Serialize)]
+#[derive(Debug, PartialEq, Clone, Copy, Default, Serialize)]
 pub struct F32NotNan(f32);
 
-impl TryFrom<f32> for F32NotNan {
-	type Error = IsNaN;
+impl F32NotNan {
+	pub const ZERO: Self = Self(0.);
 
-	fn try_from(value: f32) -> Result<Self, Self::Error> {
+	pub const fn try_from_f32(value: f32) -> Result<Self, IsNaN> {
 		if value.is_nan() {
 			return Err(IsNaN);
 		}
 
 		Ok(Self(value))
+	}
+}
+
+impl TryFrom<f32> for F32NotNan {
+	type Error = IsNaN;
+
+	fn try_from(value: f32) -> Result<Self, Self::Error> {
+		Self::try_from_f32(value)
 	}
 }
 
@@ -24,6 +32,14 @@ impl<'de> Deserialize<'de> for F32NotNan {
 		let value = f32::deserialize(deserializer)?;
 
 		F32NotNan::try_from(value).map_err(IsNaN::into_serde_error)
+	}
+}
+
+impl Deref for F32NotNan {
+	type Target = f32;
+
+	fn deref(&self) -> &Self::Target {
+		&self.0
 	}
 }
 

--- a/src/zyheeda_core/src/prelude.rs
+++ b/src/zyheeda_core/src/prelude.rs
@@ -7,7 +7,7 @@ pub use crate::{
 	errors::*,
 	logger::*,
 	macros::{all::*, any::*, none::*, write_iter::*},
-	math::f32_not_nan::F32NotNan,
+	math::f32_not_nan::{F32NotNan, f32_not_nan},
 	serialization::*,
 	yields::*,
 };

--- a/src/zyheeda_core/src/prelude.rs
+++ b/src/zyheeda_core/src/prelude.rs
@@ -7,6 +7,7 @@ pub use crate::{
 	errors::*,
 	logger::*,
 	macros::{all::*, any::*, none::*, write_iter::*},
+	math::f32_not_nan::F32NotNan,
 	serialization::*,
 	yields::*,
 };


### PR DESCRIPTION
- added `F32NotNan`
- used `F32NotNan` in `VecNotNan<N>`, which allowed us to make the inner array public
- overhauled not nan related macros and constructors to dispatch responsibility towards `F32NotNan`