### PR TITLE
make normalized name not lazy

### DIFF
--- a/src/plugins/common/src/components/asset_mesh_name.rs
+++ b/src/plugins/common/src/components/asset_mesh_name.rs
@@ -1,5 +1,6 @@
 use bevy::prelude::*;
-use zyheeda_core::prelude::NormalizedNameLazy;
+use std::ops::Deref;
+use zyheeda_core::prelude::NormalizedName;
 
 /// Represents a normalized asset mesh name.
 ///
@@ -7,10 +8,10 @@ use zyheeda_core::prelude::NormalizedNameLazy;
 /// [`GltfMeshName`](bevy::gltf::GltfMeshName) is inserted .
 #[derive(Component, Debug, PartialEq)]
 #[component(immutable)]
-pub struct AssetMeshName(pub NormalizedNameLazy<String>);
+pub struct AssetMeshName(pub NormalizedName);
 
 impl AssetMeshName {
-	pub fn normalized(name: impl Into<String>) -> Self {
-		Self(NormalizedNameLazy::from_name(name.into()))
+	pub fn normalized(name: impl Deref<Target = str>) -> Self {
+		Self(NormalizedName::from(name))
 	}
 }

--- a/src/plugins/common/src/observers/insert_asset_mesh_name.rs
+++ b/src/plugins/common/src/observers/insert_asset_mesh_name.rs
@@ -4,7 +4,7 @@ use crate::{
 	zyheeda_commands::ZyheedaCommands,
 };
 use bevy::{gltf::GltfMeshName, prelude::*};
-use zyheeda_core::prelude::NormalizedNameLazy;
+use zyheeda_core::prelude::NormalizedName;
 
 impl AssetMeshName {
 	pub(crate) fn insert(
@@ -17,7 +17,7 @@ impl AssetMeshName {
 		};
 
 		commands.try_apply_on(&inserted_name.entity, |mut e| {
-			e.try_insert(AssetMeshName(NormalizedNameLazy::from(name.clone())));
+			e.try_insert(AssetMeshName(NormalizedName::from(name.clone())));
 		});
 	}
 }
@@ -26,7 +26,7 @@ impl AssetMeshName {
 mod tests {
 	use super::*;
 	use testing::SingleThreadedApp;
-	use zyheeda_core::prelude::NormalizedNameLazy;
+	use zyheeda_core::prelude::NormalizedName;
 
 	fn setup() -> App {
 		let mut app = App::new().single_threaded(Update);
@@ -43,7 +43,7 @@ mod tests {
 		let entity = app.world_mut().spawn(GltfMeshName("name".to_owned()));
 
 		assert_eq!(
-			Some(&AssetMeshName(NormalizedNameLazy::from("name".to_owned()))),
+			Some(&AssetMeshName(NormalizedName::from("name".to_owned()))),
 			entity.get::<AssetMeshName>(),
 		);
 	}
@@ -56,7 +56,7 @@ mod tests {
 		entity.insert(GltfMeshName("other name".to_owned()));
 
 		assert_eq!(
-			Some(&AssetMeshName(NormalizedNameLazy::from(
+			Some(&AssetMeshName(NormalizedName::from(
 				"other name".to_owned()
 			))),
 			entity.get::<AssetMeshName>(),

--- a/src/plugins/light/src/components/corridor_light.rs
+++ b/src/plugins/light/src/components/corridor_light.rs
@@ -1,7 +1,7 @@
 use crate::{components::light::Light, observers::get_insert_system::TargetMeshName};
 use bevy::{color::palettes::css::ANTIQUE_WHITE, prelude::*};
 use common::components::insert_asset::InsertAsset;
-use zyheeda_core::prelude::NormalizedNameLazy;
+use zyheeda_core::prelude::NormalizedName;
 
 #[derive(Component, Debug, PartialEq, Default)]
 #[require(Light, SpotLight = Self, InsertAsset<StandardMaterial> = Self)]
@@ -37,7 +37,7 @@ impl From<CorridorLight> for InsertAsset<StandardMaterial> {
 }
 
 impl TargetMeshName for CorridorLight {
-	fn target_mesh_name() -> NormalizedNameLazy {
-		const { NormalizedNameLazy::from_name("CorridorLight") }
+	fn target_mesh_name() -> NormalizedName {
+		NormalizedName::from("CorridorLight")
 	}
 }

--- a/src/plugins/light/src/components/wall_light.rs
+++ b/src/plugins/light/src/components/wall_light.rs
@@ -1,6 +1,6 @@
 use crate::{components::light::Light, observers::get_insert_system::TargetMeshName};
 use bevy::prelude::*;
-use zyheeda_core::prelude::NormalizedNameLazy;
+use zyheeda_core::prelude::NormalizedName;
 
 #[derive(Component, Debug, PartialEq, Default)]
 #[require(Light, SpotLight = Self)]
@@ -19,7 +19,7 @@ impl From<WallLight> for SpotLight {
 }
 
 impl TargetMeshName for WallLight {
-	fn target_mesh_name() -> NormalizedNameLazy {
-		const { NormalizedNameLazy::from_name("WallLight") }
+	fn target_mesh_name() -> NormalizedName {
+		NormalizedName::from("WallLight")
 	}
 }

--- a/src/plugins/light/src/observers/get_insert_system.rs
+++ b/src/plugins/light/src/observers/get_insert_system.rs
@@ -36,7 +36,7 @@ pub(crate) trait GetInsertObserver: Component + Default + TargetMeshName {
 }
 
 pub(crate) trait TargetMeshName {
-	fn target_mesh_name() -> NormalizedNameLazy;
+	fn target_mesh_name() -> NormalizedName;
 }
 
 #[cfg(test)]
@@ -49,8 +49,8 @@ mod tests {
 	struct _Component;
 
 	impl TargetMeshName for _Component {
-		fn target_mesh_name() -> NormalizedNameLazy {
-			NormalizedNameLazy::from_name("TargetName")
+		fn target_mesh_name() -> NormalizedName {
+			NormalizedName::from("TargetName")
 		}
 	}
 

--- a/src/zyheeda_core/src/prelude.rs
+++ b/src/zyheeda_core/src/prelude.rs
@@ -9,6 +9,6 @@ pub use crate::{
 	macros::{all::*, any::*, none::*, write_iter::*},
 	math::f32_not_nan::{F32NotNan, f32_not_nan},
 	serialization::*,
-	strings::normalized_name::NormalizedNameLazy,
+	strings::normalized_name::NormalizedName,
 	yields::*,
 };

--- a/src/zyheeda_core/src/strings/normalized_name.rs
+++ b/src/zyheeda_core/src/strings/normalized_name.rs
@@ -1,102 +1,40 @@
-use std::{fmt::Display, ops::Deref, sync::OnceLock};
+use std::{fmt::Display, ops::Deref};
 
 /// Normalizes names by:
 /// - removing numbered suffixes like `.001`
 /// - streamlining different ways of word separation like CamelCase, snake_case, using dots or
 ///   spaces.
-///
-/// It is lazy and constructed on first read to allow instantiation in `const` contexts.
-#[derive(Debug, Clone)]
-pub struct NormalizedNameLazy<TName = &'static str>
-where
-	TName: Deref<Target = str>,
-{
-	name: TName,
-	normalized: OnceLock<String>,
-}
+#[derive(Debug, PartialEq, Clone)]
+pub struct NormalizedName(String);
 
-impl<TName> NormalizedNameLazy<TName>
-where
-	TName: Deref<Target = str>,
-{
+impl NormalizedName {
 	const REMOVE_CHARS: &'static [char] = &['_', ' ', '.'];
-
-	pub const fn from_name(name: TName) -> Self {
-		Self {
-			name,
-			normalized: OnceLock::new(),
-		}
-	}
-
-	pub fn as_str(&self) -> &'_ str {
-		self.normalized.get_or_init(|| {
-			let name = match self.name.rsplit_once('.') {
-				Some(("", suffix)) => suffix,
-				Some((name, suffix)) if suffix.chars().all(|c| c.is_ascii_digit()) => name,
-				_ => &self.name,
-			};
-
-			name.to_lowercase().replace(Self::REMOVE_CHARS, "")
-		})
-	}
-
-	pub fn to_owned(&self) -> String {
-		String::from(self.as_str())
-	}
 }
 
-impl<TName> From<TName> for NormalizedNameLazy<TName>
+impl<TName> From<TName> for NormalizedName
 where
 	TName: Deref<Target = str>,
 {
-	fn from(raw: TName) -> Self {
-		Self::from_name(raw)
+	fn from(name: TName) -> Self {
+		let name = match name.rsplit_once('.') {
+			Some(("", suffix)) => suffix,
+			Some((name, suffix)) if suffix.chars().all(|c| c.is_ascii_digit()) => name,
+			_ => &name,
+		};
+
+		Self(name.to_lowercase().replace(Self::REMOVE_CHARS, ""))
 	}
 }
 
-impl<TName> From<NormalizedNameLazy<TName>> for String
-where
-	TName: Deref<Target = str>,
-{
-	fn from(name: NormalizedNameLazy<TName>) -> Self {
-		name.to_owned()
-	}
-}
-
-impl<TName> Deref for NormalizedNameLazy<TName>
-where
-	TName: Deref<Target = str>,
-{
-	type Target = str;
-
-	fn deref(&self) -> &Self::Target {
-		self.as_str()
-	}
-}
-
-impl<TName> Display for NormalizedNameLazy<TName>
-where
-	TName: Deref<Target = str>,
-{
+impl Display for NormalizedName {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		Display::fmt(self.as_str(), f)
-	}
-}
-
-impl<TLeft, TRight> PartialEq<NormalizedNameLazy<TRight>> for NormalizedNameLazy<TLeft>
-where
-	TLeft: Deref<Target = str>,
-	TRight: Deref<Target = str>,
-{
-	fn eq(&self, other: &NormalizedNameLazy<TRight>) -> bool {
-		self.as_str() == other.as_str()
+		self.0.fmt(f)
 	}
 }
 
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use std::fmt::Debug;
 	use test_case::test_case;
 
 	#[test_case("normalized", "normalized"; "unchanged")]
@@ -110,33 +48,8 @@ mod tests {
 	#[test_case("001", "001"; "with only digits")]
 	#[test_case(".001", "001"; "with only suffix leading with a dot")]
 	fn normalize_name(name: &str, expected: &str) {
-		let name = NormalizedNameLazy::from(name);
+		let name = NormalizedName::from(name);
 
-		assert_eq!(
-			(
-				expected,
-				expected,
-				expected.to_owned(),
-				expected.to_owned(),
-				expected.to_owned()
-			),
-			(
-				name.clone().as_str(),
-				name.clone().deref(),
-				name.to_string(),
-				name.to_owned(),
-				String::from(name),
-			)
-		);
-	}
-
-	#[test_case("my_name", "my name"; "when values differ")]
-	#[test_case("name", String::from("name"); "when types differ")]
-	#[test_case("my_name", String::from("my name"); "when types and values differ")]
-	fn partial_eq(l: impl Deref<Target = str> + Debug, r: impl Deref<Target = str> + Debug) {
-		let l = NormalizedNameLazy::from_name(l);
-		let r = NormalizedNameLazy::from_name(r);
-
-		assert_eq!(l, r);
+		assert_eq!(NormalizedName(expected.to_owned()), name);
 	}
 }


### PR DESCRIPTION
The lazy scheme for `NormalizedName` to enable const construction was not really helpful. The moment we need const references or put the name into some kind of const collection (slizes, arrays) it would just break because of the internal mutable field. So we abandon this lazy approach completely.