### PR TITLE
Fix agent config params

### DIFF
--- a/src/plugins/animations/src/components/animation_lookup.rs
+++ b/src/plugins/animations/src/components/animation_lookup.rs
@@ -1,3 +1,4 @@
+use crate::components::animation_dispatch::AnimationDispatch;
 use bevy::prelude::*;
 use common::traits::handles_animations::{
 	AffectedAnimationBones,
@@ -9,6 +10,7 @@ use common::traits::handles_animations::{
 use std::collections::HashMap;
 
 #[derive(Component, Debug, PartialEq)]
+#[require(AnimationDispatch)]
 pub(crate) struct AnimationLookup<TClips = AnimationClips<AnimationNodeIndex>> {
 	pub(crate) animations: HashMap<AnimationKey, Animation<TClips>>,
 	pub(crate) animation_mask_groups: HashMap<AnimationMaskBits, AffectedAnimationBones>,

--- a/src/plugins/animations/src/system_params/animations.rs
+++ b/src/plugins/animations/src/system_params/animations.rs
@@ -5,6 +5,7 @@ mod register_animations;
 
 use crate::components::{
 	animation_dispatch::AnimationDispatch,
+	animation_lookup::AnimationLookup,
 	current_forward_pitch::CurrentForwardPitch,
 	current_movement_direction::CurrentMovementDirection,
 };
@@ -12,7 +13,7 @@ use bevy::{ecs::system::SystemParam, prelude::*};
 use common::{
 	traits::{
 		accessors::get::{GetContextMut, GetMut},
-		handles_animations::{Animations, WithoutAnimations},
+		handles_animations::{AnimationClips, Animations, WithoutAnimations},
 	},
 	zyheeda_commands::{ZyheedaCommands, ZyheedaEntityCommands},
 };
@@ -23,6 +24,7 @@ where
 	TAnimationGraph: Asset,
 {
 	commands: ZyheedaCommands<'w, 's>,
+	lookups: Query<'w, 's, (), With<AnimationLookup<AnimationClips<AnimationNodeIndex>>>>,
 	animators: Query<
 		'w,
 		's,
@@ -46,7 +48,7 @@ where
 		param: &'ctx mut AnimationsParamMut<TAnimationGraph>,
 		WithoutAnimations { entity }: WithoutAnimations,
 	) -> Option<Self::TContext<'ctx>> {
-		if param.animators.contains(entity) {
+		if param.lookups.contains(entity) {
 			return None;
 		}
 
@@ -65,10 +67,13 @@ where
 
 	fn get_context_mut<'ctx>(
 		param: &'ctx mut AnimationsParamMut<TAnimationGraph>,
-		animations: Animations,
+		Animations { entity }: Animations,
 	) -> Option<Self::TContext<'ctx>> {
-		let (dispatch, movement_direction, forward_pitch) =
-			param.animators.get_mut(animations.entity).ok()?;
+		if !param.lookups.contains(entity) {
+			return None;
+		}
+
+		let (dispatch, movement_direction, forward_pitch) = param.animators.get_mut(entity).ok()?;
 
 		Some(AnimationsContextMut {
 			dispatch,
@@ -90,4 +95,102 @@ pub struct AnimationsContextMut<'a> {
 	dispatch: Mut<'a, AnimationDispatch>,
 	movement_direction: Mut<'a, CurrentMovementDirection>,
 	forward_pitch: Mut<'a, CurrentForwardPitch>,
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::components::animation_lookup::AnimationLookup;
+	use bevy::ecs::system::{RunSystemError, RunSystemOnce};
+	use testing::SingleThreadedApp;
+
+	#[derive(TypePath, Asset)]
+	struct _Graph;
+
+	fn setup() -> App {
+		let mut app = App::new().single_threaded(Update);
+
+		app.init_resource::<Assets<_Graph>>();
+
+		app
+	}
+
+	mod without_animations {
+		use super::*;
+
+		#[test]
+		fn get_context_if_lookup_missing() -> Result<(), RunSystemError> {
+			let mut app = setup();
+			let entity = app.world_mut().spawn_empty().id();
+
+			let ctx =
+				app.world_mut()
+					.run_system_once(move |mut p: AnimationsParamMut<_Graph>| {
+						AnimationsParamMut::get_context_mut(&mut p, WithoutAnimations { entity })
+							.is_some()
+					})?;
+
+			assert!(ctx);
+			Ok(())
+		}
+
+		#[test]
+		fn no_context_if_lookup_present() -> Result<(), RunSystemError> {
+			let mut app = setup();
+			let entity = app
+				.world_mut()
+				.spawn(AnimationLookup::<AnimationClips<AnimationNodeIndex>>::default())
+				.id();
+
+			let ctx =
+				app.world_mut()
+					.run_system_once(move |mut p: AnimationsParamMut<_Graph>| {
+						AnimationsParamMut::get_context_mut(&mut p, WithoutAnimations { entity })
+							.is_some()
+					})?;
+
+			assert!(!ctx);
+			Ok(())
+		}
+	}
+
+	mod animations {
+		use super::*;
+
+		#[test]
+		fn no_context_if_lookup_missing() -> Result<(), RunSystemError> {
+			let mut app = setup();
+			let entity = app.world_mut().spawn(AnimationDispatch::default()).id();
+
+			let ctx =
+				app.world_mut()
+					.run_system_once(move |mut p: AnimationsParamMut<_Graph>| {
+						AnimationsParamMut::get_context_mut(&mut p, Animations { entity }).is_some()
+					})?;
+
+			assert!(!ctx);
+			Ok(())
+		}
+
+		#[test]
+		fn get_context_if_lookup_present() -> Result<(), RunSystemError> {
+			let mut app = setup();
+			let entity = app
+				.world_mut()
+				.spawn((
+					AnimationLookup::<AnimationClips<AnimationNodeIndex>>::default(),
+					AnimationDispatch::default(),
+				))
+				.id();
+
+			let ctx =
+				app.world_mut()
+					.run_system_once(move |mut p: AnimationsParamMut<_Graph>| {
+						AnimationsParamMut::get_context_mut(&mut p, Animations { entity }).is_some()
+					})?;
+
+			assert!(ctx);
+			Ok(())
+		}
+	}
 }

--- a/src/plugins/animations/src/system_params/animations/active_animations.rs
+++ b/src/plugins/animations/src/system_params/animations/active_animations.rs
@@ -30,7 +30,7 @@ mod tests {
 	#![allow(clippy::unwrap_used)]
 	use super::*;
 	use crate::{
-		components::animation_dispatch::AnimationDispatch,
+		components::{animation_dispatch::AnimationDispatch, animation_lookup::AnimationLookup},
 		system_params::animations::AnimationsParamMut,
 	};
 	use bevy::{
@@ -41,7 +41,7 @@ mod tests {
 		tools::action_key::slot::SlotKey,
 		traits::{
 			accessors::get::GetContextMut,
-			handles_animations::{Animations, SkillAnimation},
+			handles_animations::{AnimationClips, Animations, SkillAnimation},
 		},
 	};
 	use test_case::test_case;
@@ -80,7 +80,10 @@ mod tests {
 				animation: SkillAnimation::Aim,
 			},
 		];
-		let entity = app.world_mut().spawn(AnimationDispatch::default()).id();
+		let entity = app
+			.world_mut()
+			.spawn(AnimationLookup::<AnimationClips<AnimationNodeIndex>>::default())
+			.id();
 
 		app.world_mut()
 			.run_system_once(move |mut p: AnimationsParamMut| {
@@ -111,7 +114,10 @@ mod tests {
 		];
 		let entity = app
 			.world_mut()
-			.spawn(dispatch_with([(animation_priority, animations)]))
+			.spawn((
+				AnimationLookup::<AnimationClips<AnimationNodeIndex>>::default(),
+				dispatch_with([(animation_priority, animations)]),
+			))
 			.id();
 
 		app.world_mut()

--- a/src/plugins/animations/src/system_params/animations/get_forward_pitch.rs
+++ b/src/plugins/animations/src/system_params/animations/get_forward_pitch.rs
@@ -20,6 +20,7 @@ mod tests {
 	use crate::{
 		components::{
 			animation_dispatch::AnimationDispatch,
+			animation_lookup::AnimationLookup,
 			current_forward_pitch::CurrentForwardPitch,
 		},
 		system_params::animations::AnimationsParamMut,
@@ -30,7 +31,7 @@ mod tests {
 	};
 	use common::traits::{
 		accessors::get::GetContextMut,
-		handles_animations::{Animations, ForwardPitch},
+		handles_animations::{AnimationClips, Animations, ForwardPitch},
 	};
 	use testing::SingleThreadedApp;
 
@@ -48,6 +49,7 @@ mod tests {
 		let entity = app
 			.world_mut()
 			.spawn((
+				AnimationLookup::<AnimationClips<AnimationNodeIndex>>::default(),
 				AnimationDispatch::default(),
 				GlobalTransform::default(),
 				CurrentForwardPitch(Some(DirForwardPitch::Up(
@@ -73,7 +75,11 @@ mod tests {
 		let mut app = setup();
 		let entity = app
 			.world_mut()
-			.spawn((AnimationDispatch::default(), GlobalTransform::default()))
+			.spawn((
+				AnimationLookup::<AnimationClips<AnimationNodeIndex>>::default(),
+				AnimationDispatch::default(),
+				GlobalTransform::default(),
+			))
 			.id();
 
 		app.world_mut()

--- a/src/plugins/animations/src/system_params/animations/get_move_direction.rs
+++ b/src/plugins/animations/src/system_params/animations/get_move_direction.rs
@@ -21,6 +21,7 @@ mod tests {
 	use crate::{
 		components::{
 			animation_dispatch::AnimationDispatch,
+			animation_lookup::AnimationLookup,
 			current_movement_direction::CurrentMovementDirection,
 		},
 		system_params::animations::AnimationsParamMut,
@@ -30,7 +31,10 @@ mod tests {
 		asset::Assets,
 		ecs::system::{RunSystemError, RunSystemOnce},
 	};
-	use common::traits::{accessors::get::GetContextMut, handles_animations::Animations};
+	use common::traits::{
+		accessors::get::GetContextMut,
+		handles_animations::{AnimationClips, Animations},
+	};
 	use testing::SingleThreadedApp;
 
 	fn setup() -> App {
@@ -47,6 +51,7 @@ mod tests {
 		let entity = app
 			.world_mut()
 			.spawn((
+				AnimationLookup::<AnimationClips<AnimationNodeIndex>>::default(),
 				AnimationDispatch::default(),
 				GlobalTransform::default(),
 				CurrentMovementDirection(Some(Dir3::NEG_Z)),
@@ -67,7 +72,11 @@ mod tests {
 		let mut app = setup();
 		let entity = app
 			.world_mut()
-			.spawn((AnimationDispatch::default(), GlobalTransform::default()))
+			.spawn((
+				AnimationLookup::<AnimationClips<AnimationNodeIndex>>::default(),
+				AnimationDispatch::default(),
+				GlobalTransform::default(),
+			))
 			.id();
 
 		app.world_mut()

--- a/src/plugins/animations/src/system_params/animations/register_animations.rs
+++ b/src/plugins/animations/src/system_params/animations/register_animations.rs
@@ -1,5 +1,5 @@
 use crate::{
-	components::{animation_dispatch::AnimationDispatch, animation_lookup::AnimationLookup},
+	components::animation_lookup::AnimationLookup,
 	system_params::animations::AnimationsRegisterContextMut,
 	traits::InsertClips,
 };
@@ -34,7 +34,6 @@ where
 		};
 
 		self.entity.try_insert((
-			AnimationDispatch::default(),
 			AnimationLookup {
 				animation_mask_groups: animation_mask_groups.clone(),
 				animations: map_animations(animations, insert_into_graph),
@@ -372,21 +371,6 @@ mod tests {
 			}),
 			app.world().entity(entity).get::<AnimationLookup>()
 		);
-		Ok(())
-	}
-
-	#[test]
-	fn no_context_when_animation_dispatch_present() -> Result<(), RunSystemError> {
-		let mut app = setup();
-		let entity = app.world_mut().spawn(AnimationDispatch::default()).id();
-
-		let ctx = app
-			.world_mut()
-			.run_system_once(move |mut p: AnimationsParamMut<_Graph>| {
-				AnimationsParamMut::get_context_mut(&mut p, WithoutAnimations { entity }).is_some()
-			})?;
-
-		assert!(!ctx);
 		Ok(())
 	}
 }

--- a/src/plugins/physics/src/system_params/skill_agent.rs
+++ b/src/plugins/physics/src/system_params/skill_agent.rs
@@ -3,12 +3,12 @@ mod initialize;
 mod spawn_new_skill;
 mod target;
 
-use crate::components::{skill::Skill, target::Target};
+use crate::components::{mount_points::MountPointsDefinition, skill::Skill, target::Target};
 use bevy::{ecs::system::SystemParam, prelude::*};
 use common::{
 	traits::{
 		accessors::get::{ContextChanged, GetContext, GetContextMut, GetMut},
-		handles_skill_physics::{InitializedAgent, NotInitializedAgent},
+		handles_skill_physics::{InitializedAgent, NotInitializedAgent, SkillMountBone},
 	},
 	zyheeda_commands::{ZyheedaCommands, ZyheedaEntityCommands},
 };
@@ -34,6 +34,7 @@ impl GetContext<InitializedAgent> for SkillAgent<'_, '_> {
 #[derive(SystemParam)]
 pub struct SkillAgentMut<'w, 's> {
 	skills: Query<'w, 's, (), With<Skill>>,
+	mount_point_definitions: Query<'w, 's, (), With<MountPointsDefinition<SkillMountBone>>>,
 	targets: Query<'w, 's, &'static mut Target>,
 	commands: ZyheedaCommands<'w, 's>,
 }
@@ -45,7 +46,7 @@ impl GetContextMut<NotInitializedAgent> for SkillAgentMut<'_, '_> {
 		param: &'ctx mut SkillAgentMut,
 		NotInitializedAgent { entity }: NotInitializedAgent,
 	) -> Option<Self::TContext<'ctx>> {
-		if param.targets.contains(entity) {
+		if param.mount_point_definitions.contains(entity) && param.targets.contains(entity) {
 			return None;
 		}
 
@@ -62,6 +63,10 @@ impl GetContextMut<InitializedAgent> for SkillAgentMut<'_, '_> {
 		param: &'ctx mut SkillAgentMut,
 		InitializedAgent { entity }: InitializedAgent,
 	) -> Option<Self::TContext<'ctx>> {
+		if !param.mount_point_definitions.contains(entity) {
+			return None;
+		}
+
 		let target = param.targets.get_mut(entity).ok()?;
 
 		Some(SkillAgentContextMut { target })
@@ -90,39 +95,126 @@ pub struct SkillAgentContextMut<'ctx> {
 mod tests {
 	use super::*;
 	use bevy::ecs::system::{RunSystemError, RunSystemOnce};
+	use common::traits::handles_skill_physics::SkillMountBone;
 	use testing::SingleThreadedApp;
 
 	fn setup() -> App {
 		App::new().single_threaded(Update)
 	}
 
-	#[test]
-	fn no_uninitialized_context_when_target_present() -> Result<(), RunSystemError> {
-		let mut app = setup();
-		let entity = app.world_mut().spawn(Target(None)).id();
+	mod not_initialized {
+		use super::*;
 
-		let ctx = app
-			.world_mut()
-			.run_system_once(move |mut p: SkillAgentMut| {
-				SkillAgentMut::get_context_mut(&mut p, NotInitializedAgent { entity }).is_some()
-			})?;
+		#[test]
+		fn get_context_when_target_missing() -> Result<(), RunSystemError> {
+			let mut app = setup();
+			let entity = app
+				.world_mut()
+				.spawn(MountPointsDefinition::<SkillMountBone>::default())
+				.id();
 
-		assert!(!ctx);
-		Ok(())
+			let ctx = app
+				.world_mut()
+				.run_system_once(move |mut p: SkillAgentMut| {
+					SkillAgentMut::get_context_mut(&mut p, NotInitializedAgent { entity }).is_some()
+				})?;
+
+			assert!(ctx);
+			Ok(())
+		}
+
+		#[test]
+		fn get_context_when_mount_points_missing() -> Result<(), RunSystemError> {
+			let mut app = setup();
+			let entity = app.world_mut().spawn(Target(None)).id();
+
+			let ctx = app
+				.world_mut()
+				.run_system_once(move |mut p: SkillAgentMut| {
+					SkillAgentMut::get_context_mut(&mut p, NotInitializedAgent { entity }).is_some()
+				})?;
+
+			assert!(ctx);
+			Ok(())
+		}
+
+		#[test]
+		fn no_context_when_target_and_mount_points_present() -> Result<(), RunSystemError> {
+			let mut app = setup();
+			let entity = app
+				.world_mut()
+				.spawn((
+					MountPointsDefinition::<SkillMountBone>::default(),
+					Target(None),
+				))
+				.id();
+
+			let ctx = app
+				.world_mut()
+				.run_system_once(move |mut p: SkillAgentMut| {
+					SkillAgentMut::get_context_mut(&mut p, NotInitializedAgent { entity }).is_some()
+				})?;
+
+			assert!(!ctx);
+			Ok(())
+		}
 	}
 
-	#[test]
-	fn no_initialized_context_when_mount_points_missing() -> Result<(), RunSystemError> {
-		let mut app = setup();
-		let entity = app.world_mut().spawn_empty().id();
+	mod initialized {
+		use super::*;
 
-		let ctx = app
-			.world_mut()
-			.run_system_once(move |mut p: SkillAgentMut| {
-				SkillAgentMut::get_context_mut(&mut p, InitializedAgent { entity }).is_some()
-			})?;
+		#[test]
+		fn no_context_when_target_missing() -> Result<(), RunSystemError> {
+			let mut app = setup();
+			let entity = app
+				.world_mut()
+				.spawn(MountPointsDefinition::<SkillMountBone>::default())
+				.id();
 
-		assert!(!ctx);
-		Ok(())
+			let ctx = app
+				.world_mut()
+				.run_system_once(move |mut p: SkillAgentMut| {
+					SkillAgentMut::get_context_mut(&mut p, InitializedAgent { entity }).is_some()
+				})?;
+
+			assert!(!ctx);
+			Ok(())
+		}
+
+		#[test]
+		fn mo_context_when_mount_points_missing() -> Result<(), RunSystemError> {
+			let mut app = setup();
+			let entity = app.world_mut().spawn(Target(None)).id();
+
+			let ctx = app
+				.world_mut()
+				.run_system_once(move |mut p: SkillAgentMut| {
+					SkillAgentMut::get_context_mut(&mut p, InitializedAgent { entity }).is_some()
+				})?;
+
+			assert!(!ctx);
+			Ok(())
+		}
+
+		#[test]
+		fn get_context_when_target_and_mount_points_present() -> Result<(), RunSystemError> {
+			let mut app = setup();
+			let entity = app
+				.world_mut()
+				.spawn((
+					MountPointsDefinition::<SkillMountBone>::default(),
+					Target(None),
+				))
+				.id();
+
+			let ctx = app
+				.world_mut()
+				.run_system_once(move |mut p: SkillAgentMut| {
+					SkillAgentMut::get_context_mut(&mut p, InitializedAgent { entity }).is_some()
+				})?;
+
+			assert!(ctx);
+			Ok(())
+		}
 	}
 }

--- a/src/plugins/physics/src/system_params/skill_agent/target.rs
+++ b/src/plugins/physics/src/system_params/skill_agent/target.rs
@@ -35,7 +35,7 @@ mod tests {
 		components::persistent_entity::PersistentEntity,
 		traits::{
 			accessors::get::{GetContext, GetContextMut},
-			handles_skill_physics::{InitializedAgent, SkillMount, Target as _},
+			handles_skill_physics::{InitializedAgent, SkillMountBone, Target as _},
 		},
 	};
 	use testing::SingleThreadedApp;
@@ -52,7 +52,7 @@ mod tests {
 			.world_mut()
 			.spawn((
 				Target(Some(SkillTarget::Entity(target_entity))),
-				MountPointsDefinition::<SkillMount>::default(),
+				MountPointsDefinition::<SkillMountBone>::default(),
 			))
 			.id();
 
@@ -74,7 +74,7 @@ mod tests {
 			.world_mut()
 			.spawn((
 				Target(Some(SkillTarget::Entity(target_entity))),
-				MountPointsDefinition::<SkillMount>::default(),
+				MountPointsDefinition::<SkillMountBone>::default(),
 			))
 			.id();
 
@@ -96,7 +96,10 @@ mod tests {
 		let target_entity = PersistentEntity::default();
 		let entity = app
 			.world_mut()
-			.spawn((Target(None), MountPointsDefinition::<SkillMount>::default()))
+			.spawn((
+				Target(None),
+				MountPointsDefinition::<SkillMountBone>::default(),
+			))
 			.id();
 
 		app.world_mut()


### PR DESCRIPTION
The parameters responsible for agent animation lookup and skill mount point used insufficient guards when determining whether they have been already initialized. This caused missing animations and mount points on loading a safe game. This is fixed now with proper guards. 