### PR TITLE
Asset mesh name

### DIFF
--- a/src/plugins/common/src/components.rs
+++ b/src/plugins/common/src/components.rs
@@ -1,3 +1,4 @@
+pub mod asset_mesh_name;
 pub mod asset_model;
 pub mod child_of_persistent;
 pub mod essence;

--- a/src/plugins/common/src/components/asset_mesh_name.rs
+++ b/src/plugins/common/src/components/asset_mesh_name.rs
@@ -1,0 +1,5 @@
+use bevy::prelude::*;
+use zyheeda_core::prelude::NormalizedName;
+
+#[derive(Component, Debug, PartialEq)]
+pub struct AssetMeshName(pub NormalizedName<String>);

--- a/src/plugins/common/src/components/asset_mesh_name.rs
+++ b/src/plugins/common/src/components/asset_mesh_name.rs
@@ -1,5 +1,10 @@
 use bevy::prelude::*;
 use zyheeda_core::prelude::NormalizedName;
 
+/// Represents a normalized asset mesh name.
+///
+/// It is automatically inserted by the [`CommonPlugin`](crate::CommonPlugin) when
+/// [`GltfMeshName`](bevy::gltf::GltfMeshName) is inserted .
 #[derive(Component, Debug, PartialEq)]
+#[component(immutable)]
 pub struct AssetMeshName(pub NormalizedName<String>);

--- a/src/plugins/common/src/lib.rs
+++ b/src/plugins/common/src/lib.rs
@@ -12,7 +12,12 @@ pub mod traits;
 pub mod zyheeda_commands;
 
 use crate::{
-	components::{child_of_persistent::ChildOfPersistent, lifetime::Lifetime, model::Model},
+	components::{
+		asset_mesh_name::AssetMeshName,
+		child_of_persistent::ChildOfPersistent,
+		lifetime::Lifetime,
+		model::Model,
+	},
 	states::game_state::GameState,
 	traits::{
 		register_controlled_state::RegisterControlledState,
@@ -47,6 +52,7 @@ fn asset_loading(app: &mut App) {
 	app.add_observer(AssetModel::load);
 	app.add_observer(InsertAsset::<Mesh>::apply);
 	app.add_observer(InsertAsset::<StandardMaterial>::apply);
+	app.add_observer(AssetMeshName::insert);
 }
 
 fn life_cycles(app: &mut App) {

--- a/src/plugins/common/src/observers.rs
+++ b/src/plugins/common/src/observers.rs
@@ -1,3 +1,4 @@
+pub(crate) mod insert_asset_mesh_name;
 pub(crate) mod insert_assets;
 pub(crate) mod insert_child_of;
 pub(crate) mod insert_model;

--- a/src/plugins/common/src/observers/insert_asset_mesh_name.rs
+++ b/src/plugins/common/src/observers/insert_asset_mesh_name.rs
@@ -1,0 +1,65 @@
+use crate::{
+	components::asset_mesh_name::AssetMeshName,
+	traits::accessors::get::TryApplyOn,
+	zyheeda_commands::ZyheedaCommands,
+};
+use bevy::{gltf::GltfMeshName, prelude::*};
+use zyheeda_core::prelude::NormalizedName;
+
+impl AssetMeshName {
+	pub(crate) fn insert(
+		inserted_name: On<Insert, GltfMeshName>,
+		names: Query<&GltfMeshName>,
+		mut commands: ZyheedaCommands,
+	) {
+		let Ok(GltfMeshName(name)) = names.get(inserted_name.entity) else {
+			return;
+		};
+
+		commands.try_apply_on(&inserted_name.entity, |mut e| {
+			e.try_insert(AssetMeshName(NormalizedName::from(name.clone())));
+		});
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use testing::SingleThreadedApp;
+	use zyheeda_core::prelude::NormalizedName;
+
+	fn setup() -> App {
+		let mut app = App::new().single_threaded(Update);
+
+		app.add_observer(AssetMeshName::insert);
+
+		app
+	}
+
+	#[test]
+	fn insert_asset_mesh_name() {
+		let mut app = setup();
+
+		let entity = app.world_mut().spawn(GltfMeshName("name".to_owned()));
+
+		assert_eq!(
+			Some(&AssetMeshName(NormalizedName::from("name".to_owned()))),
+			entity.get::<AssetMeshName>(),
+		);
+	}
+
+	#[test]
+	fn act_again_when_re_inserted() {
+		let mut app = setup();
+
+		let mut entity = app.world_mut().spawn(GltfMeshName("name".to_owned()));
+		entity.insert(GltfMeshName("other name".to_owned()));
+
+		assert_eq!(
+			Some(&AssetMeshName(NormalizedName::from(
+				"other name".to_owned()
+			))),
+			entity.get::<AssetMeshName>(),
+		);
+	}
+}

--- a/src/zyheeda_core/src/strings/normalized_name.rs
+++ b/src/zyheeda_core/src/strings/normalized_name.rs
@@ -1,27 +1,33 @@
-use std::{cell::OnceCell, fmt::Display, ops::Deref};
+use std::{fmt::Display, ops::Deref, sync::OnceLock};
 
 /// Normalizes names by:
 /// - converting to lowercase
 /// - removing characters listed in [`REMOVE_CHARS`](Self::REMOVE_CHARS)
 #[derive(Debug, Clone)]
-pub struct NormalizedName<'a> {
-	raw: &'a str,
-	normalized: OnceCell<String>,
+pub struct NormalizedName<TName = &'static str>
+where
+	TName: Deref<Target = str>,
+{
+	name: TName,
+	normalized: OnceLock<String>,
 }
 
-impl<'a> NormalizedName<'a> {
+impl<TName> NormalizedName<TName>
+where
+	TName: Deref<Target = str>,
+{
 	const REMOVE_CHARS: &'static [char] = &['_', ' '];
 
-	pub const fn from_raw(raw: &'a str) -> Self {
+	pub const fn from_name(name: TName) -> Self {
 		Self {
-			raw,
-			normalized: OnceCell::new(),
+			name,
+			normalized: OnceLock::new(),
 		}
 	}
 
 	pub fn as_str(&self) -> &'_ str {
 		self.normalized
-			.get_or_init(|| self.raw.to_lowercase().replace(Self::REMOVE_CHARS, ""))
+			.get_or_init(|| self.name.to_lowercase().replace(Self::REMOVE_CHARS, ""))
 	}
 
 	pub fn to_owned(&self) -> String {
@@ -29,19 +35,28 @@ impl<'a> NormalizedName<'a> {
 	}
 }
 
-impl<'a> From<&'a str> for NormalizedName<'a> {
-	fn from(raw: &'a str) -> Self {
-		Self::from_raw(raw)
+impl<TName> From<TName> for NormalizedName<TName>
+where
+	TName: Deref<Target = str>,
+{
+	fn from(raw: TName) -> Self {
+		Self::from_name(raw)
 	}
 }
 
-impl<'a> From<NormalizedName<'a>> for String {
-	fn from(name: NormalizedName<'a>) -> Self {
+impl<TName> From<NormalizedName<TName>> for String
+where
+	TName: Deref<Target = str>,
+{
+	fn from(name: NormalizedName<TName>) -> Self {
 		name.to_owned()
 	}
 }
 
-impl<'a> Deref for NormalizedName<'a> {
+impl<TName> Deref for NormalizedName<TName>
+where
+	TName: Deref<Target = str>,
+{
 	type Target = str;
 
 	fn deref(&self) -> &Self::Target {
@@ -49,14 +64,21 @@ impl<'a> Deref for NormalizedName<'a> {
 	}
 }
 
-impl<'a> Display for NormalizedName<'a> {
+impl<TName> Display for NormalizedName<TName>
+where
+	TName: Deref<Target = str>,
+{
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		Display::fmt(self.as_str(), f)
 	}
 }
 
-impl<'a> PartialEq for NormalizedName<'a> {
-	fn eq(&self, other: &Self) -> bool {
+impl<TLeft, TRight> PartialEq<NormalizedName<TRight>> for NormalizedName<TLeft>
+where
+	TLeft: Deref<Target = str>,
+	TRight: Deref<Target = str>,
+{
+	fn eq(&self, other: &NormalizedName<TRight>) -> bool {
 		self.as_str() == other.as_str()
 	}
 }
@@ -64,14 +86,15 @@ impl<'a> PartialEq for NormalizedName<'a> {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use std::fmt::Debug;
 	use test_case::test_case;
 
 	#[test_case("normalized", "normalized"; "unchanged")]
 	#[test_case("CamelCase", "camelcase"; "camel case")]
 	#[test_case("snake_case", "snakecase"; "snake case")]
 	#[test_case("name with spaces", "namewithspaces"; "spaced")]
-	fn normalize_name(raw: &str, expected: &str) {
-		let name = NormalizedName::from(raw);
+	fn normalize_name(name: &str, expected: &str) {
+		let name = NormalizedName::from(name);
 
 		assert_eq!(
 			(
@@ -91,11 +114,13 @@ mod tests {
 		);
 	}
 
-	#[test]
-	fn partial_eq_of_different_raw_values() {
-		let a = NormalizedName::from_raw("my_name");
-		let b = NormalizedName::from_raw("my name");
+	#[test_case("my_name", "my name"; "when values differ")]
+	#[test_case("name", String::from("name"); "when types differ")]
+	#[test_case("my_name", String::from("my name"); "when types and values differ")]
+	fn partial_eq(l: impl Deref<Target = str> + Debug, r: impl Deref<Target = str> + Debug) {
+		let l = NormalizedName::from_name(l);
+		let r = NormalizedName::from_name(r);
 
-		assert_eq!(a, b);
+		assert_eq!(l, r);
 	}
 }


### PR DESCRIPTION
Added `AssetMeshName`, which is inserted when `GltfMeshNames` are inserted. This is a pure helper component that can be used to filter queries when applying mesh name based logic.