### PR TITLE
Unify different animation play traits into a single update trait

### DIFF
--- a/src/plugins/animations/src/systems/play_animation_clip.rs
+++ b/src/plugins/animations/src/systems/play_animation_clip.rs
@@ -5,10 +5,8 @@ use crate::{
 	},
 	traits::{
 		IsPlaying,
-		PlayAnimation,
-		RepeatAnimation,
-		ReplayAnimation,
-		StopAnimation,
+		SetTo,
+		UpdateAnimation,
 		YoungestToOldestActiveAnimations,
 		animation_graph::GetNodeMut,
 	},
@@ -47,10 +45,7 @@ where
 	) where
 		TAnimationPlayer: QueryData
 			+ for<'w, 's> QueryData<Item<'w, 's>: IsPlaying<AnimationNodeIndex>>
-			+ for<'w, 's> QueryData<Item<'w, 's>: PlayAnimation<AnimationNodeIndex>>
-			+ for<'w, 's> QueryData<Item<'w, 's>: ReplayAnimation<AnimationNodeIndex>>
-			+ for<'w, 's> QueryData<Item<'w, 's>: RepeatAnimation<AnimationNodeIndex>>
-			+ for<'w, 's> QueryData<Item<'w, 's>: StopAnimation<AnimationNodeIndex>>,
+			+ for<'w, 's> QueryData<Item<'w, 's>: UpdateAnimation<AnimationNodeIndex>>,
 	{
 		play_animation_clip(players, dispatchers, graphs)
 	}
@@ -74,11 +69,8 @@ fn play_animation_clip<TAnimationPlayer, TDispatch, TGraph, TClips>(
 	TGraph: Asset + GetNodeMut + WrapHandle,
 	TDispatch: Component + YoungestToOldestActiveAnimations,
 	for<'a> TClips: ThreadSafe + Iterate<'a, TItem = &'a AnimationNodeIndex>,
-	for<'w, 's> TAnimationPlayer::Item<'w, 's>: IsPlaying<AnimationNodeIndex>
-		+ PlayAnimation<AnimationNodeIndex>
-		+ ReplayAnimation<AnimationNodeIndex>
-		+ RepeatAnimation<AnimationNodeIndex>
-		+ StopAnimation<AnimationNodeIndex>,
+	for<'w, 's> TAnimationPlayer::Item<'w, 's>:
+		IsPlaying<AnimationNodeIndex> + UpdateAnimation<AnimationNodeIndex>,
 {
 	for (dispatcher, animation_players, lookup, graph_component) in &agents {
 		for entity in animation_players.iter() {
@@ -88,7 +80,7 @@ fn play_animation_clip<TAnimationPlayer, TDispatch, TGraph, TClips>(
 			let Some(graph) = graphs.get_mut(graph_component.get_handle()) else {
 				continue;
 			};
-			let active_animations = play_active(graph, &mut player, lookup, dispatcher);
+			let active_animations = play(graph, &mut player, lookup, dispatcher);
 			let inactive_animations = lookup
 				.animations
 				.values()
@@ -105,17 +97,14 @@ fn play_animation_clip<TAnimationPlayer, TDispatch, TGraph, TClips>(
 	}
 }
 
-fn play_active<TPlayer, TDispatcher, TGraph, TAnimations>(
+fn play<TPlayer, TDispatcher, TGraph, TAnimations>(
 	graph: &mut TGraph,
 	player: &mut TPlayer,
 	lookup: &AnimationLookup<TAnimations>,
 	dispatcher: &TDispatcher,
 ) -> HashSet<AnimationNodeIndex>
 where
-	TPlayer: IsPlaying<AnimationNodeIndex>
-		+ PlayAnimation<AnimationNodeIndex>
-		+ ReplayAnimation<AnimationNodeIndex>
-		+ RepeatAnimation<AnimationNodeIndex>,
+	TPlayer: IsPlaying<AnimationNodeIndex> + UpdateAnimation<AnimationNodeIndex>,
 	TDispatcher: YoungestToOldestActiveAnimations,
 	TGraph: Asset + GetNodeMut,
 	for<'a> TAnimations: Iterate<'a, TItem = &'a AnimationNodeIndex>,
@@ -143,11 +132,13 @@ where
 					continue;
 				}
 
-				match animation_data.play_mode {
-					PlayMode::Once => player.play(*id),
-					PlayMode::Repeat => player.repeat(*id),
-					PlayMode::Replay => player.replay(*id),
-				}
+				let set_to = match animation_data.play_mode {
+					PlayMode::Once => SetTo::Play,
+					PlayMode::Repeat => SetTo::Repeat,
+					PlayMode::Replay => SetTo::Replay,
+				};
+
+				player.update_animation(*id, set_to)
 			}
 
 			blocked |= mask;
@@ -162,14 +153,14 @@ fn stop<'a, TPlayer, TGraph>(
 	graph: &mut TGraph,
 	animations: impl Iterator<Item = &'a AnimationNodeIndex>,
 ) where
-	TPlayer: StopAnimation<AnimationNodeIndex>,
+	TPlayer: UpdateAnimation<AnimationNodeIndex>,
 	TGraph: GetNodeMut,
 {
 	for animation_id in animations {
 		if let Some(node) = graph.get_node_mut(*animation_id) {
 			node.add_mask(AnimationMask::MAX);
 		}
-		player.stop_animation(*animation_id);
+		player.update_animation(*animation_id, SetTo::Stop);
 	}
 }
 
@@ -334,10 +325,8 @@ mod tests {
 	impl Default for _AnimationPlayer {
 		fn default() -> Self {
 			let mut mock = Mock_AnimationPlayer::default();
-			mock.expect_replay().return_const(());
-			mock.expect_repeat().return_const(());
-			mock.expect_stop_animation().return_const(());
 			mock.expect_is_playing().return_const(false);
+			mock.expect_update_animation().return_const(());
 			Self { mock }
 		}
 	}
@@ -348,46 +337,19 @@ mod tests {
 		}
 	}
 
-	impl PlayAnimation<AnimationNodeIndex> for Mut<'_, _AnimationPlayer> {
-		fn play(&mut self, index: AnimationNodeIndex) {
-			self.mock.play(index);
-		}
-	}
-
-	impl ReplayAnimation<AnimationNodeIndex> for Mut<'_, _AnimationPlayer> {
-		fn replay(&mut self, index: AnimationNodeIndex) {
-			self.mock.replay(index)
-		}
-	}
-
-	impl RepeatAnimation<AnimationNodeIndex> for Mut<'_, _AnimationPlayer> {
-		fn repeat(&mut self, index: AnimationNodeIndex) {
-			self.mock.repeat(index)
-		}
-	}
-
-	impl StopAnimation<AnimationNodeIndex> for Mut<'_, _AnimationPlayer> {
-		fn stop_animation(&mut self, index: AnimationNodeIndex) {
-			self.mock.stop_animation(index)
+	impl UpdateAnimation<AnimationNodeIndex> for Mut<'_, _AnimationPlayer> {
+		fn update_animation(&mut self, index: AnimationNodeIndex, seek: SetTo) {
+			self.mock.update_animation(index, seek);
 		}
 	}
 
 	mock! {
 		_AnimationPlayer {}
-		impl PlayAnimation<AnimationNodeIndex> for _AnimationPlayer {
-			fn play(&mut self, index: AnimationNodeIndex);
-		}
-		impl ReplayAnimation<AnimationNodeIndex> for _AnimationPlayer {
-			fn replay(&mut self, index: AnimationNodeIndex);
-		}
-		impl RepeatAnimation<AnimationNodeIndex> for _AnimationPlayer {
-			fn repeat(&mut self, index: AnimationNodeIndex);
-		}
-		impl StopAnimation<AnimationNodeIndex> for _AnimationPlayer{
-			fn stop_animation(&mut self, index: AnimationNodeIndex);
-		}
 		impl IsPlaying<AnimationNodeIndex> for _AnimationPlayer {
 			fn is_playing(&self, index: AnimationNodeIndex) -> bool;
+		}
+		impl UpdateAnimation<AnimationNodeIndex> for _AnimationPlayer {
+			fn update_animation(&mut self, index: AnimationNodeIndex, seek: SetTo);
 		}
 	}
 
@@ -482,16 +444,13 @@ mod tests {
 			indices: impl Clone + IntoIterator<Item = usize>,
 		) -> impl Fn(&mut Mock_AnimationPlayer) {
 			move |mock| {
-				mock.expect_is_playing().return_const(false);
-				mock.expect_replay().never().return_const(());
-				mock.expect_repeat().never().return_const(());
 				for index in indices.clone() {
-					mock.expect_play()
+					mock.expect_is_playing().return_const(false);
+					mock.expect_update_animation()
 						.times(1)
-						.with(eq(AnimationNodeIndex::new(index)))
+						.with(eq(AnimationNodeIndex::new(index)), eq(SetTo::Play))
 						.return_const(());
 				}
-				mock.expect_stop_animation().never().return_const(());
 			}
 		}
 	}
@@ -537,15 +496,12 @@ mod tests {
 		) -> impl Fn(&mut Mock_AnimationPlayer) {
 			move |mock| {
 				mock.expect_is_playing().return_const(false);
-				mock.expect_play().never().return_const(());
-				mock.expect_replay().never().return_const(());
 				for index in indices.clone() {
-					mock.expect_repeat()
+					mock.expect_update_animation()
 						.times(1)
-						.with(eq(AnimationNodeIndex::new(index)))
+						.with(eq(AnimationNodeIndex::new(index)), eq(SetTo::Repeat))
 						.return_const(());
 				}
-				mock.expect_stop_animation().never().return_const(());
 			}
 		}
 	}
@@ -591,15 +547,12 @@ mod tests {
 		) -> impl Fn(&mut Mock_AnimationPlayer) {
 			move |mock| {
 				mock.expect_is_playing().return_const(false);
-				mock.expect_play().never().return_const(());
-				mock.expect_repeat().never().return_const(());
 				for index in indices.clone() {
-					mock.expect_replay()
+					mock.expect_update_animation()
 						.times(1)
-						.with(eq(AnimationNodeIndex::new(index)))
+						.with(eq(AnimationNodeIndex::new(index)), eq(SetTo::Replay))
 						.return_const(());
 				}
-				mock.expect_stop_animation().never().return_const(());
 			}
 		}
 	}
@@ -725,32 +678,29 @@ mod tests {
 			))
 			.id();
 		app.world_mut().spawn((
-			_AnimationPlayer::new().with_mock(assert_repeat(0..=11)),
+			_AnimationPlayer::new().with_mock(assert_replay(0..=11)),
 			AnimationPlayerOf(agent),
 		));
 
 		app.update();
 
-		fn assert_repeat(
+		fn assert_replay(
 			indices: impl Clone + IntoIterator<Item = usize>,
 		) -> impl Fn(&mut Mock_AnimationPlayer) {
 			move |mock| {
 				mock.expect_is_playing().return_const(false);
-				mock.expect_play().never().return_const(());
-				mock.expect_repeat().never().return_const(());
 				for index in indices.clone().into_iter() {
-					mock.expect_replay()
+					mock.expect_update_animation()
 						.times(1)
-						.with(eq(AnimationNodeIndex::new(index)))
+						.with(eq(AnimationNodeIndex::new(index)), eq(SetTo::Replay))
 						.return_const(());
 				}
-				mock.expect_stop_animation().return_const(());
 			}
 		}
 	}
 
 	#[test]
-	fn do_not_play_animation_which_is_playing() {
+	fn do_not_update_animation_when_playing() {
 		let handle = new_handle();
 		let lookup = AnimationLookup {
 			animations: HashMap::from([(
@@ -795,10 +745,7 @@ mod tests {
 						.with(eq(AnimationNodeIndex::new(index)))
 						.return_const(true);
 				}
-				mock.expect_play().never().return_const(());
-				mock.expect_replay().never().return_const(());
-				mock.expect_repeat().never().return_const(());
-				mock.expect_stop_animation().never().return_const(());
+				mock.expect_update_animation().never().return_const(());
 			}
 		}
 	}
@@ -840,14 +787,10 @@ mod tests {
 			indices: impl Clone + IntoIterator<Item = usize>,
 		) -> impl Fn(&mut Mock_AnimationPlayer) {
 			move |mock| {
-				mock.expect_is_playing().return_const(false);
-				mock.expect_play().never().return_const(());
-				mock.expect_replay().return_const(());
-				mock.expect_repeat().return_const(());
 				for index in indices.clone() {
-					mock.expect_stop_animation()
+					mock.expect_update_animation()
 						.times(1)
-						.with(eq(AnimationNodeIndex::new(index)))
+						.with(eq(AnimationNodeIndex::new(index)), eq(SetTo::Stop))
 						.return_const(());
 				}
 			}
@@ -893,10 +836,10 @@ mod tests {
 
 		fn assert_repeat_once(mock: &mut Mock_AnimationPlayer) {
 			mock.expect_is_playing().return_const(false);
-			mock.expect_play().never().return_const(());
-			mock.expect_replay().never().return_const(());
-			mock.expect_repeat().times(1).return_const(());
-			mock.expect_stop_animation().never().return_const(());
+			mock.expect_update_animation()
+				.with(eq(AnimationNodeIndex::new(1)), eq(SetTo::Repeat))
+				.once()
+				.return_const(());
 		}
 	}
 
@@ -944,10 +887,10 @@ mod tests {
 
 		fn assert_repeat_twice(mock: &mut Mock_AnimationPlayer) {
 			mock.expect_is_playing().return_const(false);
-			mock.expect_play().never().return_const(());
-			mock.expect_replay().never().return_const(());
-			mock.expect_repeat().times(2).return_const(());
-			mock.expect_stop_animation().never().return_const(());
+			mock.expect_update_animation()
+				.with(eq(AnimationNodeIndex::new(1)), eq(SetTo::Repeat))
+				.times(2)
+				.return_const(());
 		}
 	}
 
@@ -1316,10 +1259,7 @@ mod tests {
 					.with(eq(AnimationNodeIndex::new(3)))
 					.return_const(true);
 				mock.expect_is_playing().return_const(false);
-				mock.expect_play().never().return_const(());
-				mock.expect_repeat().return_const(());
-				mock.expect_replay().return_const(());
-				mock.expect_stop_animation().return_const(());
+				mock.expect_update_animation().return_const(());
 			}),
 			AnimationPlayerOf(agent),
 		));

--- a/src/plugins/animations/src/traits.rs
+++ b/src/plugins/animations/src/traits.rs
@@ -13,7 +13,7 @@ pub(crate) trait InsertClips<TIndex>: Sized {
 	fn insert_clips(&mut self, data: &Self::TBuffer, animations: AnimationClips) -> TIndex;
 }
 
-pub trait YoungestToOldestActiveAnimations {
+pub(crate) trait YoungestToOldestActiveAnimations {
 	type TIter<'a>: Iterator<Item = &'a AnimationKey>
 	where
 		Self: 'a;
@@ -26,7 +26,7 @@ pub trait YoungestToOldestActiveAnimations {
 		TPriority: Into<AnimationPriority> + 'static;
 }
 
-pub trait GetAllActiveAnimations {
+pub(crate) trait GetAllActiveAnimations {
 	type TIter<'a>: Iterator<Item = &'a AnimationKey>
 	where
 		Self: 'a;
@@ -34,22 +34,18 @@ pub trait GetAllActiveAnimations {
 	fn get_all_active_animations(&self) -> Self::TIter<'_>;
 }
 
-pub trait IsPlaying<TIndex> {
+pub(crate) trait IsPlaying<TIndex> {
 	fn is_playing(&self, index: TIndex) -> bool;
 }
 
-pub trait PlayAnimation<TIndex> {
-	fn play(&mut self, index: TIndex);
+pub(crate) trait UpdateAnimation<TIndex> {
+	fn update_animation(&mut self, index: TIndex, set_to: SetTo);
 }
 
-pub trait ReplayAnimation<TIndex> {
-	fn replay(&mut self, index: TIndex);
-}
-
-pub trait RepeatAnimation<TIndex> {
-	fn repeat(&mut self, index: TIndex);
-}
-
-pub trait StopAnimation<TIndex> {
-	fn stop_animation(&mut self, index: TIndex);
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub(crate) enum SetTo {
+	Play,
+	Replay,
+	Repeat,
+	Stop,
 }

--- a/src/plugins/animations/src/traits/animation_player.rs
+++ b/src/plugins/animations/src/traits/animation_player.rs
@@ -1,5 +1,5 @@
-use super::{IsPlaying, RepeatAnimation, ReplayAnimation, StopAnimation};
-use crate::traits::PlayAnimation;
+use super::UpdateAnimation;
+use crate::traits::IsPlaying;
 use bevy::prelude::*;
 
 impl IsPlaying<AnimationNodeIndex> for Mut<'_, AnimationPlayer> {
@@ -8,26 +8,22 @@ impl IsPlaying<AnimationNodeIndex> for Mut<'_, AnimationPlayer> {
 	}
 }
 
-impl PlayAnimation<AnimationNodeIndex> for Mut<'_, AnimationPlayer> {
-	fn play(&mut self, index: AnimationNodeIndex) {
-		AnimationPlayer::play(self, index);
-	}
-}
+impl UpdateAnimation<AnimationNodeIndex> for Mut<'_, AnimationPlayer> {
+	fn update_animation(&mut self, index: AnimationNodeIndex, seek: super::SetTo) {
+		match seek {
+			super::SetTo::Play => {
+				self.play(index);
+			}
+			super::SetTo::Replay => {
+				self.play(index).replay();
+			}
+			super::SetTo::Repeat => {
+				self.play(index).repeat();
+			}
 
-impl ReplayAnimation<AnimationNodeIndex> for Mut<'_, AnimationPlayer> {
-	fn replay(&mut self, index: AnimationNodeIndex) {
-		AnimationPlayer::play(self, index).replay();
-	}
-}
-
-impl RepeatAnimation<AnimationNodeIndex> for Mut<'_, AnimationPlayer> {
-	fn repeat(&mut self, index: AnimationNodeIndex) {
-		AnimationPlayer::play(self, index).repeat();
-	}
-}
-
-impl StopAnimation<AnimationNodeIndex> for Mut<'_, AnimationPlayer> {
-	fn stop_animation(&mut self, index: AnimationNodeIndex) {
-		self.stop(index);
+			super::SetTo::Stop => {
+				self.stop(index);
+			}
+		}
 	}
 }

--- a/src/plugins/animations/src/traits/tuple_animation_player_transitions.rs
+++ b/src/plugins/animations/src/traits/tuple_animation_player_transitions.rs
@@ -1,6 +1,4 @@
-use crate::traits::PlayAnimation;
-
-use super::{IsPlaying, RepeatAnimation, ReplayAnimation};
+use crate::traits::{IsPlaying, UpdateAnimation};
 use bevy::prelude::*;
 use std::time::Duration;
 
@@ -9,31 +7,29 @@ type AnimationPlayerComponents<'a> = (Mut<'a, AnimationPlayer>, Mut<'a, Animatio
 impl IsPlaying<AnimationNodeIndex> for AnimationPlayerComponents<'_> {
 	fn is_playing(&self, index: AnimationNodeIndex) -> bool {
 		let (player, _) = self;
-		player.is_playing_animation(index)
+		player.is_playing(index)
 	}
 }
 
-impl PlayAnimation<AnimationNodeIndex> for AnimationPlayerComponents<'_> {
-	fn play(&mut self, index: AnimationNodeIndex) {
-		let (player, transitions) = self;
-		transitions.play(player, index, Duration::from_millis(100));
-	}
-}
+impl UpdateAnimation<AnimationNodeIndex> for AnimationPlayerComponents<'_> {
+	fn update_animation(&mut self, index: AnimationNodeIndex, seek: super::SetTo) {
+		const TRANSITION: Duration = Duration::from_millis(100);
 
-impl ReplayAnimation<AnimationNodeIndex> for AnimationPlayerComponents<'_> {
-	fn replay(&mut self, index: AnimationNodeIndex) {
 		let (player, transitions) = self;
-		transitions
-			.play(player, index, Duration::from_millis(100))
-			.replay();
-	}
-}
 
-impl RepeatAnimation<AnimationNodeIndex> for AnimationPlayerComponents<'_> {
-	fn repeat(&mut self, index: AnimationNodeIndex) {
-		let (player, transitions) = self;
-		transitions
-			.play(player, index, Duration::from_millis(100))
-			.repeat();
+		match seek {
+			super::SetTo::Play => {
+				transitions.play(player, index, TRANSITION);
+			}
+			super::SetTo::Replay => {
+				transitions.play(player, index, TRANSITION).replay();
+			}
+			super::SetTo::Repeat => {
+				transitions.play(player, index, TRANSITION).repeat();
+			}
+			super::SetTo::Stop => {
+				player.update_animation(index, super::SetTo::Stop);
+			}
+		}
 	}
 }


### PR DESCRIPTION
Internal animation play traits have been unified into a single update trait using an enum to set the target activity.