### PR TITLE
Constrain interface system parameters to be `ThreadSafe`

### DIFF
--- a/src/plugins/agents/src/lib.rs
+++ b/src/plugins/agents/src/lib.rs
@@ -21,34 +21,18 @@ use common::{
 		after_plugin::AfterPlugin,
 		delta::Delta,
 		handles_agents::HandlesAgents,
-		handles_animations::{AnimationsSystemParamMut, HandlesAnimations},
+		handles_animations::HandlesAnimations,
 		handles_custom_assets::HandlesCustomFolderAssets,
 		handles_enemies::HandlesEnemies,
-		handles_input::{HandlesInput, InputSystemParam},
-		handles_loadout::{
-			HandlesLoadout,
-			LoadoutActivityMutParam,
-			LoadoutActivityParam,
-			LoadoutPrepParam,
-		},
-		handles_map_generation::{HandlesMapGeneration, NewMapAgentParamMut},
-		handles_movement::{
-			HandlesMovement,
-			MovementSystemConfigParam,
-			MovementSystemParam,
-			MovementSystemParamMut,
-		},
+		handles_input::HandlesInput,
+		handles_loadout::HandlesLoadout,
+		handles_map_generation::HandlesMapGeneration,
+		handles_movement::HandlesMovement,
 		handles_orientation::HandlesOrientation,
-		handles_physics::{
-			HandlesPhysicalEffectTargets,
-			HandlesPhysicsConfig,
-			HandlesRaycast,
-			PhysicsConfigMut,
-			RaycastSystemParam,
-		},
+		handles_physics::{HandlesPhysicalEffectTargets, HandlesPhysicsConfig, HandlesRaycast},
 		handles_player::{HandlesPlayer, PlayerMainCamera},
 		handles_saving::HandlesSaving,
-		handles_skill_physics::{HandlesPhysicalSkillAgent, SkillAgentMut},
+		handles_skill_physics::HandlesPhysicalSkillAgent,
 		prefab::AddPrefabObserver,
 		system_set_definition::SystemSetDefinition,
 		thread_safe::ThreadSafe,
@@ -136,19 +120,18 @@ where
 		TPhysics::mark_as_effect_target::<Agent>(app);
 		app.add_systems(
 			Startup,
-			Agent::configure_map_prefab::<NewMapAgentParamMut<TMaps>>.pipe(OnError::log),
+			Agent::configure_map_prefab::<TMaps::TNewMapAgent>.pipe(OnError::log),
 		);
 		app.add_systems(
 			Update,
 			(
 				ApplyAgentConfig::system::<
-					LoadoutPrepParam<TLoadout>,
-					SkillAgentMut<TPhysics>,
-					MovementSystemConfigParam<TMovement>,
-					PhysicsConfigMut<TPhysics>,
+					TLoadout::TLoadoutPrep,
+					TPhysics::TAgentMut,
+					TMovement::TMovementConfig,
+					TPhysics::TConfigMut,
 				>,
-				ApplyAgentAnimations::system::<AnimationsSystemParamMut<TAnimations>>
-					.pipe(OnError::log),
+				ApplyAgentAnimations::system::<TAnimations::TAnimationsMut>.pipe(OnError::log),
 			),
 		);
 
@@ -169,44 +152,31 @@ where
 			Update,
 			(
 				(
-					Player::movement::<
-						InputSystemParam<TInput>,
-						RaycastSystemParam<TPhysics>,
-						MovementSystemParamMut<TMovement>,
-					>,
-					Player::toggle_speed::<
-						InputSystemParam<TInput>,
-						MovementSystemParamMut<TMovement>,
-					>,
-					Player::animate_movement::<
-						MovementSystemParam<TMovement>,
-						AnimationsSystemParamMut<TAnimations>,
-					>,
+					Player::movement::<TInput::TInput, TPhysics::TRaycast, TMovement::TMovementMut>,
+					Player::toggle_speed::<TInput::TInput, TMovement::TMovementMut>,
+					Player::animate_movement::<TMovement::TMovement, TAnimations::TAnimationsMut>,
 					Player::use_skills::<
-						InputSystemParam<TInput>,
-						SkillAgentMut<TPhysics>,
-						LoadoutActivityMutParam<TLoadout>,
+						TInput::TInput,
+						TPhysics::TAgentMut,
+						TLoadout::TLoadoutActivityMut,
 					>,
 				)
 					.chain(),
 				(
-					Enemy::attack_decision::<RaycastSystemParam<TPhysics>>,
+					Enemy::attack_decision::<TPhysics::TRaycast>,
 					Enemy::chase_decision,
-					Enemy::chase_player::<MovementSystemParamMut<TMovement>>,
-					Enemy::animate_movement::<
-						MovementSystemParam<TMovement>,
-						AnimationsSystemParamMut<TAnimations>,
-					>,
+					Enemy::chase_player::<TMovement::TMovementMut>,
+					Enemy::animate_movement::<TMovement::TMovement, TAnimations::TAnimationsMut>,
 					ring_rotation,
 					Enemy::begin_attack,
-					Enemy::hold_attack::<SkillAgentMut<TPhysics>, LoadoutActivityMutParam<TLoadout>>,
+					Enemy::hold_attack::<TPhysics::TAgentMut, TLoadout::TLoadoutActivityMut>,
 					Update::delta.pipe(Enemy::advance_attack_phase),
 				)
 					.chain(),
-				AnimateIdle::execute::<AnimationsSystemParamMut<TAnimations>>,
+				AnimateIdle::execute::<TAnimations::TAnimationsMut>,
 				AgentConfig::animate_skills::<
-					LoadoutActivityParam<TLoadout>,
-					AnimationsSystemParamMut<TAnimations>,
+					TLoadout::TLoadoutActivity,
+					TAnimations::TAnimationsMut,
 				>,
 			)
 				.chain()

--- a/src/plugins/animations/src/lib.rs
+++ b/src/plugins/animations/src/lib.rs
@@ -84,5 +84,5 @@ impl<TDependencies> SystemSetDefinition for AnimationsPlugin<TDependencies> {
 }
 
 impl<TDependencies> HandlesAnimations for AnimationsPlugin<TDependencies> {
-	type TAnimationsMut<'w, 's> = AnimationsParamMut<'w, 's>;
+	type TAnimationsMut = AnimationsParamMut<'static, 'static>;
 }

--- a/src/plugins/animations/src/system_params/animations.rs
+++ b/src/plugins/animations/src/system_params/animations.rs
@@ -38,7 +38,7 @@ where
 }
 
 impl<TAnimationGraph> GetContextMut<WithoutAnimations>
-	for AnimationsParamMut<'_, '_, TAnimationGraph>
+	for AnimationsParamMut<'static, 'static, TAnimationGraph>
 where
 	TAnimationGraph: Asset,
 {
@@ -59,7 +59,8 @@ where
 	}
 }
 
-impl<TAnimationGraph> GetContextMut<Animations> for AnimationsParamMut<'_, '_, TAnimationGraph>
+impl<TAnimationGraph> GetContextMut<Animations>
+	for AnimationsParamMut<'static, 'static, TAnimationGraph>
 where
 	TAnimationGraph: Asset,
 {

--- a/src/plugins/camera_control/src/lib.rs
+++ b/src/plugins/camera_control/src/lib.rs
@@ -9,7 +9,7 @@ use common::{
 	traits::{
 		after_plugin::AfterPlugin,
 		handles_graphics::{FirstPassCamera, WorldCameras},
-		handles_input::{HandlesInput, InputSystemParam},
+		handles_input::HandlesInput,
 		handles_player::{HandlesPlayer, PlayerMainCamera},
 		handles_saving::HandlesSaving,
 		system_set_definition::SystemSetDefinition,
@@ -55,7 +55,7 @@ where
 			Update,
 			(
 				TGraphics::TWorldCameras::set_to_orbit::<TPlayers::TPlayer>.pipe(OnError::log),
-				move_on_orbit::<OrbitPlayer, InputSystemParam<TInput>>,
+				move_on_orbit::<OrbitPlayer, TInput::TInput>,
 				move_with_target::<OrbitPlayer>,
 			)
 				.chain()

--- a/src/plugins/common/src/traits/accessors/get.rs
+++ b/src/plugins/common/src/traits/accessors/get.rs
@@ -16,6 +16,7 @@ use std::{any::type_name, fmt::Display, marker::PhantomData};
 use crate::{
 	errors::{ErrorData, Level},
 	systems::log::output,
+	traits::thread_safe::ThreadSafe,
 };
 
 pub trait Get<TKey> {
@@ -39,7 +40,7 @@ pub trait ContextChanged {
 /// Retrieve a context for data inspection.
 ///
 /// It is up to the implementor, what kind of system parameters are involved.
-pub trait GetContext<TKey>: SystemParam {
+pub trait GetContext<TKey>: SystemParam + ThreadSafe {
 	type TContext<'ctx>: ContextChanged;
 
 	fn get_context<'ctx>(
@@ -81,7 +82,7 @@ pub trait GetMut<TKey> {
 /// Retrieve a context for data mutation.
 ///
 /// It is up to the implementor, what kind of system parameters are involved.
-pub trait GetContextMut<TKey>: SystemParam {
+pub trait GetContextMut<TKey>: SystemParam + ThreadSafe {
 	type TContext<'ctx>;
 
 	fn get_context_mut<'ctx>(

--- a/src/plugins/common/src/traits/accessors/get/components.rs
+++ b/src/plugins/common/src/traits/accessors/get/components.rs
@@ -10,7 +10,7 @@ where
 	}
 }
 
-impl<T, TKey> GetContext<TKey> for Query<'_, '_, Ref<'static, T>>
+impl<T, TKey> GetContext<TKey> for Query<'static, 'static, Ref<'static, T>>
 where
 	T: Component,
 	TKey: View<Entity>,
@@ -22,7 +22,7 @@ where
 	}
 }
 
-impl<T, TKey> GetContextMut<TKey> for Query<'_, '_, Mut<'static, T>>
+impl<T, TKey> GetContextMut<TKey> for Query<'static, 'static, Mut<'static, T>>
 where
 	T: Component<Mutability = Mutable>,
 	TKey: View<Entity>,
@@ -37,7 +37,7 @@ where
 	}
 }
 
-impl<T, TKey> GetContextMut<TKey> for Query<'_, '_, &'static mut T>
+impl<T, TKey> GetContextMut<TKey> for Query<'static, 'static, &'static mut T>
 where
 	T: Component<Mutability = Mutable>,
 	TKey: View<Entity>,

--- a/src/plugins/common/src/traits/handles_animations.rs
+++ b/src/plugins/common/src/traits/handles_animations.rs
@@ -19,7 +19,7 @@ use std::{
 use zyheeda_core::prelude::OrderedSet;
 
 pub trait HandlesAnimations {
-	type TAnimationsMut<'w, 's>: SystemParam
+	type TAnimationsMut: SystemParam
 		+ for<'c> GetContextMut<WithoutAnimations, TContext<'c>: RegisterAnimations>
 		+ for<'c> GetContextMut<Animations, TContext<'c>: ActiveAnimationsMut>
 		+ for<'c> GetContextMut<Animations, TContext<'c>: GetMoveDirectionMut>
@@ -35,8 +35,6 @@ pub struct WithoutAnimations {
 pub struct Animations {
 	pub entity: Entity,
 }
-
-pub type AnimationsSystemParamMut<'w, 's, T> = <T as HandlesAnimations>::TAnimationsMut<'w, 's>;
 
 pub trait RegisterAnimations {
 	fn register_animations(

--- a/src/plugins/common/src/traits/handles_input.rs
+++ b/src/plugins/common/src/traits/handles_input.rs
@@ -25,27 +25,19 @@ impl ViewField for MouseOverrideActive {
 }
 
 pub trait HandlesInput {
-	type TInput<'world, 'state>: SystemParam
+	type TInput: SystemParam
 		+ for<'w, 's> SystemParam<Item<'w, 's>: GetInput + GetAllInputs + InputSetupChanged>
 		+ for<'w, 's> SystemParam<Item<'w, 's>: GetInputState + GetAllInputStates>
 		+ for<'w, 's> SystemParam<Item<'w, 's>: GetRawUserInput>;
 }
 
 pub trait HandlesInputMut {
-	type TInputMut<'world, 'state>: SystemParam
+	type TInputMut: SystemParam
 		+ for<'w, 's> SystemParam<Item<'w, 's>: GetInput + GetAllInputs + InputSetupChanged>
 		+ for<'w, 's> SystemParam<Item<'w, 's>: GetInputState + GetAllInputStates>
 		+ for<'w, 's> SystemParam<Item<'w, 's>: GetRawUserInput>
 		+ for<'w, 's> SystemParam<Item<'w, 's>: UpdateKey>;
 }
-
-/// Helper type to designate [`HandlesInput::TInput`] as a [`SystemParam`] implementation for a
-/// given generic system constraint
-pub type InputSystemParam<'w, 's, T> = <T as HandlesInput>::TInput<'w, 's>;
-
-/// Helper type to designate [`HandlesInputMut::TInputMut`] as a [`SystemParam`] implementation for a
-/// given generic system constraint
-pub type InputMutSystemParam<'w, 's, T> = <T as HandlesInputMut>::TInputMut<'w, 's>;
 
 pub trait UpdateKey {
 	fn update_key<TAction>(&mut self, action: TAction, input: UserInput)

--- a/src/plugins/common/src/traits/handles_loadout.rs
+++ b/src/plugins/common/src/traits/handles_loadout.rs
@@ -34,33 +34,27 @@ use std::{
 pub trait HandlesLoadout {
 	type TSkillID: Debug + PartialEq + Copy + ThreadSafe;
 
-	type TLoadoutPrep<'w, 's>: SystemParam
+	type TLoadoutPrep: SystemParam
 		+ for<'c> GetContextMut<NotLoadedOut, TContext<'c>: InsertDefaultLoadout>
 		+ for<'c> GetContextMut<NoBonesRegistered, TContext<'c>: RegisterLoadoutBones>;
 
-	type TLoadout<'w, 's>: SystemParam
+	type TLoadout: SystemParam
 		+ for<'c> GetContext<Items, TContext<'c>: ReadItems>
 		+ for<'c> GetContext<Skills, TContext<'c>: ReadSkills>
 		+ for<'c> GetContext<Combos, TContext<'c>: ReadCombos<Self::TSkillID>>
 		+ for<'c> GetContext<AvailableSkills, TContext<'c>: ReadAvailableSkills<Self::TSkillID>>;
 
-	type TLoadoutMut<'w, 's>: SystemParam
+	type TLoadoutMut: SystemParam
 		+ for<'c> GetContextMut<Items, TContext<'c>: SwapItems>
 		+ for<'c> GetContextMut<Combos, TContext<'c>: UpdateCombos<Self::TSkillID>>;
 
-	type TLoadoutActivity<'w, 's>: SystemParam
+	type TLoadoutActivity: SystemParam
 		+ for<'c> GetContext<Skills, TContext<'c>: ActiveSkills>
 		+ for<'c> GetContext<Skills, TContext<'c>: HeldSkills>;
 
-	type TLoadoutActivityMut<'w, 's>: SystemParam
+	type TLoadoutActivityMut: SystemParam
 		+ for<'c> GetContextMut<Skills, TContext<'c>: HeldSkillsMut>;
 }
-
-pub type LoadoutPrepParam<'w, 's, T> = <T as HandlesLoadout>::TLoadoutPrep<'w, 's>;
-pub type LoadoutParam<'w, 's, T> = <T as HandlesLoadout>::TLoadout<'w, 's>;
-pub type LoadoutMutParam<'w, 's, T> = <T as HandlesLoadout>::TLoadoutMut<'w, 's>;
-pub type LoadoutActivityParam<'w, 's, T> = <T as HandlesLoadout>::TLoadoutActivity<'w, 's>;
-pub type LoadoutActivityMutParam<'w, 's, T> = <T as HandlesLoadout>::TLoadoutActivityMut<'w, 's>;
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum LoadoutKey {

--- a/src/plugins/common/src/traits/handles_map_generation.rs
+++ b/src/plugins/common/src/traits/handles_map_generation.rs
@@ -17,7 +17,7 @@ use std::{
 };
 
 pub trait HandlesMapGeneration: SystemSetDefinition {
-	type TNewMapAgent<'w, 's>: SystemParam
+	type TNewMapAgent: SystemParam
 		+ for<'c> GetContextMut<AgentPrefab, TContext<'c>: SetMapAgentPrefab>;
 
 	type TGraph: Graph + for<'a> From<&'a Self::TMap> + ThreadSafe;
@@ -25,8 +25,6 @@ pub trait HandlesMapGeneration: SystemSetDefinition {
 	type TMap: Component;
 	type TMapRef: Component + View<Entity>;
 }
-
-pub type NewMapAgentParamMut<'w, 's, TMaps> = <TMaps as HandlesMapGeneration>::TNewMapAgent<'w, 's>;
 
 pub trait Graph:
 	GraphNode<TNNode = Self::TNode>

--- a/src/plugins/common/src/traits/handles_movement.rs
+++ b/src/plugins/common/src/traits/handles_movement.rs
@@ -11,17 +11,12 @@ use serde::{Deserialize, Serialize};
 use std::ops::DerefMut;
 
 pub trait HandlesMovement: SystemSetDefinition {
-	type TMovement<'w, 's>: SystemParam
-		+ for<'c> GetContext<Movement, TContext<'c>: CurrentMovement>;
-	type TMovementMut<'w, 's>: SystemParam
+	type TMovement: SystemParam + for<'c> GetContext<Movement, TContext<'c>: CurrentMovement>;
+	type TMovementMut: SystemParam
 		+ for<'c> GetContextMut<ConfiguredMovement, TContext<'c>: ControlMovement>;
-	type TMovementConfig<'w, 's>: SystemParam
+	type TMovementConfig: SystemParam
 		+ for<'c> GetContextMut<NotConfiguredMovement, TContext<'c>: ConfigureMovement>;
 }
-
-pub type MovementSystemParam<'w, 's, T> = <T as HandlesMovement>::TMovement<'w, 's>;
-pub type MovementSystemParamMut<'w, 's, T> = <T as HandlesMovement>::TMovementMut<'w, 's>;
-pub type MovementSystemConfigParam<'w, 's, T> = <T as HandlesMovement>::TMovementConfig<'w, 's>;
 
 pub trait ControlMovement: StartMovement + StopMovement + ToggleSpeed + CurrentMovement {}
 

--- a/src/plugins/common/src/traits/handles_orientation.rs
+++ b/src/plugins/common/src/traits/handles_orientation.rs
@@ -8,11 +8,8 @@ use serde::{Deserialize, Serialize};
 use std::ops::DerefMut;
 
 pub trait HandlesOrientation {
-	type TFaceSystemParam<'w, 's>: SystemParam
-		+ for<'c> GetContextMut<Facing, TContext<'c>: OverrideFace>;
+	type TFaceSystemParam: SystemParam + for<'c> GetContextMut<Facing, TContext<'c>: OverrideFace>;
 }
-
-pub type FacingSystemParamMut<'w, 's, T> = <T as HandlesOrientation>::TFaceSystemParam<'w, 's>;
 
 #[derive(EntityKey)]
 pub struct Facing {

--- a/src/plugins/common/src/traits/handles_physics.rs
+++ b/src/plugins/common/src/traits/handles_physics.rs
@@ -25,16 +25,12 @@ pub trait HandlesRaycast {
 
 	/// Raycast system parameter. [`MouseHover`] raycast requires that `Self::TWorldCamera` is being
 	/// attached to the actual camera.
-	type TRaycast<'world, 'state>: SystemParam
+	type TRaycast: SystemParam
 		+ for<'w, 's> SystemParam<Item<'w, 's>: Raycast<SolidObjects>>
 		+ for<'w, 's> SystemParam<Item<'w, 's>: Raycast<Terrain>>
 		+ for<'w, 's> SystemParam<Item<'w, 's>: Raycast<MouseTerrainHover>>
 		+ for<'w, 's> SystemParam<Item<'w, 's>: Raycast<MouseHover>>;
 }
-
-/// Helper type to designate [`HandlesRaycast::TRaycast`] as a [`SystemParam`] implementation for a
-/// given generic system constraint
-pub type RaycastSystemParam<'w, 's, T> = <T as HandlesRaycast>::TRaycast<'w, 's>;
 
 pub trait Raycast<TArgs>
 where
@@ -58,12 +54,10 @@ pub trait RaycastResult {
 }
 
 pub trait HandlesPhysicsConfig {
-	type TConfigMut<'w, 's>: SystemParam
+	type TConfigMut: SystemParam
 		+ for<'c> GetContextMut<NoDefaultAttributes, TContext<'c>: ConfigureDefaultAttributes>
 		+ for<'c> GetContextMut<NoBodyConfigured, TContext<'c>: ConfigureBody>;
 }
-
-pub type PhysicsConfigMut<'w, 's, T> = <T as HandlesPhysicsConfig>::TConfigMut<'w, 's>;
 
 #[derive(EntityKey)]
 pub struct NoDefaultAttributes {

--- a/src/plugins/common/src/traits/handles_skill_physics.rs
+++ b/src/plugins/common/src/traits/handles_skill_physics.rs
@@ -44,10 +44,8 @@ pub trait HandlesPhysicalSkillComponents {
 }
 
 pub trait HandlesNewPhysicalSkill {
-	type TSkillSpawnerMut<'world, 'state>: for<'w, 's> SystemParam<Item<'w, 's>: Spawn + Despawn>;
+	type TSkillSpawnerMut: for<'w, 's> SystemParam<Item<'w, 's>: Spawn + Despawn>;
 }
-
-pub type SkillSpawnerMut<'w, 's, T> = <T as HandlesNewPhysicalSkill>::TSkillSpawnerMut<'w, 's>;
 
 pub trait Spawn {
 	fn spawn(&mut self, args: SpawnArgs<'_>) -> PersistentEntity;
@@ -76,14 +74,11 @@ where
 }
 
 pub trait HandlesPhysicalSkillAgent {
-	type TAgent<'w, 's>: SystemParam + for<'c> GetContext<InitializedAgent, TContext<'c>: Target>;
-	type TAgentMut<'w, 's>: SystemParam
+	type TAgent: SystemParam + for<'c> GetContext<InitializedAgent, TContext<'c>: Target>;
+	type TAgentMut: SystemParam
 		+ for<'c> GetContextMut<NotInitializedAgent, TContext<'c>: Initialize>
 		+ for<'c> GetContextMut<InitializedAgent, TContext<'c>: TargetMut>;
 }
-
-pub type SkillAgent<'w, 's, T> = <T as HandlesPhysicalSkillAgent>::TAgent<'w, 's>;
-pub type SkillAgentMut<'w, 's, T> = <T as HandlesPhysicalSkillAgent>::TAgentMut<'w, 's>;
 
 #[derive(EntityKey)]
 pub struct NotInitializedAgent {

--- a/src/plugins/input/src/lib.rs
+++ b/src/plugins/input/src/lib.rs
@@ -87,9 +87,9 @@ impl<TDependencies> HandlesActionKeyButton for InputPlugin<TDependencies> {
 }
 
 impl<TDependencies> HandlesInput for InputPlugin<TDependencies> {
-	type TInput<'world, 'state> = Input<'world, 'state, Res<'static, KeyMap>>;
+	type TInput = Input<'static, 'static, Res<'static, KeyMap>>;
 }
 
 impl<TDependencies> HandlesInputMut for InputPlugin<TDependencies> {
-	type TInputMut<'world, 'state> = Input<'world, 'state, ResMut<'static, KeyMap>>;
+	type TInputMut = Input<'static, 'static, ResMut<'static, KeyMap>>;
 }

--- a/src/plugins/map_generation/src/lib.rs
+++ b/src/plugins/map_generation/src/lib.rs
@@ -33,7 +33,7 @@ use common::{
 		handles_lights::HandlesLights,
 		handles_load_tracking::{AssetsProgress, HandlesLoadTracking, LoadTrackingInApp},
 		handles_map_generation::{AgentType, HandlesMapGeneration},
-		handles_physics::{HandlesPhysicsConfig, HandlesRaycast, PhysicsConfigMut},
+		handles_physics::{HandlesPhysicsConfig, HandlesRaycast},
 		handles_saving::HandlesSaving,
 		prefab::AddPrefabObserver,
 		spawn::Spawn,
@@ -93,7 +93,7 @@ where
 		app.init_resource::<AgentPrefab>()
 			.register_required_components::<Map, TSavegame::TSaveEntityMarker>()
 			.add_systems(OnEnter(GameState::NewGame), Level::<0>::spawn)
-			.add_prefab_observer::<MeshCollider, PhysicsConfigMut<TPhysics>>()
+			.add_prefab_observer::<MeshCollider, TPhysics::TConfigMut>()
 			.add_observer(NavMesh::identify_by_prefix(Self::NAV_MESH_PREFIX))
 			.add_observer(MeshCollider::identify_by_prefix(Self::MESH_COLLIDER_PREFIX))
 			.add_observer(AgentSpawner::identify_by_prefix_map(Self::SPAWNERS))
@@ -116,7 +116,7 @@ where
 pub struct MapSystems;
 
 impl<TDependencies> HandlesMapGeneration for MapGenerationPlugin<TDependencies> {
-	type TNewMapAgent<'w, 's> = SetAgentPrefab<'w>;
+	type TNewMapAgent = SetAgentPrefab<'static>;
 
 	type TGraph = MeshGridGraph;
 

--- a/src/plugins/map_generation/src/system_params/set_agent_prefab.rs
+++ b/src/plugins/map_generation/src/system_params/set_agent_prefab.rs
@@ -27,7 +27,7 @@ impl SetMapAgentPrefab for &mut AgentPrefab {
 	}
 }
 
-impl GetContextMut<AgentPrefabMarker> for SetAgentPrefab<'_> {
+impl GetContextMut<AgentPrefabMarker> for SetAgentPrefab<'static> {
 	type TContext<'ctx> = &'ctx mut AgentPrefab;
 
 	fn get_context_mut<'ctx>(

--- a/src/plugins/menu/src/lib.rs
+++ b/src/plugins/menu/src/lib.rs
@@ -44,20 +44,14 @@ use common::{
 	tools::{action_key::ActionKey, path::Path},
 	traits::{
 		handles_graphics::UiCamera,
-		handles_input::{
-			HandlesActionKeyButton,
-			HandlesInput,
-			HandlesInputMut,
-			InputMutSystemParam,
-			InputSystemParam,
-		},
+		handles_input::{HandlesActionKeyButton, HandlesInput, HandlesInputMut},
 		handles_load_tracking::{
 			AssetsProgress,
 			DependenciesProgress,
 			HandlesLoadTracking,
 			LoadGroup,
 		},
-		handles_loadout::{HandlesLoadout, LoadoutMutParam, LoadoutParam},
+		handles_loadout::HandlesLoadout,
 		handles_localization::{HandlesLocalization, Token, localized::Localized},
 		handles_player::HandlesPlayer,
 		handles_saving::HandlesSaving,
@@ -179,7 +173,7 @@ where
 			Update,
 			(
 				PreventMenuChange::menus_unchangeable_when_present,
-				set_state_from_input::<MenuState, InputSystemParam<TInput>>
+				set_state_from_input::<MenuState, TInput::TInput>
 					.run_if(changeable_and_not_loading),
 			)
 				.chain(),
@@ -242,11 +236,11 @@ where
 			.add_systems(
 				Update,
 				(
-					QuickbarPanel::set_icon::<TPlayers::TPlayer, LoadoutParam<TLoadout>>,
+					QuickbarPanel::set_icon::<TPlayers::TPlayer, TLoadout::TLoadout>,
 					QuickbarPanel::set_color::<
 						TPlayers::TPlayer,
 						TInput::TActionKeyButton,
-						LoadoutParam<TLoadout>,
+						TLoadout::TLoadout,
 					>,
 					panel_colors::<QuickbarPanel>,
 				)
@@ -273,40 +267,37 @@ where
 			(
 				ComboOverview::update_from::<
 					TPlayers::TPlayer,
-					LoadoutParam<TLoadout>,
+					TLoadout::TLoadout,
 					TLoadout::TSkillID,
 				>,
-				KeySelectDropdownCommand::insert_dropdown::<
-					TPlayers::TPlayer,
-					LoadoutParam<TLoadout>,
-				>,
+				KeySelectDropdownCommand::insert_dropdown::<TPlayers::TPlayer, TLoadout::TLoadout>,
 				SkillSelectDropdownCommand::<Vertical>::insert_dropdown::<
 					TPlayers::TPlayer,
-					LoadoutParam<TLoadout>,
+					TLoadout::TLoadout,
 					TLoadout::TSkillID,
 				>,
 				SkillSelectDropdownCommand::<Horizontal>::insert_dropdown::<
 					TPlayers::TPlayer,
-					LoadoutParam<TLoadout>,
+					TLoadout::TLoadout,
 					TLoadout::TSkillID,
 				>,
 				VerticalItem::<TLoadout::TSkillID>::update::<
 					TPlayers::TPlayer,
-					LoadoutMutParam<TLoadout>,
+					TLoadout::TLoadoutMut,
 				>,
 				HorizontalItem::<TLoadout::TSkillID>::update::<
 					TPlayers::TPlayer,
-					LoadoutMutParam<TLoadout>,
+					TLoadout::TLoadoutMut,
 				>,
 				DeleteSkill::from_combos::<
 					TPlayers::TPlayer,
-					LoadoutMutParam<TLoadout>,
+					TLoadout::TLoadoutMut,
 					TLoadout::TSkillID,
 				>,
 				Trigger::<TLoadout::TSkillID>::visualize_invalid::<
 					Unusable,
 					TPlayers::TPlayer,
-					LoadoutParam<TLoadout>,
+					TLoadout::TLoadout,
 				>,
 			)
 				.chain()
@@ -323,10 +314,10 @@ where
 		.add_systems(
 			Update,
 			(
-				InventoryPanel::set_label::<TPlayers::TPlayer, LoadoutParam<TLoadout>>,
+				InventoryPanel::set_label::<TPlayers::TPlayer, TLoadout::TLoadout>,
 				panel_colors::<InventoryPanel>,
 				drag_item::<TPlayers::TPlayer>,
-				drop_item::<TPlayers::TPlayer, LoadoutMutParam<TLoadout>>,
+				drop_item::<TPlayers::TPlayer, TLoadout::TLoadoutMut>,
 			)
 				.chain()
 				.run_if(in_state(inventory)),
@@ -348,12 +339,12 @@ where
 			.add_systems(
 				Update,
 				(
-					SettingsScreen::set_key_bindings_from::<InputSystemParam<TInput>>,
+					SettingsScreen::set_key_bindings_from::<TInput::TInput>,
 					KeyBindAction::render_ui::<TLocalization::TLocalizationServer>,
 					KeyBindInput::render_ui::<TLocalization::TLocalizationServer>,
 					KeyBindInput::rebind_on_click,
 					KeyRebindInput::render_ui::<TLocalization::TLocalizationServer>,
-					KeyRebindInput::rebind_apply::<InputMutSystemParam<TInput>>,
+					KeyRebindInput::rebind_apply::<TInput::TInputMut>,
 				)
 					.run_if(in_state(settings)),
 			);
@@ -374,7 +365,7 @@ where
 					DispatchTextColor::apply,
 					UIDisabled::apply,
 					(
-						InputLabel::icon::<InputSystemParam<TInput>>("icons/keys"),
+						InputLabel::icon::<TInput::TInput>("icons/keys"),
 						Icon::load_image,
 						Icon::insert_image,
 						UILabel::icon_tooltip,

--- a/src/plugins/menu/src/systems/combos/update_combos_view.rs
+++ b/src/plugins/menu/src/systems/combos/update_combos_view.rs
@@ -69,7 +69,7 @@ mod tests {
 	#[derive(SystemParam)]
 	struct _Param<'w, 's>(Query<'w, 's, Ref<'static, _Combos>>);
 
-	impl GetContext<Combos> for _Param<'_, '_> {
+	impl GetContext<Combos> for _Param<'static, 'static> {
 		type TContext<'ctx> = _CombosContext<'ctx>;
 
 		fn get_context<'ctx>(

--- a/src/plugins/movement/src/lib.rs
+++ b/src/plugins/movement/src/lib.rs
@@ -24,19 +24,14 @@ use common::{
 	tools::plugin_system_set::PluginSystemSet,
 	traits::{
 		after_plugin::AfterPlugin,
-		handles_animations::{AnimationsSystemParamMut, HandlesAnimations},
+		handles_animations::HandlesAnimations,
 		handles_input::HandlesInput,
 		handles_movement::HandlesMovement,
 		handles_orientation::HandlesOrientation,
 		handles_path_finding::HandlesPathFinding,
-		handles_physics::{
-			HandlesAllPhysicalEffects,
-			HandlesMotion,
-			HandlesRaycast,
-			RaycastSystemParam,
-		},
+		handles_physics::{HandlesAllPhysicalEffects, HandlesMotion, HandlesRaycast},
 		handles_saving::HandlesSaving,
-		handles_skill_physics::{HandlesSkillPhysics, SkillAgent},
+		handles_skill_physics::HandlesSkillPhysics,
 		system_set_definition::SystemSetDefinition,
 		thread_safe::ThreadSafe,
 	},
@@ -102,10 +97,9 @@ where
 				Movement::compute_path::<TPathing::TComputePath, TPathing::TComputerRef>,
 				Movement::apply::<TPhysics::TCharacterMotion>,
 				TPhysics::TCharacterMotion::update_speed,
-				TPhysics::TCharacterMotion::animate_forward::<AnimationsSystemParamMut<TAnimations>>,
+				TPhysics::TCharacterMotion::animate_forward::<TAnimations::TAnimationsMut>,
 				TPhysics::TCharacterMotion::set_facing,
-				SetFace::get_faces
-					.pipe(execute_face::<RaycastSystemParam<TPhysics>, SkillAgent<TPhysics>>),
+				SetFace::get_faces.pipe(execute_face::<TPhysics::TRaycast, TPhysics::TAgent>),
 				MovementParam::<TPhysics::TCharacterMotion>::update_just_removed,
 			)
 				.chain()
@@ -120,7 +114,7 @@ where
 }
 
 impl<TDependencies> HandlesOrientation for MovementPlugin<TDependencies> {
-	type TFaceSystemParam<'w, 's> = FaceParamMut<'w, 's>;
+	type TFaceSystemParam = FaceParamMut<'static, 'static>;
 }
 
 #[derive(SystemSet, Debug, PartialEq, Eq, Hash, Clone, Copy)]
@@ -145,7 +139,7 @@ where
 		+ HandlesRaycast,
 	TPathing: ThreadSafe + HandlesPathFinding,
 {
-	type TMovement<'w, 's> = MovementParam<'w, 's, TPhysics::TCharacterMotion>;
-	type TMovementMut<'w, 's> = MovementParamMut<'w, 's, TPhysics::TCharacterMotion>;
-	type TMovementConfig<'w, 's> = MovementConfigParamMut<'w, 's>;
+	type TMovement = MovementParam<'static, 'static, TPhysics::TCharacterMotion>;
+	type TMovementMut = MovementParamMut<'static, 'static, TPhysics::TCharacterMotion>;
+	type TMovementConfig = MovementConfigParamMut<'static, 'static>;
 }

--- a/src/plugins/movement/src/system_param/face_param.rs
+++ b/src/plugins/movement/src/system_param/face_param.rs
@@ -14,7 +14,7 @@ pub struct FaceParamMut<'w, 's> {
 	commands: ZyheedaCommands<'w, 's>,
 }
 
-impl GetContextMut<Facing> for FaceParamMut<'_, '_> {
+impl GetContextMut<Facing> for FaceParamMut<'static, 'static> {
 	type TContext<'ctx> = FaceContextMut<'ctx>;
 
 	fn get_context_mut<'ctx>(

--- a/src/plugins/movement/src/system_param/movement_config_param.rs
+++ b/src/plugins/movement/src/system_param/movement_config_param.rs
@@ -16,7 +16,7 @@ pub struct MovementConfigParamMut<'w, 's> {
 	configured: Query<'w, 's, (), With<Config>>,
 }
 
-impl GetContextMut<NotConfiguredMovement> for MovementConfigParamMut<'_, '_> {
+impl GetContextMut<NotConfiguredMovement> for MovementConfigParamMut<'static, 'static> {
 	type TContext<'ctx> = MovementConfigContextMut<'ctx>;
 
 	fn get_context_mut<'ctx>(

--- a/src/plugins/movement/src/system_param/movement_param.rs
+++ b/src/plugins/movement/src/system_param/movement_param.rs
@@ -27,7 +27,7 @@ where
 	just_removed_movements: Res<'w, JustRemovedMovements>,
 }
 
-impl<TMotion> GetContext<Movement> for MovementParam<'_, '_, TMotion>
+impl<TMotion> GetContext<Movement> for MovementParam<'static, 'static, TMotion>
 where
 	TMotion: Component,
 {
@@ -68,7 +68,7 @@ where
 	>,
 }
 
-impl<TMotion> GetContextMut<ConfiguredMovement> for MovementParamMut<'_, '_, TMotion>
+impl<TMotion> GetContextMut<ConfiguredMovement> for MovementParamMut<'static, 'static, TMotion>
 where
 	TMotion: Component,
 {

--- a/src/plugins/physics/src/lib.rs
+++ b/src/plugins/physics/src/lib.rs
@@ -59,7 +59,7 @@ use common::{
 	tools::plugin_system_set::PluginSystemSet,
 	traits::{
 		delta::Delta,
-		handles_animations::{AnimationsSystemParamMut, HandlesAnimations},
+		handles_animations::HandlesAnimations,
 		handles_physics::{
 			HandlesMotion,
 			HandlesPhysicalEffectTargets,
@@ -149,7 +149,7 @@ where
 			// Animations
 			.add_systems(
 				Update,
-				Target::update_pitch::<RayCaster, AnimationsSystemParamMut<TAnimations>>,
+				Target::update_pitch::<RayCaster, TAnimations::TAnimationsMut>,
 			)
 			// Skills
 			.register_required_components::<Skill, TSaveGame::TSaveEntityMarker>()
@@ -252,11 +252,11 @@ pub struct PhysicsSystems;
 
 impl<TDependencies> HandlesRaycast for PhysicsPlugin<TDependencies> {
 	type TWorldCamera = WorldCamera;
-	type TRaycast<'world, 'state> = RayCaster<'world, 'state>;
+	type TRaycast = RayCaster<'static, 'static>;
 }
 
 impl<TDependencies> HandlesPhysicsConfig for PhysicsPlugin<TDependencies> {
-	type TConfigMut<'w, 's> = ConfigParamMut<'w, 's>;
+	type TConfigMut = ConfigParamMut<'static, 'static>;
 }
 
 impl<TDependencies> SystemSetDefinition for PhysicsPlugin<TDependencies> {
@@ -279,12 +279,12 @@ impl<TDependencies> HandlesMotion for PhysicsPlugin<TDependencies> {
 }
 
 impl<TDependencies> HandlesPhysicalSkillAgent for PhysicsPlugin<TDependencies> {
-	type TAgent<'w, 's> = SkillAgent<'w, 's>;
-	type TAgentMut<'w, 's> = SkillAgentMut<'w, 's>;
+	type TAgent = SkillAgent<'static, 'static>;
+	type TAgentMut = SkillAgentMut<'static, 'static>;
 }
 
 impl<TDependencies> HandlesNewPhysicalSkill for PhysicsPlugin<TDependencies> {
-	type TSkillSpawnerMut<'w, 's> = SkillAgentMut<'w, 's>;
+	type TSkillSpawnerMut = SkillAgentMut<'static, 'static>;
 }
 
 impl<TDependencies> HandlesPhysicalSkillComponents for PhysicsPlugin<TDependencies> {

--- a/src/plugins/physics/src/system_params/config.rs
+++ b/src/plugins/physics/src/system_params/config.rs
@@ -18,7 +18,7 @@ pub struct ConfigParamMut<'w, 's> {
 	commands: ZyheedaCommands<'w, 's>,
 }
 
-impl GetContextMut<NoDefaultAttributes> for ConfigParamMut<'_, '_> {
+impl GetContextMut<NoDefaultAttributes> for ConfigParamMut<'static, 'static> {
 	type TContext<'ctx> = ConfigContextMut<'ctx>;
 
 	fn get_context_mut<'ctx>(
@@ -35,7 +35,7 @@ impl GetContextMut<NoDefaultAttributes> for ConfigParamMut<'_, '_> {
 	}
 }
 
-impl GetContextMut<NoBodyConfigured> for ConfigParamMut<'_, '_> {
+impl GetContextMut<NoBodyConfigured> for ConfigParamMut<'static, 'static> {
 	type TContext<'ctx> = ConfigContextMut<'ctx>;
 
 	fn get_context_mut<'ctx>(

--- a/src/plugins/physics/src/system_params/ray_caster/solid_objects.rs
+++ b/src/plugins/physics/src/system_params/ray_caster/solid_objects.rs
@@ -83,16 +83,15 @@ impl RayCaster<'_, '_> {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::{
-		PhysicsPlugin,
-		components::{collider::MOUSE_HOVERABLE_GROUP, interaction_target::InteractionTarget},
+	use crate::components::{
+		collider::MOUSE_HOVERABLE_GROUP,
+		interaction_target::InteractionTarget,
 	};
 	use bevy::{
 		ecs::system::{RunSystemError, RunSystemOnce},
 		mesh::MeshPlugin,
 		scene::ScenePlugin,
 	};
-	use common::traits::handles_physics::RaycastSystemParam;
 	use test_case::test_case;
 	use testing::SingleThreadedApp;
 
@@ -122,15 +121,15 @@ mod tests {
 			.id();
 		app.update();
 
-		let hit = app.world_mut().run_system_once(
-			|mut ray_caster: RaycastSystemParam<PhysicsPlugin<()>>| {
+		let hit = app
+			.world_mut()
+			.run_system_once(|mut ray_caster: RayCaster| {
 				ray_caster.raycast(SolidObjects {
 					ray: Ray3d::new(Vec3::Y, Dir3::NEG_Y),
 					exclude: vec![],
 					only_hoverable: false,
 				})
-			},
-		)?;
+			})?;
 
 		assert_eq!(
 			Some(RaycastHit {
@@ -155,15 +154,15 @@ mod tests {
 		app.world_mut().spawn(());
 		app.update();
 
-		let hit = app.world_mut().run_system_once(
-			|mut ray_caster: RaycastSystemParam<PhysicsPlugin<()>>| {
+		let hit = app
+			.world_mut()
+			.run_system_once(|mut ray_caster: RayCaster| {
 				ray_caster.raycast(SolidObjects {
 					ray: Ray3d::new(Vec3::Y, Dir3::NEG_Y),
 					exclude: vec![],
 					only_hoverable: false,
 				})
-			},
-		)?;
+			})?;
 
 		assert_eq!(
 			Some(RaycastHit {
@@ -188,15 +187,15 @@ mod tests {
 		app.world_mut().spawn(());
 		app.update();
 
-		let hit = app.world_mut().run_system_once(
-			|mut ray_caster: RaycastSystemParam<PhysicsPlugin<()>>| {
+		let hit = app
+			.world_mut()
+			.run_system_once(|mut ray_caster: RayCaster| {
 				ray_caster.raycast(SolidObjects {
 					ray: Ray3d::new(Vec3::Y, Dir3::NEG_Y),
 					exclude: vec![],
 					only_hoverable: false,
 				})
-			},
-		)?;
+			})?;
 
 		assert_eq!(
 			Some(RaycastHit {
@@ -224,15 +223,15 @@ mod tests {
 		app.world_mut().spawn(());
 		app.update();
 
-		let hit = app.world_mut().run_system_once(
-			|mut ray_caster: RaycastSystemParam<PhysicsPlugin<()>>| {
+		let hit = app
+			.world_mut()
+			.run_system_once(|mut ray_caster: RayCaster| {
 				ray_caster.raycast(SolidObjects {
 					ray: Ray3d::new(Vec3::Y, Dir3::NEG_Y),
 					exclude: vec![],
 					only_hoverable: false,
 				})
-			},
-		)?;
+			})?;
 
 		assert_eq!(
 			Some(RaycastHit {
@@ -255,15 +254,15 @@ mod tests {
 		));
 		app.update();
 
-		let hit = app.world_mut().run_system_once(
-			|mut ray_caster: RaycastSystemParam<PhysicsPlugin<()>>| {
+		let hit = app
+			.world_mut()
+			.run_system_once(|mut ray_caster: RayCaster| {
 				ray_caster.raycast(SolidObjects {
 					ray: Ray3d::new(Vec3::Y, Dir3::NEG_Y),
 					exclude: vec![],
 					only_hoverable: false,
 				})
-			},
-		)?;
+			})?;
 
 		assert_eq!(None, hit);
 		Ok(())
@@ -282,15 +281,15 @@ mod tests {
 			.id();
 		app.update();
 
-		let hit = app.world_mut().run_system_once(
-			move |mut ray_caster: RaycastSystemParam<PhysicsPlugin<()>>| {
+		let hit = app
+			.world_mut()
+			.run_system_once(move |mut ray_caster: RayCaster| {
 				ray_caster.raycast(SolidObjects {
 					ray: Ray3d::new(Vec3::Y, Dir3::NEG_Y),
 					exclude: vec![a, b],
 					only_hoverable: false,
 				})
-			},
-		)?;
+			})?;
 
 		assert_eq!(None, hit);
 		Ok(())
@@ -321,15 +320,15 @@ mod tests {
 			.id();
 		app.update();
 
-		let hit = app.world_mut().run_system_once(
-			move |mut ray_caster: RaycastSystemParam<PhysicsPlugin<()>>| {
+		let hit = app
+			.world_mut()
+			.run_system_once(move |mut ray_caster: RayCaster| {
 				ray_caster.raycast(SolidObjects {
 					ray: Ray3d::new(Vec3::Y, Dir3::NEG_Y),
 					exclude: vec![a, b],
 					only_hoverable: false,
 				})
-			},
-		)?;
+			})?;
 
 		assert_eq!(None, hit);
 		Ok(())
@@ -354,15 +353,15 @@ mod tests {
 			.id();
 		app.update();
 
-		let hit = app.world_mut().run_system_once(
-			move |mut ray_caster: RaycastSystemParam<PhysicsPlugin<()>>| {
+		let hit = app
+			.world_mut()
+			.run_system_once(move |mut ray_caster: RayCaster| {
 				ray_caster.raycast(SolidObjects {
 					ray: Ray3d::new(Vec3::Y, Dir3::NEG_Y),
 					exclude: vec![],
 					only_hoverable: true,
 				})
-			},
-		)?;
+			})?;
 
 		assert_eq!(
 			Some(RaycastHit {
@@ -393,15 +392,15 @@ mod tests {
 		));
 		app.update();
 
-		let hit = app.world_mut().run_system_once(
-			move |mut ray_caster: RaycastSystemParam<PhysicsPlugin<()>>| {
+		let hit = app
+			.world_mut()
+			.run_system_once(move |mut ray_caster: RayCaster| {
 				ray_caster.raycast(SolidObjects {
 					ray: Ray3d::new(Vec3::Y, Dir3::NEG_Y),
 					exclude: vec![],
 					only_hoverable: false,
 				})
-			},
-		)?;
+			})?;
 
 		assert_eq!(
 			Some(RaycastHit {
@@ -433,15 +432,15 @@ mod tests {
 			.id();
 		app.update();
 
-		let hit = app.world_mut().run_system_once(
-			move |mut ray_caster: RaycastSystemParam<PhysicsPlugin<()>>| {
+		let hit = app
+			.world_mut()
+			.run_system_once(move |mut ray_caster: RayCaster| {
 				ray_caster.raycast(SolidObjects {
 					ray: Ray3d::new(Vec3::Y, Dir3::NEG_Y),
 					exclude: vec![],
 					only_hoverable,
 				})
-			},
-		)?;
+			})?;
 
 		assert_eq!(
 			Some(RaycastHit {

--- a/src/plugins/physics/src/system_params/ray_caster/terrain.rs
+++ b/src/plugins/physics/src/system_params/ray_caster/terrain.rs
@@ -28,13 +28,12 @@ impl Raycast<Terrain> for RayCaster<'_, '_> {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::PhysicsPlugin;
 	use bevy::{
 		ecs::system::{RunSystemError, RunSystemOnce},
 		mesh::MeshPlugin,
 		scene::ScenePlugin,
 	};
-	use common::{tools::Units, traits::handles_physics::RaycastSystemParam};
+	use common::tools::Units;
 	use testing::SingleThreadedApp;
 
 	fn setup() -> App {
@@ -65,11 +64,11 @@ mod tests {
 		));
 		app.update();
 
-		let hit = app.world_mut().run_system_once(
-			move |mut ray_caster: RaycastSystemParam<PhysicsPlugin<()>>| {
+		let hit = app
+			.world_mut()
+			.run_system_once(move |mut ray_caster: RayCaster| {
 				ray_caster.raycast(Terrain { ray })
-			},
-		)?;
+			})?;
 
 		assert_eq!(Some(TimeOfImpact::from(Units::from(0.5))), hit);
 		Ok(())
@@ -91,11 +90,11 @@ mod tests {
 		));
 		app.update();
 
-		let hit = app.world_mut().run_system_once(
-			move |mut ray_caster: RaycastSystemParam<PhysicsPlugin<()>>| {
+		let hit = app
+			.world_mut()
+			.run_system_once(move |mut ray_caster: RayCaster| {
 				ray_caster.raycast(Terrain { ray })
-			},
-		)?;
+			})?;
 
 		assert_eq!(None, hit);
 		Ok(())
@@ -117,11 +116,11 @@ mod tests {
 		));
 		app.update();
 
-		let hit = app.world_mut().run_system_once(
-			move |mut ray_caster: RaycastSystemParam<PhysicsPlugin<()>>| {
+		let hit = app
+			.world_mut()
+			.run_system_once(move |mut ray_caster: RayCaster| {
 				ray_caster.raycast(Terrain { ray })
-			},
-		)?;
+			})?;
 
 		assert_eq!(None, hit);
 		Ok(())

--- a/src/plugins/physics/src/system_params/skill_agent.rs
+++ b/src/plugins/physics/src/system_params/skill_agent.rs
@@ -18,7 +18,7 @@ pub struct SkillAgent<'w, 's> {
 	targets: Query<'w, 's, Ref<'static, Target>>,
 }
 
-impl GetContext<InitializedAgent> for SkillAgent<'_, '_> {
+impl GetContext<InitializedAgent> for SkillAgent<'static, 'static> {
 	type TContext<'ctx> = SkillAgentContext<'ctx>;
 
 	fn get_context<'ctx>(
@@ -39,7 +39,7 @@ pub struct SkillAgentMut<'w, 's> {
 	commands: ZyheedaCommands<'w, 's>,
 }
 
-impl GetContextMut<NotInitializedAgent> for SkillAgentMut<'_, '_> {
+impl GetContextMut<NotInitializedAgent> for SkillAgentMut<'static, 'static> {
 	type TContext<'ctx> = SkillAgentInitializerContext<'ctx>;
 
 	fn get_context_mut<'ctx>(
@@ -56,7 +56,7 @@ impl GetContextMut<NotInitializedAgent> for SkillAgentMut<'_, '_> {
 	}
 }
 
-impl GetContextMut<InitializedAgent> for SkillAgentMut<'_, '_> {
+impl GetContextMut<InitializedAgent> for SkillAgentMut<'static, 'static> {
 	type TContext<'ctx> = SkillAgentContextMut<'ctx>;
 
 	fn get_context_mut<'ctx>(

--- a/src/plugins/savegame/src/lib.rs
+++ b/src/plugins/savegame/src/lib.rs
@@ -28,7 +28,7 @@ use common::{
 	tools::action_key::{ActionKey, save_key::SaveKey},
 	traits::{
 		after_plugin::AfterPlugin,
-		handles_input::{HandlesInput, InputSystemParam},
+		handles_input::HandlesInput,
 		handles_saving::{HandlesSaving, SavableComponent},
 		system_set_definition::SystemSetDefinition,
 		thread_safe::ThreadSafe,
@@ -84,11 +84,11 @@ where
 		let quick_save = Arc::new(Mutex::new(SaveContext::from(FileIO::with_file(
 			quick_save_file,
 		))));
-		let trigger_quick_save = InputSystemParam::<TInput>::trigger(
+		let trigger_quick_save = TInput::TInput::trigger(
 			ActionKey::Save(SaveKey::QuickSave),
 			GameState::Save(SaveState::Save),
 		);
-		let trigger_quick_load_attempt = InputSystemParam::<TInput>::trigger(
+		let trigger_quick_load_attempt = TInput::TInput::trigger(
 			ActionKey::Save(SaveKey::QuickLoad),
 			GameState::Save(SaveState::AttemptLoad),
 		);

--- a/src/plugins/skills/src/lib.rs
+++ b/src/plugins/skills/src/lib.rs
@@ -34,10 +34,10 @@ use common::{
 		handles_custom_assets::{HandlesCustomAssets, HandlesCustomFolderAssets},
 		handles_load_tracking::HandlesLoadTracking,
 		handles_loadout::HandlesLoadout,
-		handles_orientation::{FacingSystemParamMut, HandlesOrientation},
+		handles_orientation::HandlesOrientation,
 		handles_physics::{HandlesAllPhysicalEffects, HandlesRaycast},
 		handles_saving::HandlesSaving,
-		handles_skill_physics::{HandlesSkillPhysics, SkillSpawnerMut},
+		handles_skill_physics::HandlesSkillPhysics,
 		system_set_definition::SystemSetDefinition,
 		thread_safe::ThreadSafe,
 		visible_slots::{EssenceSlot, ForearmSlot, HandSlot},
@@ -122,8 +122,8 @@ where
 				Queue::enqueue_system::<Slots>,
 				Combos::update::<Queue>,
 				flush_skill_combos::<Combos, CombosTimeOut, Virtual, Queue>,
-				schedule_active_skill::<Queue, FacingSystemParamMut<TMovement>, ActiveSkill, Virtual>,
-				ActiveSkill::<SkillBehaviorConfig>::execute::<SkillSpawnerMut<TPhysics>>,
+				schedule_active_skill::<Queue, TMovement::TFaceSystemParam, ActiveSkill, Virtual>,
+				ActiveSkill::<SkillBehaviorConfig>::execute::<TPhysics::TSkillSpawnerMut>,
 				flush::<Queue>,
 			)
 				.chain()
@@ -152,9 +152,9 @@ where
 
 impl<TDependencies> HandlesLoadout for SkillsPlugin<TDependencies> {
 	type TSkillID = SkillId;
-	type TLoadoutPrep<'w, 's> = LoadoutPrep<'w, 's>;
-	type TLoadout<'w, 's> = LoadoutReader<'w, 's>;
-	type TLoadoutMut<'w, 's> = LoadoutWriter<'w, 's>;
-	type TLoadoutActivity<'w, 's> = LoadoutActivityReader<'w, 's>;
-	type TLoadoutActivityMut<'w, 's> = LoadoutActivityWriter<'w, 's>;
+	type TLoadoutPrep = LoadoutPrep<'static, 'static>;
+	type TLoadout = LoadoutReader<'static, 'static>;
+	type TLoadoutMut = LoadoutWriter<'static, 'static>;
+	type TLoadoutActivity = LoadoutActivityReader<'static, 'static>;
+	type TLoadoutActivityMut = LoadoutActivityWriter<'static, 'static>;
 }

--- a/src/plugins/skills/src/system_parameters/loadout/read/available_skills.rs
+++ b/src/plugins/skills/src/system_parameters/loadout/read/available_skills.rs
@@ -17,7 +17,7 @@ use common::{
 	},
 };
 
-impl GetContext<AvailableSkills> for LoadoutReader<'_, '_> {
+impl GetContext<AvailableSkills> for LoadoutReader<'static, 'static> {
 	type TContext<'ctx> = AvailableSkillsView<'ctx>;
 
 	fn get_context<'ctx>(

--- a/src/plugins/skills/src/system_parameters/loadout/read/combos.rs
+++ b/src/plugins/skills/src/system_parameters/loadout/read/combos.rs
@@ -14,7 +14,7 @@ use common::{
 };
 use std::{collections::HashSet, ops::Deref};
 
-impl GetContext<CombosMarker> for LoadoutReader<'_, '_> {
+impl GetContext<CombosMarker> for LoadoutReader<'static, 'static> {
 	type TContext<'ctx> = CombosView<'ctx>;
 
 	fn get_context<'ctx>(

--- a/src/plugins/skills/src/system_parameters/loadout/read/items.rs
+++ b/src/plugins/skills/src/system_parameters/loadout/read/items.rs
@@ -16,7 +16,7 @@ use common::{
 	},
 };
 
-impl GetContext<Items> for LoadoutReader<'_, '_> {
+impl GetContext<Items> for LoadoutReader<'static, 'static> {
 	type TContext<'ctx> = ItemsView<'ctx>;
 
 	fn get_context<'ctx>(

--- a/src/plugins/skills/src/system_parameters/loadout/read/skills.rs
+++ b/src/plugins/skills/src/system_parameters/loadout/read/skills.rs
@@ -19,7 +19,7 @@ use common::{
 	},
 };
 
-impl GetContext<Skills> for LoadoutReader<'_, '_> {
+impl GetContext<Skills> for LoadoutReader<'static, 'static> {
 	type TContext<'ctx> = SkillsView<'ctx>;
 
 	fn get_context<'ctx>(

--- a/src/plugins/skills/src/system_parameters/loadout/write/combos.rs
+++ b/src/plugins/skills/src/system_parameters/loadout/write/combos.rs
@@ -13,7 +13,7 @@ use common::{
 	},
 };
 
-impl GetContextMut<CombosMarker> for LoadoutWriter<'_, '_> {
+impl GetContextMut<CombosMarker> for LoadoutWriter<'static, 'static> {
 	type TContext<'ctx> = CombosMut<'ctx>;
 
 	fn get_context_mut<'ctx>(

--- a/src/plugins/skills/src/system_parameters/loadout/write/insert_default_loadout.rs
+++ b/src/plugins/skills/src/system_parameters/loadout/write/insert_default_loadout.rs
@@ -69,7 +69,7 @@ impl DefaultLoadout<'_> {
 	}
 }
 
-impl GetContextMut<NotLoadedOut> for LoadoutPrep<'_, '_> {
+impl GetContextMut<NotLoadedOut> for LoadoutPrep<'static, 'static> {
 	type TContext<'ctx> = DefaultLoadout<'ctx>;
 
 	fn get_context_mut<'ctx>(

--- a/src/plugins/skills/src/system_parameters/loadout/write/items.rs
+++ b/src/plugins/skills/src/system_parameters/loadout/write/items.rs
@@ -14,7 +14,7 @@ use common::{
 	},
 };
 
-impl GetContextMut<Items> for LoadoutWriter<'_, '_> {
+impl GetContextMut<Items> for LoadoutWriter<'static, 'static> {
 	type TContext<'ctx> = ItemsMut<'ctx>;
 
 	fn get_context_mut<'ctx>(

--- a/src/plugins/skills/src/system_parameters/loadout/write/register_loadout_bones.rs
+++ b/src/plugins/skills/src/system_parameters/loadout/write/register_loadout_bones.rs
@@ -12,7 +12,7 @@ use common::{
 };
 use std::collections::HashMap;
 
-impl GetContextMut<NoBonesRegistered> for LoadoutPrep<'_, '_> {
+impl GetContextMut<NoBonesRegistered> for LoadoutPrep<'static, 'static> {
 	type TContext<'ctx> = PrepareLoadoutBones<'ctx>;
 
 	fn get_context_mut<'ctx>(

--- a/src/plugins/skills/src/system_parameters/loadout_activity.rs
+++ b/src/plugins/skills/src/system_parameters/loadout_activity.rs
@@ -15,7 +15,7 @@ pub struct LoadoutActivityReader<'w, 's> {
 	loadout: Query<'w, 's, (Ref<'static, Queue>, Ref<'static, HeldSlots>)>,
 }
 
-impl GetContext<Skills> for LoadoutActivityReader<'_, '_> {
+impl GetContext<Skills> for LoadoutActivityReader<'static, 'static> {
 	type TContext<'ctx> = LoadoutActivityReadContext<'ctx>;
 
 	fn get_context<'ctx>(
@@ -44,7 +44,7 @@ pub struct LoadoutActivityWriter<'w, 's> {
 	held_slots: Query<'w, 's, &'static mut HeldSlots>,
 }
 
-impl GetContextMut<Skills> for LoadoutActivityWriter<'_, '_> {
+impl GetContextMut<Skills> for LoadoutActivityWriter<'static, 'static> {
 	type TContext<'ctx> = LoadoutActivityWriteContext<'ctx>;
 
 	fn get_context_mut<'ctx>(


### PR DESCRIPTION
Constrained system parameters for `GetContext(Mut)` and others to be thread safe.  This has the added advantage that we can get rid of the lifetimes of the generic system parameters. We now set all related assignments to use `'static` lifetime and don't need the helper typos to name a plugin's related system parameter.