### PR TITLE
Add center offset for physical agents

### DIFF
--- a/assets/agents/player.agent
+++ b/assets/agents/player.agent
@@ -33,9 +33,10 @@
 				]
 			},
 			"required_clearance": {
-				"vertical": 0.6,
+				"vertical": 0.65,
 				"horizontal": 0.2
 			},
+			"center_height": 1,
 			"bones": {
 				"skill_mounts": {
 					"skill_spawn": "Neutral",

--- a/assets/agents/player.agent
+++ b/assets/agents/player.agent
@@ -26,14 +26,16 @@
 	"model": {
 		"Asset": {
 			"model_path": "models/player.glb",
-			"required_movement_clearance": 0.2,
 			"movement_speed": {
 				"Variable": [
 					3,
 					0.9
 				]
 			},
-			"ground_offset": 0.6,
+			"required_clearance": {
+				"vertical": 0.6,
+				"horizontal": 0.2
+			},
 			"bones": {
 				"skill_mounts": {
 					"skill_spawn": "Neutral",

--- a/src/plugins/agents/src/assets/agent_config.rs
+++ b/src/plugins/agents/src/assets/agent_config.rs
@@ -2,18 +2,12 @@ pub(crate) mod dto;
 
 use bevy::prelude::*;
 use common::{
-	tools::{
-		Units,
-		action_key::slot::SlotKey,
-		bone_name::BoneName,
-		mesh_name::MeshName,
-		path::Path,
-	},
+	tools::{action_key::slot::SlotKey, bone_name::BoneName, mesh_name::MeshName, path::Path},
 	traits::{
 		accessors::get::View,
 		handles_animations::{AffectedAnimationBones, Animation, AnimationKey, AnimationMaskBits},
 		handles_custom_assets::AssetFolderPath,
-		handles_movement::MovementSpeed,
+		handles_movement::{MovementSpeed, RequiredClearance},
 		handles_physics::PhysicalDefaultAttributes,
 		handles_skill_physics::SkillMount,
 		loadout::ItemName,
@@ -27,9 +21,8 @@ use std::collections::HashMap;
 pub struct AgentConfigAsset {
 	pub(crate) loadout: Loadout,
 	pub(crate) bones: Bones,
-	pub(crate) agent_model: AgentModel,
-	pub(crate) ground_offset: Units,
-	pub(crate) required_clearance: Units,
+	pub(crate) model: AgentModel,
+	pub(crate) required_clearance: RequiredClearance,
 	pub(crate) speed: MovementSpeed,
 	pub(crate) attributes: PhysicalDefaultAttributes,
 	pub(crate) animations: HashMap<AnimationKey, Animation>,

--- a/src/plugins/agents/src/assets/agent_config.rs
+++ b/src/plugins/agents/src/assets/agent_config.rs
@@ -23,6 +23,7 @@ pub struct AgentConfigAsset {
 	pub(crate) bones: Bones,
 	pub(crate) model: AgentModel,
 	pub(crate) required_clearance: RequiredClearance,
+	pub(crate) center_height: f32,
 	pub(crate) speed: MovementSpeed,
 	pub(crate) attributes: PhysicalDefaultAttributes,
 	pub(crate) animations: HashMap<AnimationKey, Animation>,

--- a/src/plugins/agents/src/assets/agent_config/dto.rs
+++ b/src/plugins/agents/src/assets/agent_config/dto.rs
@@ -31,6 +31,7 @@ pub(crate) enum ModelConfig {
 		bones: Bones,
 		movement_speed: MovementSpeed,
 		required_clearance: RequiredClearance,
+		center_height: f32,
 		#[serde(with = "as_vec")]
 		animations: HashMap<AnimationKey, Animation>,
 		animation_mask_groups: HashMap<AnimationMaskBits, AffectedAnimationBones>,
@@ -63,6 +64,7 @@ impl TryLoadFrom<AgentConfigDto> for AgentConfigAsset {
 				bones,
 				movement_speed,
 				required_clearance,
+				center_height,
 				animations,
 				animation_mask_groups,
 			} => Ok(AgentConfigAsset {
@@ -70,6 +72,7 @@ impl TryLoadFrom<AgentConfigDto> for AgentConfigAsset {
 				bones,
 				model: AgentModel::Asset(model_path),
 				required_clearance,
+				center_height,
 				speed: movement_speed,
 				attributes,
 				animations,

--- a/src/plugins/agents/src/assets/agent_config/dto.rs
+++ b/src/plugins/agents/src/assets/agent_config/dto.rs
@@ -1,11 +1,10 @@
 use crate::{
-	assets::agent_config::{AgentConfigAsset, AgentModel, Bones, Loadout},
+	assets::agent_config::{AgentConfigAsset, AgentModel, Bones, Loadout, RequiredClearance},
 	components::enemy::void_sphere::VoidSphere,
 };
 use bevy::prelude::*;
 use common::{
 	errors::Unreachable,
-	tools::Units,
 	traits::{
 		handles_animations::{AffectedAnimationBones, Animation, AnimationKey, AnimationMaskBits},
 		handles_custom_assets::{AssetFileExtensions, TryLoadFrom},
@@ -31,8 +30,7 @@ pub(crate) enum ModelConfig {
 		model_path: String,
 		bones: Bones,
 		movement_speed: MovementSpeed,
-		required_movement_clearance: Units,
-		ground_offset: Units,
+		required_clearance: RequiredClearance,
 		#[serde(with = "as_vec")]
 		animations: HashMap<AnimationKey, Animation>,
 		animation_mask_groups: HashMap<AnimationMaskBits, AffectedAnimationBones>,
@@ -64,16 +62,14 @@ impl TryLoadFrom<AgentConfigDto> for AgentConfigAsset {
 				model_path,
 				bones,
 				movement_speed,
-				required_movement_clearance,
-				ground_offset,
+				required_clearance,
 				animations,
 				animation_mask_groups,
 			} => Ok(AgentConfigAsset {
 				loadout,
 				bones,
-				agent_model: AgentModel::Asset(model_path),
-				ground_offset,
-				required_clearance: required_movement_clearance,
+				model: AgentModel::Asset(model_path),
+				required_clearance,
 				speed: movement_speed,
 				attributes,
 				animations,

--- a/src/plugins/agents/src/components/enemy/void_sphere.rs
+++ b/src/plugins/agents/src/components/enemy/void_sphere.rs
@@ -19,7 +19,7 @@ use common::{
 	traits::{
 		handles_enemies::EnemyType,
 		handles_map_generation::AgentType,
-		handles_movement::MovementSpeed,
+		handles_movement::{MovementSpeed, RequiredClearance},
 		handles_physics::PhysicalDefaultAttributes,
 		handles_skill_physics::SkillMount,
 		prefab::{Prefab, PrefabEntityCommands},
@@ -71,12 +71,14 @@ impl VoidSphere {
 		AgentConfigAsset {
 			loadout,
 			attributes,
-			agent_model: AgentModel::Procedural(|e| {
+			model: AgentModel::Procedural(|e| {
 				e.try_insert(Self);
 			}),
 			bones: Self::bones(),
-			ground_offset: *COLLIDER_GROUND_OFFSET,
-			required_clearance: Units::from(Self::OUTER_RADIUS),
+			required_clearance: RequiredClearance {
+				vertical: *COLLIDER_GROUND_OFFSET,
+				horizontal: Units::from(Self::OUTER_RADIUS),
+			},
 			speed: MovementSpeed::Fixed(UnitsPerSecond::from_u8(1)),
 			animations: HashMap::from([]),
 			animation_mask_groups: HashMap::from([]),

--- a/src/plugins/agents/src/components/enemy/void_sphere.rs
+++ b/src/plugins/agents/src/components/enemy/void_sphere.rs
@@ -43,12 +43,12 @@ type LazyBoneName = LazyLock<BoneName>;
 static ALL_PURPOSE_SLOT_BONE: &str = "slot";
 static SKILL_MOUNT: LazyBoneName = LazyLock::new(|| BoneName::from("skill_spawn"));
 static SKILL_MOUNT_NEUTRAL: LazyBoneName = LazyLock::new(|| BoneName::from("skill_spawn_neutral"));
-static COLLIDER_GROUND_OFFSET: LazyLock<Units> = LazyLock::new(|| Units::from(0.6));
 
 impl VoidSphere {
 	const SLOT_KEY: SlotKey = SlotKey(0);
 
-	const INNER_MODEL_OFFSET: Vec3 = Vec3::new(0., 0.2, 0.);
+	const COLLIDER_GROUND_OFFSET: f32 = 0.6;
+	const INNER_MODEL_OFFSET: f32 = 0.2;
 	const INNER_RADIUS: f32 = 0.3;
 	const OUTER_RADIUS: f32 = 0.4;
 	const TORUS_RADIUS: f32 = 0.35;
@@ -76,9 +76,10 @@ impl VoidSphere {
 			}),
 			bones: Self::bones(),
 			required_clearance: RequiredClearance {
-				vertical: *COLLIDER_GROUND_OFFSET,
+				vertical: Units::from(Self::COLLIDER_GROUND_OFFSET),
 				horizontal: Units::from(Self::OUTER_RADIUS),
 			},
+			center_height: Self::COLLIDER_GROUND_OFFSET + Self::INNER_MODEL_OFFSET,
 			speed: MovementSpeed::Fixed(UnitsPerSecond::from_u8(1)),
 			animations: HashMap::from([]),
 			animation_mask_groups: HashMap::from([]),
@@ -123,34 +124,34 @@ impl Prefab<()> for VoidSphere {
 	) -> Result<(), Unreachable> {
 		entity
 			.with_child((
-				Transform::from_translation(Self::INNER_MODEL_OFFSET),
+				Transform::from_translation(Vec3::ZERO.with_y(Self::INNER_MODEL_OFFSET)),
 				VoidSpherePart::Core,
 				VoidSphereCore,
 			))
 			.with_child((
-				Transform::from_translation(Self::INNER_MODEL_OFFSET),
+				Transform::from_translation(Vec3::ZERO.with_y(Self::INNER_MODEL_OFFSET)),
 				VoidSpherePart::RingA(UnitsPerSecond::from(3.6_f32.to_radians())),
 				VoidSphereRing,
 			))
 			.with_child((
-				Transform::from_translation(Self::INNER_MODEL_OFFSET)
+				Transform::from_translation(Vec3::ZERO.with_y(Self::INNER_MODEL_OFFSET))
 					.with_rotation(Quat::from_rotation_z(90_f32.to_radians())),
 				VoidSpherePart::RingB(UnitsPerSecond::from(2.4_f32.to_radians())),
 				VoidSphereRing,
 			))
 			// One unified slot bone
 			.with_child((
-				Transform::from_translation(Self::INNER_MODEL_OFFSET + Self::SLOT_OFFSET),
+				Transform::from_translation(Vec3::Y * Self::INNER_MODEL_OFFSET + Self::SLOT_OFFSET),
 				Name::from(ALL_PURPOSE_SLOT_BONE),
 			))
 			// Skill spawn directly on slot offset
 			.with_child((
-				Transform::from_translation(Self::INNER_MODEL_OFFSET + Self::SLOT_OFFSET),
+				Transform::from_translation(Vec3::Y * Self::INNER_MODEL_OFFSET + Self::SLOT_OFFSET),
 				Name::from(SKILL_MOUNT.clone()),
 			))
 			// Neutral skill spawn directly on slot offset
 			.with_child((
-				Transform::from_translation(Self::INNER_MODEL_OFFSET + Self::SLOT_OFFSET),
+				Transform::from_translation(Vec3::Y * Self::INNER_MODEL_OFFSET + Self::SLOT_OFFSET),
 				Name::from(SKILL_MOUNT_NEUTRAL.clone()),
 			));
 

--- a/src/plugins/agents/src/systems/agent_config/apply_config_system.rs
+++ b/src/plugins/agents/src/systems/agent_config/apply_config_system.rs
@@ -112,14 +112,17 @@ impl ApplyAgentConfig {
 
 			let no_body = NoBodyConfigured { entity };
 			if let Some(mut ctx) = TPhysics::get_context_mut(&mut physics, no_body) {
-				ctx.configure_body(Body {
-					shape: Shape::Capsule {
-						half_y: Units::from(*config.ground_offset - *config.required_clearance),
-						radius: config.required_clearance,
+				ctx.configure_body(
+					Body {
+						shape: Shape::Capsule {
+							half_y: Units::from(*config.ground_offset - *config.required_clearance),
+							radius: config.required_clearance,
+						},
+						physics_type: PhysicsType::Agent,
+						blocker_types: HashSet::from([Blocker::Character]),
 					},
-					physics_type: PhysicsType::Agent,
-					blocker_types: HashSet::from([Blocker::Character]),
-				});
+					Units::ZERO,
+				);
 			}
 
 			if transform_dirty.is_some() {
@@ -356,8 +359,8 @@ mod tests {
 	}
 
 	impl ConfigureBody for _Physics {
-		fn configure_body(&mut self, body: Body) {
-			self.mock.configure_body(body);
+		fn configure_body(&mut self, body: Body, center_offset: Units) {
+			self.mock.configure_body(body, center_offset);
 		}
 	}
 
@@ -367,7 +370,7 @@ mod tests {
 			fn configure_default_attributes(&mut self, default: PhysicalDefaultAttributes);
 		}
 		impl ConfigureBody for _Physics {
-			fn configure_body(&mut self, body: Body);
+			fn configure_body(&mut self, body: Body, center_offset: Units);
 		}
 	}
 
@@ -837,7 +840,7 @@ mod tests {
 					mock.expect_configure_default_attributes().return_const(());
 					mock.expect_configure_body()
 						.once()
-						.with(eq(expected_body))
+						.with(eq(expected_body), eq(Units::ZERO))
 						.return_const(());
 				}),
 			));

--- a/src/plugins/agents/src/systems/agent_config/apply_config_system.rs
+++ b/src/plugins/agents/src/systems/agent_config/apply_config_system.rs
@@ -118,7 +118,7 @@ impl ApplyAgentConfig {
 						physics_type: PhysicsType::Agent,
 						blocker_types: HashSet::from([Blocker::Character]),
 					},
-					Units::ZERO,
+					0.,
 				);
 			}
 
@@ -350,7 +350,7 @@ mod tests {
 	}
 
 	impl ConfigureBody for _Physics {
-		fn configure_body(&mut self, body: Body, center_offset: Units) {
+		fn configure_body(&mut self, body: Body, center_offset: f32) {
 			self.mock.configure_body(body, center_offset);
 		}
 	}
@@ -361,7 +361,7 @@ mod tests {
 			fn configure_default_attributes(&mut self, default: PhysicalDefaultAttributes);
 		}
 		impl ConfigureBody for _Physics {
-			fn configure_body(&mut self, body: Body, center_offset: Units);
+			fn configure_body(&mut self, body: Body, center_offset: f32);
 		}
 	}
 
@@ -841,7 +841,7 @@ mod tests {
 					mock.expect_configure_default_attributes().return_const(());
 					mock.expect_configure_body()
 						.once()
-						.with(eq(expected_body), eq(Units::ZERO))
+						.with(eq(expected_body), eq(0.))
 						.return_const(());
 				}),
 			));

--- a/src/plugins/agents/src/systems/agent_config/apply_config_system.rs
+++ b/src/plugins/agents/src/systems/agent_config/apply_config_system.rs
@@ -112,13 +112,14 @@ impl ApplyAgentConfig {
 					*config.required_clearance.vertical - *config.required_clearance.horizontal,
 				);
 				let radius = config.required_clearance.horizontal;
+				let center_offset = config.center_height - *config.required_clearance.vertical;
 				ctx.configure_body(
 					Body {
 						shape: Shape::Capsule { half_y, radius },
 						physics_type: PhysicsType::Agent,
 						blocker_types: HashSet::from([Blocker::Character]),
 					},
-					0.,
+					center_offset,
 				);
 			}
 
@@ -817,10 +818,12 @@ mod tests {
 				horizontal: Units::from(0.5),
 				vertical: Units::from(2.),
 			};
+			let center_height = 3.5;
 			let mut app = setup([(
 				&config_handle,
 				AgentConfigAsset {
 					required_clearance,
+					center_height,
 					..default()
 				},
 			)]);
@@ -837,11 +840,12 @@ mod tests {
 						physics_type: PhysicsType::Agent,
 						blocker_types: HashSet::from([Blocker::Character]),
 					};
+					let expected_center_offset = 1.5;
 
 					mock.expect_configure_default_attributes().return_const(());
 					mock.expect_configure_body()
 						.once()
-						.with(eq(expected_body), eq(0.))
+						.with(eq(expected_body), eq(expected_center_offset))
 						.return_const(());
 				}),
 			));

--- a/src/plugins/agents/src/systems/agent_config/apply_config_system.rs
+++ b/src/plugins/agents/src/systems/agent_config/apply_config_system.rs
@@ -98,11 +98,7 @@ impl ApplyAgentConfig {
 
 			let not_configured = NotConfiguredMovement { entity };
 			if let Some(mut ctx) = TMovement::get_context_mut(&mut movement, not_configured) {
-				ctx.configure(
-					config.speed.with_fastest_left(),
-					config.required_clearance,
-					config.ground_offset,
-				);
+				ctx.configure(config.speed.with_fastest_left(), config.required_clearance);
 			}
 
 			let no_default_attr = NoDefaultAttributes { entity };
@@ -112,12 +108,13 @@ impl ApplyAgentConfig {
 
 			let no_body = NoBodyConfigured { entity };
 			if let Some(mut ctx) = TPhysics::get_context_mut(&mut physics, no_body) {
+				let half_y = Units::from(
+					*config.required_clearance.vertical - *config.required_clearance.horizontal,
+				);
+				let radius = config.required_clearance.horizontal;
 				ctx.configure_body(
 					Body {
-						shape: Shape::Capsule {
-							half_y: Units::from(*config.ground_offset - *config.required_clearance),
-							radius: config.required_clearance,
-						},
+						shape: Shape::Capsule { half_y, radius },
 						physics_type: PhysicsType::Agent,
 						blocker_types: HashSet::from([Blocker::Character]),
 					},
@@ -126,11 +123,11 @@ impl ApplyAgentConfig {
 			}
 
 			if transform_dirty.is_some() {
-				transform.translation.y += *config.ground_offset;
+				transform.translation.y += *config.required_clearance.vertical;
 			}
 
 			commands.try_apply_on(&entity, |mut e| {
-				match &config.agent_model {
+				match &config.model {
 					AgentModel::Asset(path) => {
 						e.try_insert(AssetModel::path(path));
 					}
@@ -212,7 +209,7 @@ mod tests {
 				AnimationPath,
 				PlayMode,
 			},
-			handles_movement::MovementSpeed,
+			handles_movement::{MovementSpeed, RequiredClearance},
 			handles_physics::{PhysicalDefaultAttributes, physical_bodies::Body},
 			handles_skill_physics::SkillMount,
 		},
@@ -327,14 +324,8 @@ mod tests {
 
 	#[automock]
 	impl ConfigureMovement for _Movement {
-		fn configure(
-			&mut self,
-			speed: MovementSpeed,
-			required_clearance: Units,
-			ground_offset: Units,
-		) {
-			self.mock
-				.configure(speed, required_clearance, ground_offset);
+		fn configure(&mut self, speed: MovementSpeed, required_clearance: RequiredClearance) {
+			self.mock.configure(speed, required_clearance);
 		}
 	}
 
@@ -577,9 +568,12 @@ mod tests {
 		fn configure() {
 			let config_handle = new_handle();
 			let config = AgentConfigAsset {
-				required_clearance: Units::from_u8(12),
+				required_clearance: RequiredClearance {
+					horizontal: Units::from_u8(12),
+					vertical: Units::from(2.),
+				},
 				speed: MovementSpeed::Fixed(UnitsPerSecond::from_u8(21)),
-				ground_offset: Units::from(2.),
+
 				..default()
 			};
 			let mut app = setup([(&config_handle, config.clone())]);
@@ -590,11 +584,7 @@ mod tests {
 				_Movement::new().with_mock(move |mock| {
 					mock.expect_configure()
 						.times(1)
-						.with(
-							eq(config.speed),
-							eq(config.required_clearance),
-							eq(config.ground_offset),
-						)
+						.with(eq(config.speed), eq(config.required_clearance))
 						.return_const(());
 				}),
 			));
@@ -606,12 +596,14 @@ mod tests {
 		fn configure_fastest_left() {
 			let config_handle = new_handle();
 			let config = AgentConfigAsset {
-				required_clearance: Units::from_u8(12),
+				required_clearance: RequiredClearance {
+					horizontal: Units::from_u8(12),
+					vertical: Units::from(2.),
+				},
 				speed: MovementSpeed::Variable([
 					UnitsPerSecond::from_u8(11),
 					UnitsPerSecond::from_u8(21),
 				]),
-				ground_offset: Units::from(2.),
 				..default()
 			};
 			let mut app = setup([(&config_handle, config.clone())]);
@@ -625,7 +617,6 @@ mod tests {
 						.with(
 							eq(config.speed.with_fastest_left()),
 							eq(config.required_clearance),
-							eq(config.ground_offset),
 						)
 						.return_const(());
 				}),
@@ -642,7 +633,7 @@ mod tests {
 		fn insert_asset_model() {
 			let config_handle = new_handle();
 			let config = AgentConfigAsset {
-				agent_model: AgentModel::from("my/path"),
+				model: AgentModel::from("my/path"),
 				..default()
 			};
 			let mut app = setup([(&config_handle, config)]);
@@ -676,7 +667,7 @@ mod tests {
 		fn insert_procedural_model() {
 			let config_handle = new_handle();
 			let config = AgentConfigAsset {
-				agent_model: AgentModel::Procedural(_Model::insert),
+				model: AgentModel::Procedural(_Model::insert),
 				..default()
 			};
 			let mut app = setup([(&config_handle, config)]);
@@ -702,7 +693,10 @@ mod tests {
 		fn update_transform() {
 			let config_handle = new_handle();
 			let config = AgentConfigAsset {
-				ground_offset: Units::from(6.),
+				required_clearance: RequiredClearance {
+					horizontal: Units::from_u8(12),
+					vertical: Units::from(6.),
+				},
 				..default()
 			};
 			let mut app = setup([(&config_handle, config)]);
@@ -728,7 +722,10 @@ mod tests {
 		fn do_not_update_transform_when_agent_transform_not_dirty() {
 			let config_handle = new_handle();
 			let config = AgentConfigAsset {
-				ground_offset: Units::from(6.),
+				required_clearance: RequiredClearance {
+					horizontal: Units::from_u8(12),
+					vertical: Units::from(6.),
+				},
 				..default()
 			};
 			let mut app = setup([(&config_handle, config)]);
@@ -753,7 +750,10 @@ mod tests {
 		fn remove_transform_dirty_marker() {
 			let config_handle = new_handle();
 			let config = AgentConfigAsset {
-				ground_offset: Units::from(6.),
+				required_clearance: RequiredClearance {
+					horizontal: Units::from_u8(12),
+					vertical: Units::from(6.),
+				},
 				..default()
 			};
 			let mut app = setup([(&config_handle, config)]);
@@ -813,12 +813,13 @@ mod tests {
 		#[test]
 		fn config_body() {
 			let config_handle = new_handle();
-			let ground_offset = Units::from(2.);
-			let required_clearance = Units::from(0.5);
+			let required_clearance = RequiredClearance {
+				horizontal: Units::from(0.5),
+				vertical: Units::from(2.),
+			};
 			let mut app = setup([(
 				&config_handle,
 				AgentConfigAsset {
-					ground_offset,
 					required_clearance,
 					..default()
 				},
@@ -855,7 +856,7 @@ mod tests {
 		let mut app = setup([(
 			&config_handle,
 			AgentConfigAsset {
-				agent_model: AgentModel::from("my/path"),
+				model: AgentModel::from("my/path"),
 				..default()
 			},
 		)]);
@@ -920,7 +921,7 @@ mod tests {
 		_ = configs.insert(
 			&config_handle,
 			AgentConfigAsset {
-				agent_model: AgentModel::from("my/path"),
+				model: AgentModel::from("my/path"),
 				..default()
 			},
 		);

--- a/src/plugins/common/src/traits/handles_movement.rs
+++ b/src/plugins/common/src/traits/handles_movement.rs
@@ -50,16 +50,15 @@ impl ViewField for MovementTarget {
 }
 
 pub trait ConfigureMovement {
-	fn configure(&mut self, speed: MovementSpeed, required_clearance: Units, ground_offset: Units);
+	fn configure(&mut self, speed: MovementSpeed, required_clearance: RequiredClearance);
 }
 
 impl<T> ConfigureMovement for T
 where
 	T: DerefMut<Target: ConfigureMovement>,
 {
-	fn configure(&mut self, speed: MovementSpeed, required_clearance: Units, ground_offset: Units) {
-		self.deref_mut()
-			.configure(speed, required_clearance, ground_offset);
+	fn configure(&mut self, speed: MovementSpeed, required_clearance: RequiredClearance) {
+		self.deref_mut().configure(speed, required_clearance);
 	}
 }
 
@@ -82,6 +81,12 @@ impl Default for MovementSpeed {
 	fn default() -> Self {
 		Self::Fixed(UnitsPerSecond::from_u8(1))
 	}
+}
+
+#[derive(Debug, PartialEq, Default, Clone, Copy, Serialize, Deserialize)]
+pub struct RequiredClearance {
+	pub vertical: Units,
+	pub horizontal: Units,
 }
 
 pub trait StartMovement {

--- a/src/plugins/common/src/traits/handles_physics.rs
+++ b/src/plugins/common/src/traits/handles_physics.rs
@@ -89,14 +89,14 @@ pub struct NoBodyConfigured {
 }
 
 pub trait ConfigureBody {
-	fn configure_body(&mut self, body: Body, center_offset: Units);
+	fn configure_body(&mut self, body: Body, center_offset: f32);
 }
 
 impl<T> ConfigureBody for T
 where
 	T: DerefMut<Target: ConfigureBody>,
 {
-	fn configure_body(&mut self, body: Body, center_offset: Units) {
+	fn configure_body(&mut self, body: Body, center_offset: f32) {
 		self.deref_mut().configure_body(body, center_offset);
 	}
 }

--- a/src/plugins/common/src/traits/handles_physics.rs
+++ b/src/plugins/common/src/traits/handles_physics.rs
@@ -4,7 +4,7 @@ use crate::{
 	attributes::{effect_target::EffectTarget, health::Health},
 	effects::{force::Force, gravity::Gravity, health_damage::HealthDamage},
 	toi,
-	tools::{Units, speed::Speed, vec_not_nan::VecNotNan},
+	tools::{Units, speed::Speed},
 	traits::{
 		accessors::get::{GetContextMut, View, ViewField},
 		handles_physics::physical_bodies::{Blocker, Body},
@@ -320,13 +320,7 @@ impl RaycastResult for MouseHover {
 pub enum HoverMode {
 	#[default]
 	ColliderOrTerrain,
-	ColliderOrDirectionFrom(VecNotNan<3>),
-}
-
-impl HoverMode {
-	pub fn collider_or_direction_from(vec: Vec3) -> Option<Self> {
-		Some(Self::ColliderOrDirectionFrom(vec.try_into().ok()?))
-	}
+	ColliderOrDirectionFrom(Entity),
 }
 
 #[derive(Debug, PartialEq, Clone, Copy)]

--- a/src/plugins/common/src/traits/handles_physics.rs
+++ b/src/plugins/common/src/traits/handles_physics.rs
@@ -89,15 +89,15 @@ pub struct NoBodyConfigured {
 }
 
 pub trait ConfigureBody {
-	fn configure_body(&mut self, body: Body);
+	fn configure_body(&mut self, body: Body, center_offset: Units);
 }
 
 impl<T> ConfigureBody for T
 where
 	T: DerefMut<Target: ConfigureBody>,
 {
-	fn configure_body(&mut self, body: Body) {
-		self.deref_mut().configure_body(body);
+	fn configure_body(&mut self, body: Body, center_offset: Units) {
+		self.deref_mut().configure_body(body, center_offset);
 	}
 }
 

--- a/src/plugins/map_generation/src/components/mesh_collider.rs
+++ b/src/plugins/map_generation/src/components/mesh_collider.rs
@@ -1,6 +1,7 @@
 use bevy::{ecs::system::StaticSystemParam, prelude::*};
 use common::{
 	errors::{ErrorData, Level},
+	tools::Units,
 	traits::{
 		accessors::get::GetContextMut,
 		handles_physics::{
@@ -40,6 +41,7 @@ where
 			Body::from_shape(Shape::StaticGltfMesh3d)
 				.with_physics_type(PhysicsType::Terrain)
 				.with_blocker_types(Blocker::Physical),
+			Units::ZERO,
 		);
 
 		Ok(())

--- a/src/plugins/map_generation/src/components/mesh_collider.rs
+++ b/src/plugins/map_generation/src/components/mesh_collider.rs
@@ -1,7 +1,6 @@
 use bevy::{ecs::system::StaticSystemParam, prelude::*};
 use common::{
 	errors::{ErrorData, Level},
-	tools::Units,
 	traits::{
 		accessors::get::GetContextMut,
 		handles_physics::{
@@ -41,12 +40,14 @@ where
 			Body::from_shape(Shape::StaticGltfMesh3d)
 				.with_physics_type(PhysicsType::Terrain)
 				.with_blocker_types(Blocker::Physical),
-			Units::ZERO,
+			NO_CENTER_OFFSET,
 		);
 
 		Ok(())
 	}
 }
+
+const NO_CENTER_OFFSET: f32 = 0.;
 
 #[derive(Debug, PartialEq)]
 pub struct HasAlreadyBody {

--- a/src/plugins/movement/src/components/config.rs
+++ b/src/plugins/movement/src/components/config.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 use common::{
-	tools::{Units, UnitsPerSecond},
-	traits::handles_movement::{MovementSpeed, SpeedToggle},
+	tools::UnitsPerSecond,
+	traits::handles_movement::{MovementSpeed, RequiredClearance, SpeedToggle},
 };
 use macros::SavableComponent;
 use serde::{Deserialize, Serialize};
@@ -11,8 +11,7 @@ use std::ops::Index;
 #[require(SpeedIndex)]
 pub(crate) struct Config {
 	pub(crate) speed: MovementSpeed,
-	pub(crate) required_clearance: Units,
-	pub(crate) ground_offset: Units,
+	pub(crate) required_clearance: RequiredClearance,
 }
 
 impl Index<SpeedIndex> for Config {

--- a/src/plugins/movement/src/system_param/movement_config_param/configure_movement.rs
+++ b/src/plugins/movement/src/system_param/movement_config_param/configure_movement.rs
@@ -2,17 +2,13 @@ use crate::{
 	components::config::Config,
 	system_param::movement_config_param::MovementConfigContextMut,
 };
-use common::{
-	tools::Units,
-	traits::handles_movement::{ConfigureMovement, MovementSpeed},
-};
+use common::traits::handles_movement::{ConfigureMovement, MovementSpeed, RequiredClearance};
 
 impl ConfigureMovement for MovementConfigContextMut<'_> {
-	fn configure(&mut self, speed: MovementSpeed, required_clearance: Units, ground_offset: Units) {
+	fn configure(&mut self, speed: MovementSpeed, required_clearance: RequiredClearance) {
 		self.entity.try_insert(Config {
 			speed,
 			required_clearance,
-			ground_offset,
 		});
 	}
 }
@@ -27,7 +23,7 @@ mod tests {
 		prelude::*,
 	};
 	use common::{
-		tools::UnitsPerSecond,
+		tools::{Units, UnitsPerSecond},
 		traits::{accessors::get::GetContextMut, handles_movement::NotConfiguredMovement},
 	};
 	use testing::SingleThreadedApp;
@@ -50,16 +46,20 @@ mod tests {
 				.unwrap();
 				ctx.configure(
 					MovementSpeed::Fixed(UnitsPerSecond::from_u8(11)),
-					Units::from_u8(2),
-					Units::from_u8(5),
+					RequiredClearance {
+						vertical: Units::from_u8(5),
+						horizontal: Units::from_u8(2),
+					},
 				);
 			})?;
 
 		assert_eq!(
 			Some(&Config {
 				speed: MovementSpeed::Fixed(UnitsPerSecond::from_u8(11)),
-				required_clearance: Units::from_u8(2),
-				ground_offset: Units::from_u8(5),
+				required_clearance: RequiredClearance {
+					vertical: Units::from_u8(5),
+					horizontal: Units::from_u8(2),
+				},
 			}),
 			app.world().entity(entity).get::<Config>(),
 		);

--- a/src/plugins/movement/src/systems/compute_path.rs
+++ b/src/plugins/movement/src/systems/compute_path.rs
@@ -45,20 +45,18 @@ fn compute_path<TComputer>(
 	transform: &GlobalTransform,
 	end: Vec3,
 	Config {
-		required_clearance,
-		ground_offset,
-		..
+		required_clearance, ..
 	}: &Config,
 ) -> VecDeque<Vec3>
 where
 	TComputer: ComputePath,
 {
 	let start = transform.translation();
-	let Some(path) = computer.compute_path(start, end, *required_clearance) else {
+	let Some(path) = computer.compute_path(start, end, required_clearance.horizontal) else {
 		return VecDeque::from([]);
 	};
 	let mut path = path
-		.map(|GroundPosition(v)| v.with_y(v.y + **ground_offset))
+		.map(|GroundPosition(v)| v.with_y(v.y + *required_clearance.vertical))
 		.peekable();
 
 	match path.peek() {
@@ -134,6 +132,8 @@ mod tests {
 	}
 
 	mod path {
+		use common::traits::handles_movement::RequiredClearance;
+
 		use super::*;
 
 		#[test]
@@ -188,7 +188,10 @@ mod tests {
 				.world_mut()
 				.spawn((
 					Config {
-						ground_offset: Units::from(2.),
+						required_clearance: RequiredClearance {
+							vertical: Units::from_u8(2),
+							horizontal: Units::from_u8(1),
+						},
 						..default()
 					},
 					Movement::Target(Vec3::default()),
@@ -281,7 +284,10 @@ mod tests {
 				.id();
 			app.world_mut().spawn((
 				Config {
-					required_clearance: Units::from_u8(1),
+					required_clearance: RequiredClearance {
+						vertical: Units::from_u8(2),
+						horizontal: Units::from_u8(1),
+					},
 					..default()
 				},
 				Movement::Target(Vec3::default()),
@@ -310,7 +316,10 @@ mod tests {
 				.id();
 			app.world_mut().spawn((
 				Config {
-					required_clearance: Units::from_u8(42),
+					required_clearance: RequiredClearance {
+						vertical: Units::from_u8(100),
+						horizontal: Units::from_u8(42),
+					},
 					..default()
 				},
 				Movement::Target(Vec3::new(4., 5., 6.)),

--- a/src/plugins/movement/src/systems/face/execute_face.rs
+++ b/src/plugins/movement/src/systems/face/execute_face.rs
@@ -70,11 +70,10 @@ where
 		SkillTarget::Cursor(cursor) => cursor,
 	};
 
-	let transform = transforms.get(entity).ok()?;
 	let hover = hover.raycast(MouseHover {
 		exclude: vec![entity],
 		mode: match cursor {
-			Cursor::Direction => HoverMode::collider_or_direction_from(transform.translation)?,
+			Cursor::Direction => HoverMode::ColliderOrDirectionFrom(entity),
 			Cursor::TerrainHover => HoverMode::ColliderOrTerrain,
 		},
 	})?;
@@ -99,9 +98,7 @@ mod tests {
 	};
 	use common::{
 		components::persistent_entity::PersistentEntity,
-		tools::vec_not_nan::VecNotNan,
 		traits::register_persistent_entities::RegisterPersistentEntities,
-		vec_not_nan,
 	};
 	use macros::NestedMocks;
 	use mockall::{automock, predicate::eq};
@@ -153,7 +150,7 @@ mod tests {
 
 	#[test_case(Cursor::Direction, HoverMode::ColliderOrDirectionFrom; "direction")]
 	#[test_case(Cursor::TerrainHover, |_| HoverMode::ColliderOrTerrain; "terrain hover")]
-	fn do_face_target_cursor_hover_point(cursor: Cursor, mode: fn(VecNotNan<3>) -> HoverMode) {
+	fn do_face_target_cursor_hover_point(cursor: Cursor, mode: fn(Entity) -> HoverMode) {
 		let mut app = setup();
 		let agent = app
 			.world_mut()
@@ -167,7 +164,7 @@ mod tests {
 			mock.expect_raycast()
 				.with(eq(MouseHover {
 					exclude: vec![agent],
-					mode: mode(vec_not_nan!(4., 2., 6.)),
+					mode: mode(agent),
 				}))
 				.return_const(MouseHoversOver::Point(Vec3::new(1., 2., 3.)));
 		}));
@@ -182,7 +179,7 @@ mod tests {
 
 	#[test_case(Cursor::Direction, HoverMode::ColliderOrDirectionFrom; "direction")]
 	#[test_case(Cursor::TerrainHover, |_| HoverMode::ColliderOrTerrain; "terrain hover")]
-	fn face_target_cursor_hover_entity(cursor: Cursor, mode: fn(VecNotNan<3>) -> HoverMode) {
+	fn face_target_cursor_hover_entity(cursor: Cursor, mode: fn(Entity) -> HoverMode) {
 		let mut app = setup();
 		let entity = app.world_mut().spawn(Transform::from_xyz(6., 5., 20.)).id();
 		let agent = app
@@ -197,7 +194,7 @@ mod tests {
 			mock.expect_raycast()
 				.with(eq(MouseHover {
 					exclude: vec![agent],
-					mode: mode(vec_not_nan!(4., 5., 6.)),
+					mode: mode(agent),
 				}))
 				.return_const(MouseHoversOver::Object {
 					entity,
@@ -215,7 +212,7 @@ mod tests {
 
 	#[test_case(Cursor::Direction, HoverMode::ColliderOrDirectionFrom; "direction")]
 	#[test_case(Cursor::TerrainHover, |_| HoverMode::ColliderOrTerrain; "terrain hover")]
-	fn face_target_cursor_hover_ground(cursor: Cursor, mode: fn(VecNotNan<3>) -> HoverMode) {
+	fn face_target_cursor_hover_ground(cursor: Cursor, mode: fn(Entity) -> HoverMode) {
 		let mut app = setup();
 		let agent = app
 			.world_mut()
@@ -229,7 +226,7 @@ mod tests {
 			mock.expect_raycast()
 				.with(eq(MouseHover {
 					exclude: vec![agent],
-					mode: mode(vec_not_nan!(4., 5., 6.)),
+					mode: mode(agent),
 				}))
 				.return_const(MouseHoversOver::Point(Vec3::new(6., 3., 7.)));
 		}));

--- a/src/plugins/physics/src/components.rs
+++ b/src/plugins/physics/src/components.rs
@@ -3,6 +3,7 @@ pub(crate) mod anchor;
 pub(crate) mod async_collider;
 pub(crate) mod blockable;
 pub(crate) mod blocker_types;
+pub(crate) mod center_offset;
 pub(crate) mod character_gravity;
 pub(crate) mod character_motion;
 pub(crate) mod collider;

--- a/src/plugins/physics/src/components/center_offset.rs
+++ b/src/plugins/physics/src/components/center_offset.rs
@@ -1,5 +1,4 @@
 use bevy::prelude::*;
-use common::tools::Units;
 
 #[derive(Component, Debug, PartialEq, Default)]
-pub(crate) struct CenterOffset(pub(crate) Units);
+pub(crate) struct CenterOffset(pub(crate) f32);

--- a/src/plugins/physics/src/components/center_offset.rs
+++ b/src/plugins/physics/src/components/center_offset.rs
@@ -2,3 +2,16 @@ use bevy::prelude::*;
 
 #[derive(Component, Debug, PartialEq, Default)]
 pub(crate) struct CenterOffset(pub(crate) f32);
+
+pub(crate) trait ComputeOffsetTranslation {
+	fn compute_translation(self, transform: &GlobalTransform) -> Vec3;
+}
+
+impl ComputeOffsetTranslation for Option<&CenterOffset> {
+	fn compute_translation(self, transform: &GlobalTransform) -> Vec3 {
+		match self {
+			Some(CenterOffset(offset)) => transform.translation() + Vec3::new(0., *offset, 0.),
+			None => transform.translation(),
+		}
+	}
+}

--- a/src/plugins/physics/src/components/center_offset.rs
+++ b/src/plugins/physics/src/components/center_offset.rs
@@ -1,0 +1,5 @@
+use bevy::prelude::*;
+use common::tools::Units;
+
+#[derive(Component, Debug, PartialEq, Default)]
+pub(crate) struct CenterOffset(pub(crate) Units);

--- a/src/plugins/physics/src/components/physical_body.rs
+++ b/src/plugins/physics/src/components/physical_body.rs
@@ -1,5 +1,6 @@
 use crate::components::{
 	blocker_types::BlockerTypes,
+	center_offset::CenterOffset,
 	collider::{
 		ColliderShape,
 		GENERIC_COLLISION_GROUP,
@@ -20,6 +21,7 @@ use common::{
 
 #[derive(Component, Debug, PartialEq)]
 #[component(immutable)]
+#[require(CenterOffset)]
 pub struct PhysicalBody(pub(crate) Body);
 
 impl PhysicalBody {

--- a/src/plugins/physics/src/observers/process_dirty_anchor.rs
+++ b/src/plugins/physics/src/observers/process_dirty_anchor.rs
@@ -13,7 +13,6 @@ use bevy::{
 use common::{
 	components::persistent_entity::PersistentEntity,
 	errors::{ErrorData, Level},
-	tools::vec_not_nan::{IsNaN, VecNotNan},
 	traits::{
 		accessors::get::{Get, TryApplyOn},
 		handles_physics::{HoverMode, MouseHover, MouseHoversOver, Raycast},
@@ -84,10 +83,12 @@ impl AnchorDirty {
 			return Err(AnchorError::EntityWithoutTransform(mount));
 		};
 
-		let mount_translation = VecNotNan::try_from(mount_transform.translation())
-			.map_err(|_: IsNaN<3>| AnchorError::TranslationNaN(mount))?;
+		let mount_translation = mount_transform.translation();
+		if mount_translation.is_nan() {
+			return Err(AnchorError::TranslationNaN(mount));
+		}
 
-		transform.translation = Vec3::from(mount_translation);
+		transform.translation = mount_translation;
 		match anchor.rotation {
 			AnchorRotation::OfAttachedTo => match_rotation(transform, attached_to_transform),
 			AnchorRotation::OfMount => match_rotation(transform, mount_transform),
@@ -98,7 +99,7 @@ impl AnchorDirty {
 				targets,
 				transforms,
 				attached_to,
-				mount_translation,
+				mount,
 			),
 		}
 	}
@@ -119,7 +120,7 @@ fn look_at_skill_target<TRayCaster, TMountError>(
 	targets: Query<&Target>,
 	transforms: Query<&GlobalTransform>,
 	attached_to: Entity,
-	translation: VecNotNan<3>,
+	mount: Entity,
 ) -> Result<(), AnchorError<TMountError>>
 where
 	TRayCaster: for<'w, 's> SystemParam<Item<'w, 's>: Raycast<MouseHover>>,
@@ -133,7 +134,7 @@ where
 			let hover = MouseHover {
 				exclude: vec![attached_to],
 				mode: match cursor {
-					Cursor::Direction => HoverMode::ColliderOrDirectionFrom(translation),
+					Cursor::Direction => HoverMode::ColliderOrDirectionFrom(mount),
 					Cursor::TerrainHover => HoverMode::ColliderOrTerrain,
 				},
 			};
@@ -214,13 +215,12 @@ mod tests {
 	use super::*;
 	use common::{
 		components::persistent_entity::PersistentEntity,
-		tools::{action_key::slot::SlotKey, vec_not_nan::VecNotNan},
+		tools::action_key::slot::SlotKey,
 		traits::{
 			handles_physics::{HoverMode, MouseHoversOver},
 			handles_skill_physics::{Cursor, SkillMount},
 			register_persistent_entities::RegisterPersistentEntities,
 		},
-		vec_not_nan,
 	};
 	use macros::NestedMocks;
 	use mockall::{automock, predicate::eq};
@@ -419,7 +419,7 @@ mod tests {
 
 	#[test_case(Cursor::TerrainHover, |_|HoverMode::ColliderOrTerrain; "terrain")]
 	#[test_case(Cursor::Direction ,HoverMode::ColliderOrDirectionFrom; "direction")]
-	fn look_at_cursor_over_terrain(cursor: Cursor, mode: fn(VecNotNan<3>) -> HoverMode) {
+	fn look_at_cursor_over_terrain(cursor: Cursor, mode: fn(Entity) -> HoverMode) {
 		let mut app = setup();
 		let spawner_key = SkillMount::Slot(SlotKey(22));
 		let agent = app
@@ -442,7 +442,7 @@ mod tests {
 				.once()
 				.with(eq(MouseHover {
 					exclude: vec![agent],
-					mode: mode(vec_not_nan!(4., 11., 9.)),
+					mode: mode(mount_point),
 				}))
 				.return_const(MouseHoversOver::Point(Vec3::new(11., 22., 33.)));
 		}));
@@ -461,7 +461,7 @@ mod tests {
 
 	#[test_case(Cursor::TerrainHover, |_|HoverMode::ColliderOrTerrain; "terrain")]
 	#[test_case(Cursor::Direction ,HoverMode::ColliderOrDirectionFrom; "direction")]
-	fn look_at_cursor_over_object(cursor: Cursor, mode: fn(VecNotNan<3>) -> HoverMode) {
+	fn look_at_cursor_over_object(cursor: Cursor, mode: fn(Entity) -> HoverMode) {
 		let mut app = setup();
 		let spawner_key = SkillMount::Slot(SlotKey(22));
 		let agent = app
@@ -488,7 +488,7 @@ mod tests {
 				.once()
 				.with(eq(MouseHover {
 					exclude: vec![agent],
-					mode: mode(vec_not_nan!(4., 11., 9.)),
+					mode: mode(mount_point),
 				}))
 				.return_const(MouseHoversOver::Object {
 					entity: target,

--- a/src/plugins/physics/src/observers/process_dirty_anchor.rs
+++ b/src/plugins/physics/src/observers/process_dirty_anchor.rs
@@ -1,6 +1,7 @@
 use crate::{
 	components::{
 		anchor::{Anchor, AnchorDirty, AnchorRotation},
+		center_offset::{CenterOffset, ComputeOffsetTranslation},
 		target::Target,
 	},
 	system_params::mount_points_lookup::{MountPointsLookup, get_mount_point::MountPointError},
@@ -30,7 +31,7 @@ impl AnchorDirty {
 		ray_caster: StaticSystemParam<TRayCaster>,
 		agents: Query<(&Anchor, &mut Transform)>,
 		targets: Query<&Target>,
-		transforms: Query<&GlobalTransform>,
+		transforms: Query<(&GlobalTransform, Option<&CenterOffset>)>,
 	) -> Result<(), AnchorError<MountPointError<SkillMount>>>
 	where
 		TRayCaster: for<'w, 's> SystemParam<Item<'w, 's>: Raycast<MouseHover>>,
@@ -47,7 +48,7 @@ impl AnchorDirty {
 		ray_caster: StaticSystemParam<TRayCaster>,
 		mut agents: Query<(&Anchor, &mut Transform)>,
 		targets: Query<&Target>,
-		transforms: Query<&GlobalTransform>,
+		transforms: Query<(&GlobalTransform, Option<&CenterOffset>)>,
 	) -> Result<(), AnchorError<TMountError>>
 	where
 		TLookup:
@@ -75,11 +76,11 @@ impl AnchorDirty {
 			Err(error) => return Err(AnchorError::MountError(error)),
 		};
 
-		let Ok(attached_to_transform) = transforms.get(attached_to) else {
+		let Ok((attached_to_transform, _)) = transforms.get(attached_to) else {
 			return Err(AnchorError::EntityWithoutTransform(attached_to));
 		};
 
-		let Ok(mount_transform) = transforms.get(mount) else {
+		let Ok((mount_transform, _)) = transforms.get(mount) else {
 			return Err(AnchorError::EntityWithoutTransform(mount));
 		};
 
@@ -118,7 +119,7 @@ fn look_at_skill_target<TRayCaster, TMountError>(
 	mut ray_caster: StaticSystemParam<TRayCaster>,
 	commands: ZyheedaCommands,
 	targets: Query<&Target>,
-	transforms: Query<&GlobalTransform>,
+	transforms: Query<(&GlobalTransform, Option<&CenterOffset>)>,
 	attached_to: Entity,
 	mount: Entity,
 ) -> Result<(), AnchorError<TMountError>>
@@ -144,11 +145,11 @@ where
 			let target = match hit {
 				MouseHoversOver::Point(point) => point,
 				MouseHoversOver::Object { entity, .. } => {
-					let Ok(target) = transforms.get(entity) else {
+					let Ok((target, offset)) = transforms.get(entity) else {
 						return Err(AnchorError::EntityWithoutTransform(entity));
 					};
 
-					target.translation()
+					offset.compute_translation(target)
 				}
 			};
 
@@ -158,11 +159,11 @@ where
 			let Some(target) = commands.get(&entity) else {
 				return Err(AnchorError::EntityNotFound(entity));
 			};
-			let Ok(target) = transforms.get(target) else {
+			let Ok((target, offset)) = transforms.get(target) else {
 				return Err(AnchorError::EntityWithoutTransform(target));
 			};
 
-			anchor_transform.look_at(target.translation(), Vec3::Y);
+			anchor_transform.look_at(offset.compute_translation(target), Vec3::Y);
 		}
 	}
 
@@ -417,6 +418,45 @@ mod tests {
 		);
 	}
 
+	#[test]
+	fn look_at_target_with_offset() {
+		let mut app = setup();
+		let spawner_key = SkillMount::Slot(SlotKey(22));
+		let target = PersistentEntity::default();
+		let agent = app
+			.world_mut()
+			.spawn((
+				*AGENT,
+				GlobalTransform::default(),
+				Target(Some(SkillTarget::Entity(target))),
+			))
+			.id();
+		let mount_point = app
+			.world_mut()
+			.spawn(GlobalTransform::from_xyz(4., 11., 9.))
+			.id();
+		app.insert_resource(_Lookup {
+			mount_points: HashMap::from([((spawner_key, agent), mount_point)]),
+		});
+
+		app.world_mut().spawn((
+			target,
+			GlobalTransform::from_xyz(11., -20., 3.),
+			CenterOffset(5.),
+		));
+
+		let anchor = app.world_mut().spawn(
+			Anchor::attach_to(*AGENT)
+				.on(spawner_key)
+				.looking_at_skill_target(),
+		);
+
+		assert_eq!(
+			Some(&Transform::from_xyz(4., 11., 9.).looking_at(Vec3::new(11., -15., 3.), Vec3::Y)),
+			anchor.get::<Transform>(),
+		);
+	}
+
 	#[test_case(Cursor::TerrainHover, |_|HoverMode::ColliderOrTerrain; "terrain")]
 	#[test_case(Cursor::Direction ,HoverMode::ColliderOrDirectionFrom; "direction")]
 	fn look_at_cursor_over_terrain(cursor: Cursor, mode: fn(Entity) -> HoverMode) {
@@ -504,6 +544,55 @@ mod tests {
 
 		assert_eq!(
 			Some(&Transform::from_xyz(4., 11., 9.).looking_at(Vec3::new(11., 22., 33.), Vec3::Y)),
+			anchor.get::<Transform>(),
+		);
+	}
+
+	#[test_case(Cursor::TerrainHover, |_|HoverMode::ColliderOrTerrain; "terrain")]
+	#[test_case(Cursor::Direction ,HoverMode::ColliderOrDirectionFrom; "direction")]
+	fn look_at_cursor_over_object_with_pitch(cursor: Cursor, mode: fn(Entity) -> HoverMode) {
+		let mut app = setup();
+		let spawner_key = SkillMount::Slot(SlotKey(22));
+		let agent = app
+			.world_mut()
+			.spawn((
+				*AGENT,
+				GlobalTransform::default(),
+				Target(Some(SkillTarget::Cursor(cursor))),
+			))
+			.id();
+		let mount_point = app
+			.world_mut()
+			.spawn(GlobalTransform::from_xyz(4., 11., 9.))
+			.id();
+		app.insert_resource(_Lookup {
+			mount_points: HashMap::from([((spawner_key, agent), mount_point)]),
+		});
+		let target = app
+			.world_mut()
+			.spawn((GlobalTransform::from_xyz(11., 22., 33.), CenterOffset(5.)))
+			.id();
+		app.insert_resource(_RayCaster::new().with_mock(|mock| {
+			mock.expect_raycast()
+				.once()
+				.with(eq(MouseHover {
+					exclude: vec![agent],
+					mode: mode(mount_point),
+				}))
+				.return_const(MouseHoversOver::Object {
+					entity: target,
+					point: Vec3::ZERO,
+				});
+		}));
+
+		let anchor = app.world_mut().spawn(
+			Anchor::attach_to(*AGENT)
+				.on(spawner_key)
+				.looking_at_skill_target(),
+		);
+
+		assert_eq!(
+			Some(&Transform::from_xyz(4., 11., 9.).looking_at(Vec3::new(11., 27., 33.), Vec3::Y)),
 			anchor.get::<Transform>(),
 		);
 	}

--- a/src/plugins/physics/src/system_params/config/body.rs
+++ b/src/plugins/physics/src/system_params/config/body.rs
@@ -1,9 +1,16 @@
-use crate::{components::physical_body::PhysicalBody, system_params::config::ConfigContextMut};
-use common::traits::handles_physics::{ConfigureBody, physical_bodies::Body};
+use crate::{
+	components::{center_offset::CenterOffset, physical_body::PhysicalBody},
+	system_params::config::ConfigContextMut,
+};
+use common::{
+	tools::Units,
+	traits::handles_physics::{ConfigureBody, physical_bodies::Body},
+};
 
 impl ConfigureBody for ConfigContextMut<'_> {
-	fn configure_body(&mut self, body: Body) {
-		self.entity.try_insert(PhysicalBody(body));
+	fn configure_body(&mut self, body: Body, center_offset: Units) {
+		self.entity
+			.try_insert((PhysicalBody(body), CenterOffset(center_offset)));
 	}
 }
 
@@ -11,14 +18,20 @@ impl ConfigureBody for ConfigContextMut<'_> {
 mod tests {
 	#![allow(clippy::unwrap_used)]
 	use super::*;
-	use crate::{components::physical_body::PhysicalBody, system_params::config::ConfigParamMut};
+	use crate::{
+		components::{center_offset::CenterOffset, physical_body::PhysicalBody},
+		system_params::config::ConfigParamMut,
+	};
 	use bevy::{
 		ecs::system::{RunSystemError, RunSystemOnce},
 		prelude::*,
 	};
-	use common::traits::{
-		accessors::get::GetContextMut,
-		handles_physics::{NoBodyConfigured, physical_bodies::Shape},
+	use common::{
+		tools::Units,
+		traits::{
+			accessors::get::GetContextMut,
+			handles_physics::{NoBodyConfigured, physical_bodies::Shape},
+		},
 	};
 	use testing::SingleThreadedApp;
 
@@ -35,12 +48,31 @@ mod tests {
 			.run_system_once(move |mut p: ConfigParamMut| {
 				let key = NoBodyConfigured { entity };
 				let mut ctx = ConfigParamMut::get_context_mut(&mut p, key).unwrap();
-				ctx.configure_body(Body::from_shape(Shape::StaticGltfMesh3d));
+				ctx.configure_body(Body::from_shape(Shape::StaticGltfMesh3d), Units::ZERO);
 			})?;
 
 		assert_eq!(
 			Some(&PhysicalBody(Body::from_shape(Shape::StaticGltfMesh3d))),
 			app.world().entity(entity).get::<PhysicalBody>(),
+		);
+		Ok(())
+	}
+
+	#[test]
+	fn insert_offset() -> Result<(), RunSystemError> {
+		let mut app = setup();
+		let entity = app.world_mut().spawn_empty().id();
+
+		app.world_mut()
+			.run_system_once(move |mut p: ConfigParamMut| {
+				let key = NoBodyConfigured { entity };
+				let mut ctx = ConfigParamMut::get_context_mut(&mut p, key).unwrap();
+				ctx.configure_body(Body::from_shape(Shape::StaticGltfMesh3d), Units::from(11.));
+			})?;
+
+		assert_eq!(
+			Some(&CenterOffset(Units::from(11.))),
+			app.world().entity(entity).get::<CenterOffset>(),
 		);
 		Ok(())
 	}

--- a/src/plugins/physics/src/system_params/config/body.rs
+++ b/src/plugins/physics/src/system_params/config/body.rs
@@ -2,13 +2,10 @@ use crate::{
 	components::{center_offset::CenterOffset, physical_body::PhysicalBody},
 	system_params::config::ConfigContextMut,
 };
-use common::{
-	tools::Units,
-	traits::handles_physics::{ConfigureBody, physical_bodies::Body},
-};
+use common::traits::handles_physics::{ConfigureBody, physical_bodies::Body};
 
 impl ConfigureBody for ConfigContextMut<'_> {
-	fn configure_body(&mut self, body: Body, center_offset: Units) {
+	fn configure_body(&mut self, body: Body, center_offset: f32) {
 		self.entity
 			.try_insert((PhysicalBody(body), CenterOffset(center_offset)));
 	}
@@ -26,12 +23,9 @@ mod tests {
 		ecs::system::{RunSystemError, RunSystemOnce},
 		prelude::*,
 	};
-	use common::{
-		tools::Units,
-		traits::{
-			accessors::get::GetContextMut,
-			handles_physics::{NoBodyConfigured, physical_bodies::Shape},
-		},
+	use common::traits::{
+		accessors::get::GetContextMut,
+		handles_physics::{NoBodyConfigured, physical_bodies::Shape},
 	};
 	use testing::SingleThreadedApp;
 
@@ -48,7 +42,7 @@ mod tests {
 			.run_system_once(move |mut p: ConfigParamMut| {
 				let key = NoBodyConfigured { entity };
 				let mut ctx = ConfigParamMut::get_context_mut(&mut p, key).unwrap();
-				ctx.configure_body(Body::from_shape(Shape::StaticGltfMesh3d), Units::ZERO);
+				ctx.configure_body(Body::from_shape(Shape::StaticGltfMesh3d), 0.);
 			})?;
 
 		assert_eq!(
@@ -67,11 +61,11 @@ mod tests {
 			.run_system_once(move |mut p: ConfigParamMut| {
 				let key = NoBodyConfigured { entity };
 				let mut ctx = ConfigParamMut::get_context_mut(&mut p, key).unwrap();
-				ctx.configure_body(Body::from_shape(Shape::StaticGltfMesh3d), Units::from(11.));
+				ctx.configure_body(Body::from_shape(Shape::StaticGltfMesh3d), 11.);
 			})?;
 
 		assert_eq!(
-			Some(&CenterOffset(Units::from(11.))),
+			Some(&CenterOffset(11.)),
 			app.world().entity(entity).get::<CenterOffset>(),
 		);
 		Ok(())

--- a/src/plugins/physics/src/system_params/ray_caster.rs
+++ b/src/plugins/physics/src/system_params/ray_caster.rs
@@ -4,6 +4,7 @@ mod solid_objects;
 mod terrain;
 
 use crate::components::{
+	center_offset::CenterOffset,
 	collider::ChildCollider,
 	interaction_target::InteractionTarget,
 	world_camera::WorldCamera,
@@ -22,5 +23,6 @@ where
 	context: StaticSystemParam<'w, 's, T>,
 	interaction_child_colliders: Query<'w, 's, &'static ChildCollider<InteractionTarget>>,
 	rigid_body_child_colliders: Query<'w, 's, &'static ChildCollider<RigidBody>>,
+	transforms: Query<'w, 's, (&'static GlobalTransform, Option<&'static CenterOffset>)>,
 	world_cams: Query<'w, 's, &'static mut WorldCamera>,
 }

--- a/src/plugins/physics/src/system_params/ray_caster/mouse_hover.rs
+++ b/src/plugins/physics/src/system_params/ray_caster/mouse_hover.rs
@@ -1,19 +1,13 @@
-use crate::system_params::ray_caster::RayCaster;
-use bevy::{
-	ecs::system::SystemParam,
-	math::{Dir3, Ray3d, Vec3, primitives::InfinitePlane3d},
-};
-use common::{
-	tools::vec_not_nan::VecNotNan,
-	traits::handles_physics::{
-		HoverMode,
-		MouseHover,
-		MouseHoversOver,
-		Raycast,
-		SolidObjects,
-		Terrain,
-		TimeOfImpact,
-	},
+use crate::{components::center_offset::CenterOffset, system_params::ray_caster::RayCaster};
+use bevy::{ecs::system::SystemParam, prelude::*};
+use common::traits::handles_physics::{
+	HoverMode,
+	MouseHover,
+	MouseHoversOver,
+	Raycast,
+	SolidObjects,
+	Terrain,
+	TimeOfImpact,
 };
 
 impl<T> Raycast<MouseHover> for RayCaster<'_, '_, T>
@@ -36,7 +30,7 @@ where
 		});
 		let plane_hit = match mouse_hover.mode {
 			HoverMode::ColliderOrTerrain => None,
-			HoverMode::ColliderOrDirectionFrom(plane) => intersect_horizontal_plane(ray, plane),
+			HoverMode::ColliderOrDirectionFrom(entity) => self.hit_horizontal_plane(ray, entity),
 		};
 		let ground_hit = self.raycast(Terrain { ray });
 		let hover = match (object_hit, plane_hit, ground_hit) {
@@ -61,14 +55,27 @@ where
 	}
 }
 
-fn point(ray: Ray3d, toi: f32) -> Vec3 {
-	ray.origin + ray.direction * toi
+impl<T> RayCaster<'_, '_, T>
+where
+	T: SystemParam,
+{
+	fn hit_horizontal_plane(&self, ray: Ray3d, entity: Entity) -> Option<TimeOfImpact> {
+		let Ok((transform, offset)) = self.transforms.get(entity) else {
+			return None;
+		};
+
+		let plane_origin = match offset {
+			Some(CenterOffset(offset)) => transform.translation() + Vec3::new(0., *offset, 0.),
+			None => transform.translation(),
+		};
+
+		ray.intersect_plane(plane_origin, InfinitePlane3d { normal: Dir3::Y })
+			.and_then(|toi| TimeOfImpact::try_from_f32(toi).ok())
+	}
 }
 
-fn intersect_horizontal_plane(ray: Ray3d, plane_origin: VecNotNan<3>) -> Option<TimeOfImpact> {
-	let toi = ray.intersect_plane(plane_origin.into(), InfinitePlane3d { normal: Dir3::Y })?;
-
-	TimeOfImpact::try_from_f32(toi).ok()
+fn point(ray: Ray3d, toi: f32) -> Vec3 {
+	ray.origin + ray.direction * toi
 }
 
 #[cfg(test)]
@@ -82,13 +89,11 @@ mod tests {
 			resource::Resource,
 			system::{RunSystemError, RunSystemOnce},
 		},
-		prelude::*,
 	};
 	use common::{
 		toi,
 		tools::Units,
 		traits::handles_physics::{HoverMode, RaycastHit, TimeOfImpact},
-		vec_not_nan,
 	};
 	use macros::NestedMocks;
 	use mockall::{automock, predicate::eq};
@@ -277,6 +282,8 @@ mod tests {
 	}
 
 	mod direction_mode {
+		use crate::components::center_offset::CenterOffset;
+
 		use super::*;
 
 		#[test]
@@ -295,15 +302,51 @@ mod tests {
 					mock.expect_raycast().return_const(None);
 				}),
 			);
+			let entity = app
+				.world_mut()
+				.spawn(GlobalTransform::from_xyz(0., 10., 0.))
+				.id();
 
 			app.world_mut()
 				.run_system_once(move |mut ray_caster: _RayCaster| {
 					let hit = ray_caster.raycast(MouseHover {
 						exclude: vec![exclude],
-						mode: HoverMode::ColliderOrDirectionFrom(vec_not_nan!(0., 10., 0.)),
+						mode: HoverMode::ColliderOrDirectionFrom(entity),
 					});
 
 					assert_eq!(Some(MouseHoversOver::Point(Vec3::new(1., 10., 3.))), hit);
+				})
+		}
+
+		#[test]
+		fn return_direction_hit_with_center_offset() -> Result<(), RunSystemError> {
+			let ray = Ray3d {
+				origin: Vec3::new(1., 20., 3.),
+				direction: Dir3::NEG_Y,
+			};
+			let exclude = fake_entity!(444);
+			let (mut app, _) = setup(
+				ray,
+				_Objects::new().with_mock(|mock| {
+					mock.expect_raycast().return_const(None);
+				}),
+				_Ground::new().with_mock(|mock| {
+					mock.expect_raycast().return_const(None);
+				}),
+			);
+			let entity = app
+				.world_mut()
+				.spawn((GlobalTransform::from_xyz(0., 10., 0.), CenterOffset(1.)))
+				.id();
+
+			app.world_mut()
+				.run_system_once(move |mut ray_caster: _RayCaster| {
+					let hit = ray_caster.raycast(MouseHover {
+						exclude: vec![exclude],
+						mode: HoverMode::ColliderOrDirectionFrom(entity),
+					});
+
+					assert_eq!(Some(MouseHoversOver::Point(Vec3::new(1., 11., 3.))), hit);
 				})
 		}
 
@@ -324,12 +367,16 @@ mod tests {
 						.return_const(Some(TimeOfImpact::from(Units::from(1.))));
 				}),
 			);
+			let entity = app
+				.world_mut()
+				.spawn(GlobalTransform::from_xyz(0., 10., 0.))
+				.id();
 
 			app.world_mut()
 				.run_system_once(move |mut ray_caster: _RayCaster| {
 					let hit = ray_caster.raycast(MouseHover {
 						exclude: vec![exclude],
-						mode: HoverMode::ColliderOrDirectionFrom(vec_not_nan!(0., 10., 0.)),
+						mode: HoverMode::ColliderOrDirectionFrom(entity),
 					});
 
 					assert_eq!(Some(MouseHoversOver::Point(Vec3::new(1., 10., 3.))), hit);
@@ -356,12 +403,16 @@ mod tests {
 						.return_const(Some(TimeOfImpact::from(Units::from(15.))));
 				}),
 			);
+			let entity = app
+				.world_mut()
+				.spawn(GlobalTransform::from_xyz(0., 10., 0.))
+				.id();
 
 			app.world_mut()
 				.run_system_once(move |mut ray_caster: _RayCaster| {
 					let hit = ray_caster.raycast(MouseHover {
 						exclude: vec![exclude],
-						mode: HoverMode::ColliderOrDirectionFrom(vec_not_nan!(0., 10., 0.)),
+						mode: HoverMode::ColliderOrDirectionFrom(entity),
 					});
 
 					assert_eq!(
@@ -395,12 +446,16 @@ mod tests {
 						.return_const(Some(TimeOfImpact::from(Units::from(12.))));
 				}),
 			);
+			let entity = app
+				.world_mut()
+				.spawn(GlobalTransform::from_xyz(0., 10., 0.))
+				.id();
 
 			app.world_mut()
 				.run_system_once(move |mut ray_caster: _RayCaster| {
 					let hit = ray_caster.raycast(MouseHover {
 						exclude: vec![exclude],
-						mode: HoverMode::ColliderOrDirectionFrom(vec_not_nan!(0., 10., 0.)),
+						mode: HoverMode::ColliderOrDirectionFrom(entity),
 					});
 
 					assert_eq!(Some(MouseHoversOver::Point(Vec3::new(1., 10., 3.))), hit);

--- a/src/plugins/physics/src/systems/update_target_pitch.rs
+++ b/src/plugins/physics/src/systems/update_target_pitch.rs
@@ -56,14 +56,16 @@ impl Target {
 		match self.0.as_ref()? {
 			SkillTarget::Entity(entity) => {
 				let target = commands.get(entity)?;
-				let target = transforms.get(target).ok()?.0.translation();
+				let (target_transform, target_offset) = transforms.get(target).ok()?;
+				let target = with_offset(target_transform, target_offset);
 				get_pitch(transform, offset, target)
 			}
 			SkillTarget::Cursor(Cursor::TerrainHover) => {
 				match ray_cast.raycast(MouseHover::excluding([entity]))? {
 					MouseHoversOver::Point(point) => get_pitch(transform, offset, point),
 					MouseHoversOver::Object { entity, .. } => {
-						let target = transforms.get(entity).ok()?.0.translation();
+						let (target_transform, target_offset) = transforms.get(entity).ok()?;
+						let target = with_offset(target_transform, target_offset);
 						get_pitch(transform, offset, target)
 					}
 				}
@@ -78,17 +80,20 @@ fn get_pitch(
 	offset: Option<&CenterOffset>,
 	to: Vec3,
 ) -> Option<DirForwardPitch> {
-	let origin = match offset {
-		Some(CenterOffset(offset)) => transform.translation() + Vec3::new(0., *offset, 0.),
-		None => transform.translation(),
-	};
-	let dir = (to - origin).try_normalize()?;
+	let dir = (to - with_offset(transform, offset)).try_normalize()?;
 	let pitch = ForwardPitch::try_from((dir.y.asin() / FRAC_PI_2).abs()).ok()?;
 
 	if dir.y > 0. {
 		Some(DirForwardPitch::Up(pitch))
 	} else {
 		Some(DirForwardPitch::Down(pitch))
+	}
+}
+
+fn with_offset(transform: &GlobalTransform, offset: Option<&CenterOffset>) -> Vec3 {
+	match offset {
+		Some(CenterOffset(offset)) => transform.translation() + Vec3::new(0., *offset, 0.),
+		None => transform.translation(),
 	}
 }
 
@@ -285,6 +290,47 @@ mod tests {
 	#[test_case(-45., ForwardPitch::try_from(0.5).ok().map(DirForwardPitch::Down); "45 degrees down")]
 	#[test_case(90., DirForwardPitch::Up(ForwardPitch::MAX); "90 degrees up")]
 	#[test_case(-90., DirForwardPitch::Down(ForwardPitch::MAX); "90 degrees down")]
+	fn set_target_entity_pitch_with_target_offset(
+		angle: f32,
+		forward_pitch: impl Into<Option<DirForwardPitch>>,
+	) {
+		let mut app = setup();
+		let translation = Vec3::new(10., 2., 0.);
+		let offset = Quat::from_rotation_x(angle.to_radians()).mul_vec3(Vec3::new(0., 0., -30.));
+		let target_entity = PersistentEntity::default();
+		let entity = app
+			.world_mut()
+			.spawn((
+				Target(Some(SkillTarget::Entity(target_entity))),
+				GlobalTransform::from_translation(translation),
+				_Animations {
+					forward_pitch: None,
+				},
+			))
+			.id();
+
+		app.world_mut().spawn((
+			target_entity,
+			GlobalTransform::from_translation(translation + Vec3::new(0., -3., 0.) + offset),
+			CenterOffset(3.),
+		));
+
+		app.update();
+
+		assert_eq_approx!(
+			Some(&_Animations {
+				forward_pitch: forward_pitch.into()
+			}),
+			app.world().entity(entity).get::<_Animations>(),
+			1e-5,
+		);
+	}
+
+	#[test_case(0., None; "0 degrees")]
+	#[test_case(45., ForwardPitch::try_from(0.5).ok().map(DirForwardPitch::Up); "45 degrees up")]
+	#[test_case(-45., ForwardPitch::try_from(0.5).ok().map(DirForwardPitch::Down); "45 degrees down")]
+	#[test_case(90., DirForwardPitch::Up(ForwardPitch::MAX); "90 degrees up")]
+	#[test_case(-90., DirForwardPitch::Down(ForwardPitch::MAX); "90 degrees down")]
 	fn set_cursor_terrain_hit_pitch(angle: f32, forward_pitch: impl Into<Option<DirForwardPitch>>) {
 		let mut app = setup();
 		let translation = Vec3::new(10., 2., 0.);
@@ -422,6 +468,54 @@ mod tests {
 				Target(Some(SkillTarget::Cursor(Cursor::TerrainHover))),
 				GlobalTransform::from_translation(translation),
 				CenterOffset(3.),
+				_Animations {
+					forward_pitch: None,
+				},
+			))
+			.id();
+		app.insert_resource(_RayCast::new().with_mock(|mock| {
+			mock.expect_raycast()
+				.return_const(Some(MouseHoversOver::Object {
+					entity: target,
+					point: Vec3::ZERO,
+				}));
+		}));
+
+		app.update();
+
+		assert_eq_approx!(
+			Some(&_Animations {
+				forward_pitch: forward_pitch.into()
+			}),
+			app.world().entity(entity).get::<_Animations>(),
+			1e-5,
+		);
+	}
+
+	#[test_case(0., None; "0 degrees")]
+	#[test_case(45., ForwardPitch::try_from(0.5).ok().map(DirForwardPitch::Up); "45 degrees up")]
+	#[test_case(-45., ForwardPitch::try_from(0.5).ok().map(DirForwardPitch::Down); "45 degrees down")]
+	#[test_case(90., DirForwardPitch::Up(ForwardPitch::MAX); "90 degrees up")]
+	#[test_case(-90., DirForwardPitch::Down(ForwardPitch::MAX); "90 degrees down")]
+	fn set_cursor_entity_hit_pitch_with_hit_offset(
+		angle: f32,
+		forward_pitch: impl Into<Option<DirForwardPitch>>,
+	) {
+		let mut app = setup();
+		let translation = Vec3::new(10., 2., 0.);
+		let offset = Quat::from_rotation_x(angle.to_radians()).mul_vec3(Vec3::new(0., 0., -30.));
+		let target = app
+			.world_mut()
+			.spawn((
+				GlobalTransform::from_translation(translation + Vec3::new(0., -3., 0.) + offset),
+				CenterOffset(3.),
+			))
+			.id();
+		let entity = app
+			.world_mut()
+			.spawn((
+				Target(Some(SkillTarget::Cursor(Cursor::TerrainHover))),
+				GlobalTransform::from_translation(translation),
 				_Animations {
 					forward_pitch: None,
 				},

--- a/src/plugins/physics/src/systems/update_target_pitch.rs
+++ b/src/plugins/physics/src/systems/update_target_pitch.rs
@@ -1,4 +1,4 @@
-use crate::components::target::Target;
+use crate::components::{center_offset::CenterOffset, target::Target};
 use bevy::{
 	ecs::system::{StaticSystemParam, SystemParam},
 	prelude::*,
@@ -18,20 +18,27 @@ impl Target {
 	pub(crate) fn update_pitch<TRayCast, TAnimations>(
 		mut animations: StaticSystemParam<TAnimations>,
 		mut ray_caster: StaticSystemParam<TRayCast>,
-		targets: Query<(Entity, &Self, &GlobalTransform)>,
-		transforms: Query<&GlobalTransform>,
+		targets: Query<(Entity, &Self, &GlobalTransform, Option<&CenterOffset>)>,
+		transforms: Query<(&GlobalTransform, Option<&CenterOffset>)>,
 		commands: ZyheedaCommands,
 	) where
 		for<'w, 's> TRayCast: SystemParam<Item<'w, 's>: Raycast<MouseHover>>,
 		for<'c> TAnimations:
 			SystemParam + GetContextMut<Animations, TContext<'c>: GetForwardPitchMut>,
 	{
-		for (entity, target, transform) in targets {
+		for (entity, target, transform, offset) in targets {
 			let key = Animations { entity };
 			let Some(mut ctx) = TAnimations::get_context_mut(&mut animations, key) else {
 				continue;
 			};
-			let pitch = target.get_pitch(entity, transform, transforms, &commands, &mut ray_caster);
+			let pitch = target.get_pitch(
+				entity,
+				transform,
+				offset,
+				transforms,
+				&commands,
+				&mut ray_caster,
+			);
 
 			*ctx.get_forward_pitch_mut() = pitch;
 		}
@@ -41,22 +48,23 @@ impl Target {
 		&self,
 		entity: Entity,
 		transform: &GlobalTransform,
-		transforms: Query<&GlobalTransform>,
+		offset: Option<&CenterOffset>,
+		transforms: Query<(&GlobalTransform, Option<&CenterOffset>)>,
 		commands: &ZyheedaCommands,
 		ray_cast: &mut impl Raycast<MouseHover>,
 	) -> Option<DirForwardPitch> {
 		match self.0.as_ref()? {
 			SkillTarget::Entity(entity) => {
 				let target = commands.get(entity)?;
-				let target = transforms.get(target).ok()?.translation();
-				get_pitch(transform, target)
+				let target = transforms.get(target).ok()?.0.translation();
+				get_pitch(transform, offset, target)
 			}
 			SkillTarget::Cursor(Cursor::TerrainHover) => {
 				match ray_cast.raycast(MouseHover::excluding([entity]))? {
-					MouseHoversOver::Point(point) => get_pitch(transform, point),
+					MouseHoversOver::Point(point) => get_pitch(transform, offset, point),
 					MouseHoversOver::Object { entity, .. } => {
-						let target = transforms.get(entity).ok()?.translation();
-						get_pitch(transform, target)
+						let target = transforms.get(entity).ok()?.0.translation();
+						get_pitch(transform, offset, target)
 					}
 				}
 			}
@@ -65,8 +73,16 @@ impl Target {
 	}
 }
 
-fn get_pitch(transform: &GlobalTransform, to: Vec3) -> Option<DirForwardPitch> {
-	let dir = (to - transform.translation()).try_normalize()?;
+fn get_pitch(
+	transform: &GlobalTransform,
+	offset: Option<&CenterOffset>,
+	to: Vec3,
+) -> Option<DirForwardPitch> {
+	let origin = match offset {
+		Some(CenterOffset(offset)) => transform.translation() + Vec3::new(0., *offset, 0.),
+		None => transform.translation(),
+	};
+	let dir = (to - origin).try_normalize()?;
 	let pitch = ForwardPitch::try_from((dir.y.asin() / FRAC_PI_2).abs()).ok()?;
 
 	if dir.y > 0. {
@@ -228,6 +244,47 @@ mod tests {
 	#[test_case(-45., ForwardPitch::try_from(0.5).ok().map(DirForwardPitch::Down); "45 degrees down")]
 	#[test_case(90., DirForwardPitch::Up(ForwardPitch::MAX); "90 degrees up")]
 	#[test_case(-90., DirForwardPitch::Down(ForwardPitch::MAX); "90 degrees down")]
+	fn set_target_entity_pitch_with_offset(
+		angle: f32,
+		forward_pitch: impl Into<Option<DirForwardPitch>>,
+	) {
+		let mut app = setup();
+		let translation = Vec3::new(10., 2., 0.);
+		let offset = Quat::from_rotation_x(angle.to_radians()).mul_vec3(Vec3::new(0., 0., -30.));
+		let target_entity = PersistentEntity::default();
+		let entity = app
+			.world_mut()
+			.spawn((
+				Target(Some(SkillTarget::Entity(target_entity))),
+				CenterOffset(3.),
+				GlobalTransform::from_translation(translation),
+				_Animations {
+					forward_pitch: None,
+				},
+			))
+			.id();
+
+		app.world_mut().spawn((
+			target_entity,
+			GlobalTransform::from_translation(translation + Vec3::new(0., 3., 0.) + offset),
+		));
+
+		app.update();
+
+		assert_eq_approx!(
+			Some(&_Animations {
+				forward_pitch: forward_pitch.into()
+			}),
+			app.world().entity(entity).get::<_Animations>(),
+			1e-5,
+		);
+	}
+
+	#[test_case(0., None; "0 degrees")]
+	#[test_case(45., ForwardPitch::try_from(0.5).ok().map(DirForwardPitch::Up); "45 degrees up")]
+	#[test_case(-45., ForwardPitch::try_from(0.5).ok().map(DirForwardPitch::Down); "45 degrees down")]
+	#[test_case(90., DirForwardPitch::Up(ForwardPitch::MAX); "90 degrees up")]
+	#[test_case(-90., DirForwardPitch::Down(ForwardPitch::MAX); "90 degrees down")]
 	fn set_cursor_terrain_hit_pitch(angle: f32, forward_pitch: impl Into<Option<DirForwardPitch>>) {
 		let mut app = setup();
 		let translation = Vec3::new(10., 2., 0.);
@@ -245,6 +302,47 @@ mod tests {
 		app.insert_resource(_RayCast::new().with_mock(|mock| {
 			mock.expect_raycast()
 				.return_const(Some(MouseHoversOver::Point(translation + offset)));
+		}));
+
+		app.update();
+
+		assert_eq_approx!(
+			Some(&_Animations {
+				forward_pitch: forward_pitch.into()
+			}),
+			app.world().entity(entity).get::<_Animations>(),
+			1e-5,
+		);
+	}
+
+	#[test_case(0., None; "0 degrees")]
+	#[test_case(45., ForwardPitch::try_from(0.5).ok().map(DirForwardPitch::Up); "45 degrees up")]
+	#[test_case(-45., ForwardPitch::try_from(0.5).ok().map(DirForwardPitch::Down); "45 degrees down")]
+	#[test_case(90., DirForwardPitch::Up(ForwardPitch::MAX); "90 degrees up")]
+	#[test_case(-90., DirForwardPitch::Down(ForwardPitch::MAX); "90 degrees down")]
+	fn set_cursor_terrain_hit_pitch_with_offset(
+		angle: f32,
+		forward_pitch: impl Into<Option<DirForwardPitch>>,
+	) {
+		let mut app = setup();
+		let translation = Vec3::new(10., 2., 0.);
+		let offset = Quat::from_rotation_x(angle.to_radians()).mul_vec3(Vec3::new(0., 0., -30.));
+		let entity = app
+			.world_mut()
+			.spawn((
+				Target(Some(SkillTarget::Cursor(Cursor::TerrainHover))),
+				GlobalTransform::from_translation(translation),
+				CenterOffset(3.),
+				_Animations {
+					forward_pitch: None,
+				},
+			))
+			.id();
+		app.insert_resource(_RayCast::new().with_mock(|mock| {
+			mock.expect_raycast()
+				.return_const(Some(MouseHoversOver::Point(
+					translation + Vec3::new(0., 3., 0.) + offset,
+				)));
 		}));
 
 		app.update();
@@ -300,8 +398,56 @@ mod tests {
 		);
 	}
 
+	#[test_case(0., None; "0 degrees")]
+	#[test_case(45., ForwardPitch::try_from(0.5).ok().map(DirForwardPitch::Up); "45 degrees up")]
+	#[test_case(-45., ForwardPitch::try_from(0.5).ok().map(DirForwardPitch::Down); "45 degrees down")]
+	#[test_case(90., DirForwardPitch::Up(ForwardPitch::MAX); "90 degrees up")]
+	#[test_case(-90., DirForwardPitch::Down(ForwardPitch::MAX); "90 degrees down")]
+	fn set_cursor_entity_hit_pitch_with_offset(
+		angle: f32,
+		forward_pitch: impl Into<Option<DirForwardPitch>>,
+	) {
+		let mut app = setup();
+		let translation = Vec3::new(10., 2., 0.);
+		let offset = Quat::from_rotation_x(angle.to_radians()).mul_vec3(Vec3::new(0., 0., -30.));
+		let target = app
+			.world_mut()
+			.spawn(GlobalTransform::from_translation(
+				translation + Vec3::new(0., 3., 0.) + offset,
+			))
+			.id();
+		let entity = app
+			.world_mut()
+			.spawn((
+				Target(Some(SkillTarget::Cursor(Cursor::TerrainHover))),
+				GlobalTransform::from_translation(translation),
+				CenterOffset(3.),
+				_Animations {
+					forward_pitch: None,
+				},
+			))
+			.id();
+		app.insert_resource(_RayCast::new().with_mock(|mock| {
+			mock.expect_raycast()
+				.return_const(Some(MouseHoversOver::Object {
+					entity: target,
+					point: Vec3::ZERO,
+				}));
+		}));
+
+		app.update();
+
+		assert_eq_approx!(
+			Some(&_Animations {
+				forward_pitch: forward_pitch.into()
+			}),
+			app.world().entity(entity).get::<_Animations>(),
+			1e-5,
+		);
+	}
+
 	#[test]
-	fn set_not_pitch_for_directional_cursor() {
+	fn do_not_set_pitch_for_directional_cursor() {
 		let mut app = setup();
 		let entity = app
 			.world_mut()

--- a/src/plugins/physics/src/systems/update_target_pitch.rs
+++ b/src/plugins/physics/src/systems/update_target_pitch.rs
@@ -1,4 +1,7 @@
-use crate::components::{center_offset::CenterOffset, target::Target};
+use crate::components::{
+	center_offset::{CenterOffset, ComputeOffsetTranslation},
+	target::Target,
+};
 use bevy::{
 	ecs::system::{StaticSystemParam, SystemParam},
 	prelude::*,
@@ -57,7 +60,7 @@ impl Target {
 			SkillTarget::Entity(entity) => {
 				let target = commands.get(entity)?;
 				let (target_transform, target_offset) = transforms.get(target).ok()?;
-				let target = with_offset(target_transform, target_offset);
+				let target = target_offset.compute_translation(target_transform);
 				get_pitch(transform, offset, target)
 			}
 			SkillTarget::Cursor(Cursor::TerrainHover) => {
@@ -65,7 +68,7 @@ impl Target {
 					MouseHoversOver::Point(point) => get_pitch(transform, offset, point),
 					MouseHoversOver::Object { entity, .. } => {
 						let (target_transform, target_offset) = transforms.get(entity).ok()?;
-						let target = with_offset(target_transform, target_offset);
+						let target = target_offset.compute_translation(target_transform);
 						get_pitch(transform, offset, target)
 					}
 				}
@@ -80,20 +83,13 @@ fn get_pitch(
 	offset: Option<&CenterOffset>,
 	to: Vec3,
 ) -> Option<DirForwardPitch> {
-	let dir = (to - with_offset(transform, offset)).try_normalize()?;
+	let dir = (to - offset.compute_translation(transform)).try_normalize()?;
 	let pitch = ForwardPitch::try_from((dir.y.asin() / FRAC_PI_2).abs()).ok()?;
 
 	if dir.y > 0. {
 		Some(DirForwardPitch::Up(pitch))
 	} else {
 		Some(DirForwardPitch::Down(pitch))
-	}
-}
-
-fn with_offset(transform: &GlobalTransform, offset: Option<&CenterOffset>) -> Vec3 {
-	match offset {
-		Some(CenterOffset(offset)) => transform.translation() + Vec3::new(0., *offset, 0.),
-		None => transform.translation(),
 	}
 }
 


### PR DESCRIPTION
- added `CenterOffset`
- reworked agent configuration to account for center offset spec
- pitch and anchor logic takes target and agent center offset into account

This makes animated targeting pitches appear more natural, because we can set the center offset to match with torso/arm height. We also target entities on their offset center, which makes targeting appear more natural too.