### PR TITLE
UniqueComponentId lazy

### DIFF
--- a/src/macros/src/lib.rs
+++ b/src/macros/src/lib.rs
@@ -520,7 +520,7 @@ pub fn derive_savable_component(input: TokenStream) -> TokenStream {
 		Some(id) => {
 			quote! {
 				const ID: #common::traits::handles_saving::UniqueComponentId =
-					#common::traits::handles_saving::UniqueComponentId(#id);
+					#common::traits::handles_saving::UniqueComponentId::from_str(#id);
 			}
 		}
 		None => {

--- a/src/plugins/common/src/traits/handles_saving.rs
+++ b/src/plugins/common/src/traits/handles_saving.rs
@@ -51,50 +51,21 @@ pub trait SavableComponent:
 /// - must be enforced by users of `SavableComponent`.
 /// - is likely essential. Meaning that uniqueness violations may crash the application, thus,
 ///   checking on app startup is desired.
-#[derive(Debug, Eq, Clone)]
-pub enum UniqueComponentId {
-	Id(&'static str),
-	IdLazy {
-		id: OnceLock<String>,
-		f: fn() -> String,
-	},
-}
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub struct UniqueComponentId(IdInternal);
 
-use UniqueComponentId::{Id, IdLazy};
+use IdInternal::{Id, IdLazy};
 
 impl UniqueComponentId {
 	pub const fn from_str(id: &'static str) -> Self {
-		Id(id)
+		Self(Id(id))
 	}
 
 	pub const fn from_lazy(f: fn() -> String) -> Self {
-		IdLazy {
+		Self(IdLazy {
 			id: OnceLock::new(),
 			f,
-		}
-	}
-}
-
-impl PartialEq for UniqueComponentId {
-	fn eq(&self, other: &Self) -> bool {
-		match (self, other) {
-			(Id(l), Id(r)) => l == r,
-			(Id(id_str), IdLazy { id, f }) | (IdLazy { id, f }, Id(id_str)) => {
-				id_str == id.get_or_init(f)
-			}
-			(IdLazy { id: id_l, f: f_l }, IdLazy { id: id_r, f: f_r }) => {
-				id_l.get_or_init(f_l) == id_r.get_or_init(f_r)
-			}
-		}
-	}
-}
-
-impl Hash for UniqueComponentId {
-	fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-		match self {
-			Id(id) => id.hash(state),
-			IdLazy { id, f } => id.get_or_init(f).hash(state),
-		}
+		})
 	}
 }
 
@@ -102,7 +73,7 @@ impl Deref for UniqueComponentId {
 	type Target = str;
 
 	fn deref(&self) -> &Self::Target {
-		match self {
+		match &self.0 {
 			Id(id) => id,
 			IdLazy { id, f } => id.get_or_init(f),
 		}
@@ -116,7 +87,7 @@ impl From<&'static str> for UniqueComponentId {
 }
 
 impl From<&UniqueComponentId> for String {
-	fn from(id: &UniqueComponentId) -> Self {
+	fn from(UniqueComponentId(id): &UniqueComponentId) -> Self {
 		match id {
 			Id(r) => (*r).to_owned(),
 			IdLazy { id, f } => id.get_or_init(f).clone(),
@@ -127,6 +98,38 @@ impl From<&UniqueComponentId> for String {
 impl From<UniqueComponentId> for String {
 	fn from(id: UniqueComponentId) -> Self {
 		Self::from(&id)
+	}
+}
+
+#[derive(Debug, Eq, Clone)]
+enum IdInternal {
+	Id(&'static str),
+	IdLazy {
+		id: OnceLock<String>,
+		f: fn() -> String,
+	},
+}
+
+impl PartialEq for IdInternal {
+	fn eq(&self, other: &Self) -> bool {
+		match (self, other) {
+			(Id(l), Id(r)) => l == r,
+			(Id(id_str), IdLazy { id, f }) | (IdLazy { id, f }, Id(id_str)) => {
+				id_str == id.get_or_init(f)
+			}
+			(IdLazy { id: id_l, f: f_l }, IdLazy { id: id_r, f: f_r }) => {
+				id_l.get_or_init(f_l) == id_r.get_or_init(f_r)
+			}
+		}
+	}
+}
+
+impl Hash for IdInternal {
+	fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+		match self {
+			Id(id) => id.hash(state),
+			IdLazy { id, f } => id.get_or_init(f).hash(state),
+		}
 	}
 }
 

--- a/src/plugins/common/src/traits/handles_saving.rs
+++ b/src/plugins/common/src/traits/handles_saving.rs
@@ -3,7 +3,7 @@ mod external;
 use crate::{errors::Unreachable, traits::handles_custom_assets::TryLoadFrom};
 use bevy::prelude::*;
 use serde::{Serialize, de::DeserializeOwned};
-use std::ops::Deref;
+use std::{hash::Hash, ops::Deref, sync::OnceLock};
 
 pub trait HandlesSaving {
 	type TSaveEntityMarker: Component + Default;
@@ -51,12 +51,50 @@ pub trait SavableComponent:
 /// - must be enforced by users of `SavableComponent`.
 /// - is likely essential. Meaning that uniqueness violations may crash the application, thus,
 ///   checking on app startup is desired.
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
-pub struct UniqueComponentId(&'static str);
+#[derive(Debug, Eq, Clone)]
+pub enum UniqueComponentId {
+	Id(&'static str),
+	IdLazy {
+		id: OnceLock<String>,
+		f: fn() -> String,
+	},
+}
+
+use UniqueComponentId::{Id, IdLazy};
 
 impl UniqueComponentId {
 	pub const fn from_str(id: &'static str) -> Self {
-		Self(id)
+		Id(id)
+	}
+
+	pub const fn from_lazy(f: fn() -> String) -> Self {
+		IdLazy {
+			id: OnceLock::new(),
+			f,
+		}
+	}
+}
+
+impl PartialEq for UniqueComponentId {
+	fn eq(&self, other: &Self) -> bool {
+		match (self, other) {
+			(Id(l), Id(r)) => l == r,
+			(Id(id_str), IdLazy { id, f }) | (IdLazy { id, f }, Id(id_str)) => {
+				id_str == id.get_or_init(f)
+			}
+			(IdLazy { id: id_l, f: f_l }, IdLazy { id: id_r, f: f_r }) => {
+				id_l.get_or_init(f_l) == id_r.get_or_init(f_r)
+			}
+		}
+	}
+}
+
+impl Hash for UniqueComponentId {
+	fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+		match self {
+			Id(id) => id.hash(state),
+			IdLazy { id, f } => id.get_or_init(f).hash(state),
+		}
 	}
 }
 
@@ -64,7 +102,10 @@ impl Deref for UniqueComponentId {
 	type Target = str;
 
 	fn deref(&self) -> &Self::Target {
-		self.0
+		match self {
+			Id(id) => id,
+			IdLazy { id, f } => id.get_or_init(f),
+		}
 	}
 }
 
@@ -75,8 +116,11 @@ impl From<&'static str> for UniqueComponentId {
 }
 
 impl From<&UniqueComponentId> for String {
-	fn from(UniqueComponentId(id): &UniqueComponentId) -> Self {
-		(*id).to_owned()
+	fn from(id: &UniqueComponentId) -> Self {
+		match id {
+			Id(r) => (*r).to_owned(),
+			IdLazy { id, f } => id.get_or_init(f).clone(),
+		}
 	}
 }
 

--- a/src/plugins/common/src/traits/handles_saving.rs
+++ b/src/plugins/common/src/traits/handles_saving.rs
@@ -52,7 +52,13 @@ pub trait SavableComponent:
 /// - is likely essential. Meaning that uniqueness violations may crash the application, thus,
 ///   checking on app startup is desired.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
-pub struct UniqueComponentId(pub &'static str);
+pub struct UniqueComponentId(&'static str);
+
+impl UniqueComponentId {
+	pub const fn from_str(id: &'static str) -> Self {
+		Self(id)
+	}
+}
 
 impl Deref for UniqueComponentId {
 	type Target = str;
@@ -64,7 +70,7 @@ impl Deref for UniqueComponentId {
 
 impl From<&'static str> for UniqueComponentId {
 	fn from(id: &'static str) -> Self {
-		Self(id)
+		Self::from_str(id)
 	}
 }
 

--- a/src/plugins/common/src/traits/handles_saving/external.rs
+++ b/src/plugins/common/src/traits/handles_saving/external.rs
@@ -6,7 +6,7 @@ macro_rules! impl_savable_with_high_priority {
 			type TDto = $ty;
 			const PRIORITY: bool = true;
 			const ID: $crate::traits::handles_saving::UniqueComponentId =
-				$crate::traits::handles_saving::UniqueComponentId($id);
+				$crate::traits::handles_saving::UniqueComponentId::from_str($id);
 		}
 	};
 }

--- a/src/plugins/physics/src/components/ongoing_effects.rs
+++ b/src/plugins/physics/src/components/ongoing_effects.rs
@@ -24,19 +24,19 @@ where
 impl SavableComponent for OngoingEffects<HealthDamageEffect, Life> {
 	type TDto = Self;
 
-	const ID: UniqueComponentId = UniqueComponentId("ongoing health damage effects");
+	const ID: UniqueComponentId = UniqueComponentId::from_str("ongoing health damage effects");
 }
 
 impl SavableComponent for OngoingEffects<GravityEffect, GravityAffected> {
 	type TDto = Self;
 
-	const ID: UniqueComponentId = UniqueComponentId("ongoing gravity effects");
+	const ID: UniqueComponentId = UniqueComponentId::from_str("ongoing gravity effects");
 }
 
 impl SavableComponent for OngoingEffects<ForceEffect, ForceAffected> {
 	type TDto = Self;
 
-	const ID: UniqueComponentId = UniqueComponentId("ongoing force effects");
+	const ID: UniqueComponentId = UniqueComponentId::from_str("ongoing force effects");
 }
 
 impl<TActor, TTarget> Clone for OngoingEffects<TActor, TTarget>

--- a/src/plugins/savegame/src/context/handler.rs
+++ b/src/plugins/savegame/src/context/handler.rs
@@ -106,8 +106,8 @@ where
 		(self.insert_fn)(entity, components, asset_server)
 	}
 
-	fn id(&self) -> UniqueComponentId {
-		self.component_id
+	fn id(&self) -> &UniqueComponentId {
+		&self.component_id
 	}
 }
 
@@ -405,7 +405,7 @@ mod tests {
 		fn get_component_name() {
 			let handler = ComponentHandler::<_LoadAsset>::new::<_A>();
 
-			assert_eq!(_A::ID, handler.id());
+			assert_eq!(&_A::ID, handler.id());
 		}
 	}
 }

--- a/src/plugins/savegame/src/systems/read_buffer.rs
+++ b/src/plugins/savegame/src/systems/read_buffer.rs
@@ -197,9 +197,9 @@ mod tests {
 		}
 
 		fn id(&self) -> &UniqueComponentId {
-			static A: UniqueComponentId = UniqueComponentId::Id("a");
-			static B: UniqueComponentId = UniqueComponentId::Id("b");
-			static COUNT_A: UniqueComponentId = UniqueComponentId::Id("count a");
+			static A: UniqueComponentId = UniqueComponentId::from_str("a");
+			static B: UniqueComponentId = UniqueComponentId::from_str("b");
+			static COUNT_A: UniqueComponentId = UniqueComponentId::from_str("count a");
 
 			match self {
 				_FakeHandler::A => &A,

--- a/src/plugins/savegame/src/systems/read_buffer.rs
+++ b/src/plugins/savegame/src/systems/read_buffer.rs
@@ -113,7 +113,7 @@ where
 				continue;
 			};
 			for handler in handlers {
-				let Some(component) = components.remove(&*handler.id()) else {
+				let Some(component) = components.remove(&**handler.id()) else {
 					continue;
 				};
 				let Err(err) = handler.insert_component(&mut entity, component, assets) else {
@@ -196,12 +196,16 @@ mod tests {
 			Ok(())
 		}
 
-		fn id(&self) -> UniqueComponentId {
+		fn id(&self) -> &UniqueComponentId {
+			static A: UniqueComponentId = UniqueComponentId::Id("a");
+			static B: UniqueComponentId = UniqueComponentId::Id("b");
+			static COUNT_A: UniqueComponentId = UniqueComponentId::Id("count a");
+
 			match self {
-				_FakeHandler::A => "a".into(),
-				_FakeHandler::B => "b".into(),
-				_FakeHandler::CountA => "count a".into(),
-				_FakeHandler::ErrorForA => "a".into(),
+				_FakeHandler::A => &A,
+				_FakeHandler::B => &B,
+				_FakeHandler::CountA => &COUNT_A,
+				_FakeHandler::ErrorForA => &A,
 			}
 		}
 	}

--- a/src/plugins/savegame/src/traits/insert_entity_component.rs
+++ b/src/plugins/savegame/src/traits/insert_entity_component.rs
@@ -8,7 +8,7 @@ where
 	type TComponent;
 	type TError;
 
-	fn id(&self) -> UniqueComponentId;
+	fn id(&self) -> &UniqueComponentId;
 	fn insert_component(
 		&self,
 		entity: &mut EntityCommands,


### PR DESCRIPTION
add lazy abilities for `UniqueComponentId`. This allows some limit concatenation capabilities when constructing the id for `SavableComponent`.