### PR TITLE
Some agent/animation improvements

### DIFF
--- a/src/plugins/agents/src/assets/agent_meta.rs
+++ b/src/plugins/agents/src/assets/agent_meta.rs
@@ -8,9 +8,9 @@ use common::{
 		handles_animations::{
 			AffectedAnimationBones,
 			Animation,
-			AnimationClips,
 			AnimationKey,
 			AnimationMaskBits,
+			AnimationNames,
 		},
 		handles_custom_assets::AssetFolderPath,
 		handles_movement::{MovementSpeed, RequiredClearance},
@@ -33,7 +33,7 @@ pub struct AgentMeta {
 	pub(crate) height_levels: HeightLevels,
 	pub(crate) speed: MovementSpeed,
 	pub(crate) attributes: PhysicalDefaultAttributes,
-	pub(crate) animations: HashMap<AnimationKey, Animation<AnimationClips<String>>>,
+	pub(crate) animations: HashMap<AnimationKey, Animation<AnimationNames>>,
 	pub(crate) animation_mask_groups: HashMap<AnimationMaskBits, AffectedAnimationBones>,
 }
 

--- a/src/plugins/agents/src/assets/agent_meta.rs
+++ b/src/plugins/agents/src/assets/agent_meta.rs
@@ -20,6 +20,7 @@ use common::{
 	},
 	zyheeda_commands::ZyheedaEntityCommands,
 };
+use macros::asset_path;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -38,7 +39,7 @@ pub struct AgentMeta {
 
 impl AssetFolderPath for AgentMeta {
 	fn asset_folder_path() -> Path {
-		Path::from("agents")
+		Path::from(asset_path!("agents"))
 	}
 }
 

--- a/src/plugins/agents/src/assets/agent_meta/dto.rs
+++ b/src/plugins/agents/src/assets/agent_meta/dto.rs
@@ -9,9 +9,9 @@ use common::{
 		handles_animations::{
 			AffectedAnimationBones,
 			Animation,
-			AnimationClips,
 			AnimationKey,
 			AnimationMaskBits,
+			AnimationNames,
 		},
 		handles_custom_assets::{AssetFileExtensions, TryLoadFrom},
 		handles_movement::MovementSpeed,
@@ -39,7 +39,7 @@ pub(crate) enum ModelConfig {
 		required_clearance: RequiredClearance,
 		height_levels: HeightLevels,
 		#[serde(with = "as_vec")]
-		animations: HashMap<AnimationKey, Animation<AnimationClips<String>>>,
+		animations: HashMap<AnimationKey, Animation<AnimationNames>>,
 		animation_mask_groups: HashMap<AnimationMaskBits, AffectedAnimationBones>,
 	},
 	Procedural(ProceduralModel),

--- a/src/plugins/agents/src/systems/agent_config/apply_animations_system.rs
+++ b/src/plugins/agents/src/systems/agent_config/apply_animations_system.rs
@@ -10,8 +10,9 @@ use common::{
 		accessors::get::{GetContextMut, TryApplyOn},
 		handles_animations::{
 			Animation,
-			AnimationClips,
 			AnimationKey,
+			AnimationName,
+			AnimationNames,
 			RegisterAnimations,
 			WithoutAnimations,
 		},
@@ -89,15 +90,15 @@ impl ApplyAgentAnimations {
 	}
 }
 
-type AnimationKeyAndNames<'a> = (&'a AnimationKey, &'a Animation<AnimationClips<String>>);
+type AnimationKeyAndNames<'a> = (&'a AnimationKey, &'a Animation<AnimationNames>);
 type AnimationKeyAndClips = (AnimationKey, Animation);
 
 fn get_clips(
 	gltf: &Gltf,
-	missing: &mut HashSet<String>,
+	missing: &mut HashSet<AnimationName>,
 ) -> impl FnMut(AnimationKeyAndNames) -> Option<AnimationKeyAndClips> {
 	|(key, animation)| {
-		let get_clips = |name: String| match gltf.named_animations.get(name.as_str()) {
+		let get_clips = |name: AnimationName| match gltf.named_animations.get(&*name) {
 			Some(clip) => Some(clip.clone()),
 			None => {
 				missing.insert(name);
@@ -120,7 +121,7 @@ fn get_clips(
 pub(crate) enum RegisterAnimationsError {
 	MissingAnimations {
 		entity: Entity,
-		missing: HashSet<String>,
+		missing: HashSet<AnimationName>,
 		available: HashSet<Box<str>>,
 	},
 	GltfLookupMissing(Entity),
@@ -275,7 +276,7 @@ mod tests {
 			animations: HashMap::from([(
 				AnimationKey::Run,
 				Animation {
-					clips: AnimationClips::Single("Run".to_owned()),
+					clips: AnimationClips::Single(AnimationName::from("Run")),
 					..default()
 				},
 			)]),
@@ -331,7 +332,7 @@ mod tests {
 			animations: HashMap::from([(
 				AnimationKey::Run,
 				Animation {
-					clips: AnimationClips::Single("Run".to_owned()),
+					clips: AnimationClips::Single(AnimationName::from("Run")),
 					..default()
 				},
 			)]),
@@ -432,7 +433,7 @@ mod tests {
 			animations: HashMap::from([(
 				AnimationKey::Run,
 				Animation {
-					clips: AnimationClips::Single("Run".to_owned()),
+					clips: AnimationClips::Single(AnimationName::from("Run")),
 					..default()
 				},
 			)]),
@@ -525,21 +526,21 @@ mod tests {
 				(
 					AnimationKey::Walk,
 					Animation {
-						clips: AnimationClips::Single("Walk".to_owned()),
+						clips: AnimationClips::Single(AnimationName::from("Walk")),
 						..default()
 					},
 				),
 				(
 					AnimationKey::Run,
 					Animation {
-						clips: AnimationClips::Single("Run".to_owned()),
+						clips: AnimationClips::Single(AnimationName::from("Run")),
 						..default()
 					},
 				),
 				(
 					AnimationKey::Idle,
 					Animation {
-						clips: AnimationClips::Single("Idle".to_owned()),
+						clips: AnimationClips::Single(AnimationName::from("Idle")),
 						..default()
 					},
 				),
@@ -568,7 +569,7 @@ mod tests {
 		assert_eq!(
 			&_Result(Err(vec![RegisterAnimationsError::MissingAnimations {
 				entity,
-				missing: HashSet::from(["Walk".to_owned(), "Idle".to_owned()]),
+				missing: HashSet::from([AnimationName::from("Walk"), AnimationName::from("Idle")]),
 				available: HashSet::from([Box::from("Run")]),
 			}])),
 			app.world().resource::<_Result>()
@@ -581,7 +582,7 @@ mod tests {
 			animations: HashMap::from([(
 				AnimationKey::Run,
 				Animation {
-					clips: AnimationClips::Single("Run".to_owned()),
+					clips: AnimationClips::Single(AnimationName::from("Run")),
 					..default()
 				},
 			)]),
@@ -618,21 +619,21 @@ mod tests {
 				(
 					AnimationKey::Walk,
 					Animation {
-						clips: AnimationClips::Single("Walk".to_owned()),
+						clips: AnimationClips::Single(AnimationName::from("Walk")),
 						..default()
 					},
 				),
 				(
 					AnimationKey::Run,
 					Animation {
-						clips: AnimationClips::Single("Run".to_owned()),
+						clips: AnimationClips::Single(AnimationName::from("Run")),
 						..default()
 					},
 				),
 				(
 					AnimationKey::Idle,
 					Animation {
-						clips: AnimationClips::Single("Idle".to_owned()),
+						clips: AnimationClips::Single(AnimationName::from("Idle")),
 						..default()
 					},
 				),

--- a/src/plugins/common/src/traits/handles_animations.rs
+++ b/src/plugins/common/src/traits/handles_animations.rs
@@ -12,6 +12,7 @@ use bevy::{ecs::system::SystemParam, prelude::*};
 use macros::{EntityKey, InRange};
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Error};
 use std::{
+	borrow::{Borrow, Cow},
 	collections::{HashMap, HashSet},
 	hash::Hash,
 	ops::{Deref, DerefMut},
@@ -354,6 +355,44 @@ impl<'a, T> Iterator for Iter<'a, T> {
 		}
 	}
 }
+
+#[derive(Debug, PartialEq, Eq, Hash, Default, Clone, Serialize, Deserialize)]
+pub struct AnimationName(Cow<'static, str>);
+
+impl AnimationName {
+	pub const fn owned(name: String) -> Self {
+		Self(Cow::Owned(name))
+	}
+
+	pub const fn borrowed(name: &'static str) -> Self {
+		Self(Cow::Borrowed(name))
+	}
+}
+
+impl<T> From<T> for AnimationName
+where
+	T: Into<Cow<'static, str>>,
+{
+	fn from(name: T) -> Self {
+		Self(name.into())
+	}
+}
+
+impl Deref for AnimationName {
+	type Target = str;
+
+	fn deref(&self) -> &Self::Target {
+		self.0.deref()
+	}
+}
+
+impl Borrow<str> for AnimationName {
+	fn borrow(&self) -> &str {
+		self.0.borrow()
+	}
+}
+
+pub type AnimationNames = AnimationClips<AnimationName>;
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum AnimationPriority {


### PR DESCRIPTION
- Use a more descriptive `AnimationName` type for naming animation clips in assets
- `AgentMeta` asset path is validated with the `agent_asset` macro