### PR TITLE
Allow sensors as/in physical bodies

### DIFF
--- a/src/plugins/agents/src/systems/agent_config/apply_config_system.rs
+++ b/src/plugins/agents/src/systems/agent_config/apply_config_system.rs
@@ -26,7 +26,7 @@ use common::{
 			NoBodyConfigured,
 			NoDefaultAttributes,
 			TranslationOffsets,
-			physical_bodies::{Blocker, Body, PhysicsType, Shape},
+			physical_bodies::{Blocker, Body, PhysicsType, Shape, ShapeParameters},
 		},
 		handles_skill_physics::{Initialize, NotInitializedAgent},
 		loadout::ItemName,
@@ -108,7 +108,7 @@ impl ApplyAgentConfig {
 				let aim = config.height_levels.aim - *config.required_clearance.vertical;
 				ctx.configure_body(
 					Body {
-						shape: Shape::Capsule { half_y, radius },
+						shape: Shape::Parameters(ShapeParameters::Capsule { half_y, radius }),
 						physics_type: PhysicsType::Agent(HashSet::from([Blocker::Character])),
 					},
 					TranslationOffsets { center, aim },
@@ -692,6 +692,8 @@ mod tests {
 	}
 
 	mod physics {
+		use common::traits::handles_physics::physical_bodies::ShapeParameters;
+
 		use super::*;
 		use crate::assets::agent_meta::HeightLevels;
 
@@ -749,10 +751,10 @@ mod tests {
 				AgentConfig { config_handle },
 				_Physics::new().with_mock(|mock| {
 					let expected_body = Body {
-						shape: Shape::Capsule {
+						shape: Shape::Parameters(ShapeParameters::Capsule {
 							half_y: Units::from(1.5),
 							radius: Units::from(0.5),
-						},
+						}),
 						physics_type: PhysicsType::Agent(HashSet::from([Blocker::Character])),
 					};
 

--- a/src/plugins/agents/src/systems/agent_config/apply_config_system.rs
+++ b/src/plugins/agents/src/systems/agent_config/apply_config_system.rs
@@ -110,6 +110,7 @@ impl ApplyAgentConfig {
 					Body {
 						shape: Shape::Parameters(ShapeParameters::Capsule { half_y, radius }),
 						physics_type: PhysicsType::Agent(HashSet::from([Blocker::Character])),
+						sub_frames: vec![],
 					},
 					TranslationOffsets { center, aim },
 				);
@@ -756,6 +757,7 @@ mod tests {
 							radius: Units::from(0.5),
 						}),
 						physics_type: PhysicsType::Agent(HashSet::from([Blocker::Character])),
+						sub_frames: vec![],
 					};
 
 					mock.expect_configure_default_attributes().return_const(());

--- a/src/plugins/agents/src/systems/agent_config/apply_config_system.rs
+++ b/src/plugins/agents/src/systems/agent_config/apply_config_system.rs
@@ -109,8 +109,7 @@ impl ApplyAgentConfig {
 				ctx.configure_body(
 					Body {
 						shape: Shape::Capsule { half_y, radius },
-						physics_type: PhysicsType::Agent,
-						blocker_types: HashSet::from([Blocker::Character]),
+						physics_type: PhysicsType::Agent(HashSet::from([Blocker::Character])),
 					},
 					TranslationOffsets { center, aim },
 				);
@@ -754,8 +753,7 @@ mod tests {
 							half_y: Units::from(1.5),
 							radius: Units::from(0.5),
 						},
-						physics_type: PhysicsType::Agent,
-						blocker_types: HashSet::from([Blocker::Character]),
+						physics_type: PhysicsType::Agent(HashSet::from([Blocker::Character])),
 					};
 
 					mock.expect_configure_default_attributes().return_const(());

--- a/src/plugins/common/src/traits/handles_physics/physical_bodies.rs
+++ b/src/plugins/common/src/traits/handles_physics/physical_bodies.rs
@@ -32,6 +32,15 @@ impl From<Shape> for Body {
 }
 
 /// Shape definition. Used to describe physics colliders.
+#[derive(Debug, PartialEq, Clone, Copy, Serialize, Deserialize)]
+pub enum Shape {
+	/// Use the given parameters for a static collider
+	Parameters(ShapeParameters),
+	/// Use the [`Entity`]'s [`Mesh3d`] for a static collider
+	StaticGltfMesh3d,
+}
+
+/// Shape parameters for a static collider.
 ///
 /// Coordinates are in line with the bevy coordinate system.
 /// So without rotations they are:
@@ -43,7 +52,7 @@ impl From<Shape> for Body {
 /// be interpreted additively in order to prevent illogical value combinations.
 /// For instance a capsule collider's full height is composed of `2 * half_y + 2 * radius`.
 #[derive(Debug, PartialEq, Clone, Copy, Serialize, Deserialize)]
-pub enum Shape {
+pub enum ShapeParameters {
 	Sphere {
 		radius: Units,
 	},
@@ -60,8 +69,6 @@ pub enum Shape {
 		half_y: Units,
 		radius: Units,
 	},
-	/// Use the [`Entity`]'s [`Mesh3d`] for a static collider
-	StaticGltfMesh3d,
 }
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]

--- a/src/plugins/common/src/traits/handles_physics/physical_bodies.rs
+++ b/src/plugins/common/src/traits/handles_physics/physical_bodies.rs
@@ -9,6 +9,7 @@ use std::collections::HashSet;
 pub struct Body {
 	pub shape: Shape,
 	pub physics_type: PhysicsType,
+	pub sub_frames: Vec<InteractiveFrame>,
 }
 
 impl Body {
@@ -16,11 +17,17 @@ impl Body {
 		Self {
 			shape,
 			physics_type: PhysicsType::Terrain(HashSet::from([Blocker::Physical])),
+			sub_frames: vec![],
 		}
 	}
 
 	pub fn with_physics_type(mut self, physics_type: PhysicsType) -> Self {
 		self.physics_type = physics_type;
+		self
+	}
+
+	pub fn with_sub_frames(mut self, body_parts: impl Into<Vec<InteractiveFrame>>) -> Self {
+		self.sub_frames = body_parts.into();
 		self
 	}
 }
@@ -31,6 +38,9 @@ impl From<Shape> for Body {
 	}
 }
 
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+pub struct InteractiveFrame(pub ShapeParameters);
+
 /// Shape definition. Used to describe physics colliders.
 #[derive(Debug, PartialEq, Clone, Copy, Serialize, Deserialize)]
 pub enum Shape {
@@ -38,6 +48,12 @@ pub enum Shape {
 	Parameters(ShapeParameters),
 	/// Use the [`Entity`]'s [`Mesh3d`] for a static collider
 	StaticGltfMesh3d,
+}
+
+impl From<ShapeParameters> for Shape {
+	fn from(shape: ShapeParameters) -> Self {
+		Self::Parameters(shape)
+	}
 }
 
 /// Shape parameters for a static collider.

--- a/src/plugins/common/src/traits/handles_physics/physical_bodies.rs
+++ b/src/plugins/common/src/traits/handles_physics/physical_bodies.rs
@@ -9,28 +9,18 @@ use std::collections::HashSet;
 pub struct Body {
 	pub shape: Shape,
 	pub physics_type: PhysicsType,
-	pub blocker_types: HashSet<Blocker>,
 }
 
 impl Body {
 	pub fn from_shape(shape: Shape) -> Self {
 		Self {
 			shape,
-			physics_type: PhysicsType::Terrain,
-			blocker_types: HashSet::from([Blocker::Physical]),
+			physics_type: PhysicsType::Terrain(HashSet::from([Blocker::Physical])),
 		}
 	}
 
 	pub fn with_physics_type(mut self, physics_type: PhysicsType) -> Self {
 		self.physics_type = physics_type;
-		self
-	}
-
-	pub fn with_blocker_types<TBlocks>(mut self, blocks: TBlocks) -> Self
-	where
-		TBlocks: IntoIterator<Item = Blocker>,
-	{
-		self.blocker_types = HashSet::from_iter(blocks);
 		self
 	}
 }
@@ -74,10 +64,10 @@ pub enum Shape {
 	StaticGltfMesh3d,
 }
 
-#[derive(Debug, PartialEq, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub enum PhysicsType {
-	Agent,
-	Terrain,
+	Agent(HashSet<Blocker>),
+	Terrain(HashSet<Blocker>),
 	InteractiveFrame,
 }
 

--- a/src/plugins/common/src/traits/handles_physics/physical_bodies.rs
+++ b/src/plugins/common/src/traits/handles_physics/physical_bodies.rs
@@ -78,6 +78,7 @@ pub enum Shape {
 pub enum PhysicsType {
 	Agent,
 	Terrain,
+	InteractiveFrame,
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, Serialize, Deserialize)]

--- a/src/plugins/map_generation/src/components/mesh_collider.rs
+++ b/src/plugins/map_generation/src/components/mesh_collider.rs
@@ -12,7 +12,7 @@ use common::{
 		prefab::{Prefab, PrefabEntityCommands},
 	},
 };
-use std::fmt::Display;
+use std::{collections::HashSet, fmt::Display};
 
 #[derive(Component, Debug, PartialEq, Default)]
 #[component(immutable)]
@@ -39,8 +39,7 @@ where
 
 		ctx.configure_body(
 			Body::from_shape(Shape::StaticGltfMesh3d)
-				.with_physics_type(PhysicsType::Terrain)
-				.with_blocker_types(Blocker::Physical),
+				.with_physics_type(PhysicsType::Terrain(HashSet::from([Blocker::Physical]))),
 			TranslationOffsets::ZERO,
 		);
 

--- a/src/plugins/physics/src/components/blocker_types.rs
+++ b/src/plugins/physics/src/components/blocker_types.rs
@@ -2,7 +2,7 @@ use bevy::prelude::*;
 use common::traits::handles_physics::physical_bodies::Blocker;
 use std::collections::HashSet;
 
-#[derive(Component, Debug, PartialEq, Default)]
+#[derive(Component, Debug, PartialEq, Default, Clone)]
 pub(crate) struct BlockerTypes(pub(crate) HashSet<Blocker>);
 
 impl<TBlocks> From<TBlocks> for BlockerTypes

--- a/src/plugins/physics/src/components/collider.rs
+++ b/src/plugins/physics/src/components/collider.rs
@@ -18,6 +18,7 @@ pub(crate) const GENERIC_COLLISION_GROUP: Group = Group::GROUP_1;
 pub(crate) const TERRAIN_GROUP: Group = Group::GROUP_2;
 pub(crate) const RAY_GROUP: Group = Group::GROUP_3;
 pub(crate) const MOUSE_HOVERABLE_GROUP: Group = Group::GROUP_4;
+pub(crate) const INTERACTIVE_GROUP: Group = Group::GROUP_5;
 
 #[derive(Component, Debug, PartialEq, Clone, Copy)]
 #[component(immutable)]

--- a/src/plugins/physics/src/components/collider.rs
+++ b/src/plugins/physics/src/components/collider.rs
@@ -8,7 +8,7 @@ use common::{
 	errors::Unreachable,
 	tools::Units,
 	traits::{
-		handles_physics::physical_bodies::Shape,
+		handles_physics::physical_bodies::{Shape, ShapeParameters},
 		prefab::{Prefab, PrefabEntityCommands, Reapply},
 	},
 };
@@ -52,24 +52,27 @@ pub(crate) enum ColliderShape {
 }
 
 impl From<Shape> for ColliderShape {
-	fn from(value: Shape) -> Self {
-		match value {
-			Shape::Sphere { radius } => Self::Sphere {
+	fn from(shape: Shape) -> Self {
+		use Shape::{Parameters, StaticGltfMesh3d};
+		use ShapeParameters::{Capsule, Cuboid, Cylinder, Sphere};
+
+		match shape {
+			Parameters(Sphere { radius }) => ColliderShape::Sphere {
 				radius,
 				hollow: false,
 			},
-			Shape::Cuboid {
+			Parameters(Cuboid {
 				half_x,
 				half_y,
 				half_z,
-			} => Self::Cuboid {
+			}) => ColliderShape::Cuboid {
 				half_x,
 				half_y,
 				half_z,
 			},
-			Shape::Capsule { half_y, radius } => Self::Capsule { half_y, radius },
-			Shape::Cylinder { half_y, radius } => Self::Cylinder { half_y, radius },
-			Shape::StaticGltfMesh3d => Self::EntityMesh {
+			Parameters(Capsule { half_y, radius }) => ColliderShape::Capsule { half_y, radius },
+			Parameters(Cylinder { half_y, radius }) => ColliderShape::Cylinder { half_y, radius },
+			StaticGltfMesh3d => Self::EntityMesh {
 				collider_type: ColliderType::Concave,
 			},
 		}

--- a/src/plugins/physics/src/components/collider.rs
+++ b/src/plugins/physics/src/components/collider.rs
@@ -51,12 +51,15 @@ pub(crate) enum ColliderShape {
 	},
 }
 
-impl From<Shape> for ColliderShape {
-	fn from(shape: Shape) -> Self {
+impl<T> From<T> for ColliderShape
+where
+	T: Into<Shape>,
+{
+	fn from(shape: T) -> Self {
 		use Shape::{Parameters, StaticGltfMesh3d};
 		use ShapeParameters::{Capsule, Cuboid, Cylinder, Sphere};
 
-		match shape {
+		match shape.into() {
 			Parameters(Sphere { radius }) => ColliderShape::Sphere {
 				radius,
 				hollow: false,

--- a/src/plugins/physics/src/components/physical_body.rs
+++ b/src/plugins/physics/src/components/physical_body.rs
@@ -15,7 +15,7 @@ use bevy_rapier3d::prelude::*;
 use common::{
 	errors::Unreachable,
 	traits::{
-		handles_physics::physical_bodies::{Body, PhysicsType},
+		handles_physics::physical_bodies::{Body, InteractiveFrame, PhysicsType},
 		prefab::{Prefab, PrefabEntityCommands},
 	},
 };
@@ -46,9 +46,13 @@ impl Prefab<()> for PhysicalBody {
 		entity: &mut impl PrefabEntityCommands,
 		_: StaticSystemParam<()>,
 	) -> Result<(), Self::TError> {
-		let Self(Body { physics_type, .. }) = self;
+		let Self(Body {
+			physics_type,
+			shape,
+			sub_frames,
+		}) = self;
 
-		let specific_memberships = match physics_type {
+		let specific_memberships_group = match physics_type {
 			PhysicsType::Agent(blockers) => {
 				entity.try_insert((
 					RigidBody::KinematicPositionBased,
@@ -64,21 +68,43 @@ impl Prefab<()> for PhysicalBody {
 				TERRAIN_GROUP
 			}
 			PhysicsType::InteractiveFrame => {
-				entity.try_insert((RigidBody::Fixed, Sensor));
+				entity.try_insert((
+					RigidBody::Fixed,
+					Sensor,
+					ActiveEvents::COLLISION_EVENTS,
+					ActiveCollisionTypes::all(),
+				));
 				INTERACTIVE_GROUP
 			}
 		};
 
 		entity.try_insert((
 			CollisionGroups {
-				memberships: GENERIC_COLLISION_GROUP | specific_memberships,
-				filters: GENERIC_COLLISION_GROUP | RAY_GROUP,
+				memberships: generic_and(specific_memberships_group),
+				filters: generic_and(RAY_GROUP),
 			},
-			ColliderShape::from(self.0.shape),
+			ColliderShape::from(*shape),
 		));
+
+		for InteractiveFrame(shape) in sub_frames {
+			entity.with_child((
+				ColliderShape::from(*shape),
+				Sensor,
+				ActiveEvents::COLLISION_EVENTS,
+				ActiveCollisionTypes::all(),
+				CollisionGroups {
+					memberships: generic_and(INTERACTIVE_GROUP),
+					filters: generic_and(RAY_GROUP),
+				},
+			));
+		}
 
 		Ok(())
 	}
+}
+
+fn generic_and(group: Group) -> Group {
+	GENERIC_COLLISION_GROUP | group
 }
 
 #[cfg(test)]
@@ -93,7 +119,6 @@ mod tests {
 		},
 	};
 	use std::collections::HashSet;
-	use test_case::test_case;
 	use testing::SingleThreadedApp;
 
 	fn setup() -> App {
@@ -104,128 +129,226 @@ mod tests {
 		app
 	}
 
-	#[test]
-	fn insert_collider() {
-		let mut app = setup();
-		let shape = Shape::Parameters(ShapeParameters::Sphere {
-			radius: Units::from(42.),
-		});
-		let entity = app
-			.world_mut()
-			.spawn(PhysicalBody(Body::from_shape(shape)))
-			.id();
+	mod body {
+		use super::*;
+		use test_case::test_case;
 
-		assert_eq!(
-			Some(&ColliderShape::from(shape)),
-			app.world().entity(entity).get::<ColliderShape>(),
-		);
-	}
+		#[test]
+		fn insert_collider() {
+			let mut app = setup();
+			let shape = Shape::Parameters(ShapeParameters::Sphere {
+				radius: Units::from(42.),
+			});
+			let entity = app
+				.world_mut()
+				.spawn(PhysicalBody(Body::from_shape(shape)))
+				.id();
 
-	#[test_case(PhysicsType::Terrain, RigidBody::Fixed, false, None, None; "terrain")]
-	#[test_case(PhysicsType::Agent, RigidBody::KinematicPositionBased, true, Some(&ActiveEvents::COLLISION_EVENTS), Some(&ActiveCollisionTypes::all()); "agent")]
-	#[test_case(|_| PhysicsType::InteractiveFrame, RigidBody::Fixed, false, None, None; "interactive frame")]
-	fn insert_physics_constraints(
-		physics_type: fn(HashSet<Blocker>) -> PhysicsType,
-		rigid_body: RigidBody,
-		has_character_controller: bool,
-		active_events: Option<&ActiveEvents>,
-		collision_types: Option<&ActiveCollisionTypes>,
-	) {
-		let mut app = setup();
-		let shape = Shape::Parameters(ShapeParameters::Sphere {
-			radius: Units::from(42.),
-		});
-		let entity = app
-			.world_mut()
-			.spawn(PhysicalBody(
+			assert_eq!(
+				Some(&ColliderShape::from(shape)),
+				app.world().entity(entity).get::<ColliderShape>(),
+			);
+		}
+
+		#[test_case(PhysicsType::Terrain, RigidBody::Fixed, false, None, None; "terrain")]
+		#[test_case(PhysicsType::Agent, RigidBody::KinematicPositionBased, true, Some(&ActiveEvents::COLLISION_EVENTS), Some(&ActiveCollisionTypes::all()); "agent")]
+		#[test_case(|_| PhysicsType::InteractiveFrame, RigidBody::Fixed, false, Some(&ActiveEvents::COLLISION_EVENTS), Some(&ActiveCollisionTypes::all()); "interactive frame")]
+		fn insert_physics_constraints(
+			physics_type: fn(HashSet<Blocker>) -> PhysicsType,
+			rigid_body: RigidBody,
+			has_character_controller: bool,
+			active_events: Option<&ActiveEvents>,
+			collision_types: Option<&ActiveCollisionTypes>,
+		) {
+			let mut app = setup();
+			let shape = Shape::Parameters(ShapeParameters::Sphere {
+				radius: Units::from(42.),
+			});
+			let entity = app.world_mut().spawn(PhysicalBody(
 				Body::from_shape(shape).with_physics_type(physics_type(HashSet::default())),
-			))
-			.id();
+			));
 
-		assert_eq!(
-			(
-				Some(&rigid_body),
-				has_character_controller,
-				active_events,
-				collision_types
-			),
-			(
-				app.world().entity(entity).get::<RigidBody>(),
-				app.world()
-					.entity(entity)
-					.contains::<KinematicCharacterController>(),
-				app.world().entity(entity).get::<ActiveEvents>(),
-				app.world().entity(entity).get::<ActiveCollisionTypes>(),
-			)
-		);
-	}
+			assert_eq!(
+				(
+					Some(&rigid_body),
+					has_character_controller,
+					active_events,
+					collision_types
+				),
+				(
+					entity.get::<RigidBody>(),
+					entity.contains::<KinematicCharacterController>(),
+					entity.get::<ActiveEvents>(),
+					entity.get::<ActiveCollisionTypes>(),
+				)
+			);
+		}
 
-	#[test_case(PhysicsType::Terrain, Some; "terrain")]
-	#[test_case(PhysicsType::Agent, Some; "agent")]
-	#[test_case(|_| PhysicsType::InteractiveFrame, |_| None; "interactive frame")]
-	fn insert_blocker_types(
-		physics_type: fn(HashSet<Blocker>) -> PhysicsType,
-		blocks: fn(HashSet<Blocker>) -> Option<HashSet<Blocker>>,
-	) {
-		let mut app = setup();
-		let shape = Shape::Parameters(ShapeParameters::Sphere {
-			radius: Units::from(42.),
-		});
-		let entity = app
-			.world_mut()
-			.spawn(PhysicalBody(Body::from_shape(shape).with_physics_type(
-				physics_type(HashSet::from([Blocker::Force, Blocker::Physical])),
-			)))
-			.id();
+		#[test_case(PhysicsType::Terrain, Some; "terrain")]
+		#[test_case(PhysicsType::Agent, Some; "agent")]
+		#[test_case(|_| PhysicsType::InteractiveFrame, |_| None; "interactive frame")]
+		fn insert_blocker_types(
+			physics_type: fn(HashSet<Blocker>) -> PhysicsType,
+			blocks: fn(HashSet<Blocker>) -> Option<HashSet<Blocker>>,
+		) {
+			let mut app = setup();
+			let shape = Shape::Parameters(ShapeParameters::Sphere {
+				radius: Units::from(42.),
+			});
+			let entity =
+				app.world_mut()
+					.spawn(PhysicalBody(Body::from_shape(shape).with_physics_type(
+						physics_type(HashSet::from([Blocker::Force, Blocker::Physical])),
+					)));
 
-		assert_eq!(
-			blocks(HashSet::from([Blocker::Force, Blocker::Physical])).map(BlockerTypes::from),
-			app.world().entity(entity).get::<BlockerTypes>().cloned(),
-		);
-	}
+			assert_eq!(
+				blocks(HashSet::from([Blocker::Force, Blocker::Physical])).map(BlockerTypes::from),
+				entity.get::<BlockerTypes>().cloned(),
+			);
+		}
 
-	#[test_case(PhysicsType::Terrain, GENERIC_COLLISION_GROUP | TERRAIN_GROUP; "terrain")]
-	#[test_case(PhysicsType::Agent, GENERIC_COLLISION_GROUP | MOUSE_HOVERABLE_GROUP; "agent")]
-	#[test_case(|_| PhysicsType::InteractiveFrame, GENERIC_COLLISION_GROUP | INTERACTIVE_GROUP; "interactive frame")]
-	fn insert_collision_groups(
-		physics_type: fn(HashSet<Blocker>) -> PhysicsType,
-		memberships: Group,
-	) {
-		let mut app = setup();
-		let shape = Shape::Parameters(ShapeParameters::Sphere {
-			radius: Units::from(42.),
-		});
-		let entity = app
-			.world_mut()
-			.spawn(PhysicalBody(
+		#[test_case(PhysicsType::Terrain, GENERIC_COLLISION_GROUP | TERRAIN_GROUP; "terrain")]
+		#[test_case(PhysicsType::Agent, GENERIC_COLLISION_GROUP | MOUSE_HOVERABLE_GROUP; "agent")]
+		#[test_case(|_| PhysicsType::InteractiveFrame, GENERIC_COLLISION_GROUP | INTERACTIVE_GROUP; "interactive frame")]
+		fn insert_collision_groups(
+			physics_type: fn(HashSet<Blocker>) -> PhysicsType,
+			memberships: Group,
+		) {
+			let mut app = setup();
+			let shape = Shape::Parameters(ShapeParameters::Sphere {
+				radius: Units::from(42.),
+			});
+			let entity = app.world_mut().spawn(PhysicalBody(
 				Body::from_shape(shape).with_physics_type(physics_type(HashSet::default())),
-			))
-			.id();
+			));
 
-		assert_eq!(
-			Some(&CollisionGroups {
-				memberships,
-				filters: GENERIC_COLLISION_GROUP | RAY_GROUP
-			}),
-			app.world().entity(entity).get::<CollisionGroups>(),
-		);
+			assert_eq!(
+				Some(&CollisionGroups {
+					memberships,
+					filters: GENERIC_COLLISION_GROUP | RAY_GROUP
+				}),
+				entity.get::<CollisionGroups>(),
+			);
+		}
+
+		#[test_case(PhysicsType::Terrain, None; "terrain")]
+		#[test_case(PhysicsType::Agent, None; "agent")]
+		#[test_case(|_| PhysicsType::InteractiveFrame, Some(&Sensor); "interactive object")]
+		fn insert_sensor(
+			physics_type: fn(HashSet<Blocker>) -> PhysicsType,
+			sensor: Option<&Sensor>,
+		) {
+			let mut app = setup();
+			let shape = Shape::Parameters(ShapeParameters::Sphere {
+				radius: Units::from(42.),
+			});
+
+			let entity = app.world_mut().spawn(PhysicalBody(
+				Body::from_shape(shape).with_physics_type(physics_type(HashSet::default())),
+			));
+
+			assert_eq!(sensor, entity.get::<Sensor>());
+		}
 	}
 
-	#[test_case(PhysicsType::Terrain, None; "terrain")]
-	#[test_case(PhysicsType::Agent, None; "agent")]
-	#[test_case(|_| PhysicsType::InteractiveFrame, Some(&Sensor); "interactive object")]
-	fn insert_sensor(physics_type: fn(HashSet<Blocker>) -> PhysicsType, sensor: Option<&Sensor>) {
-		let mut app = setup();
-		let shape = Shape::Parameters(ShapeParameters::Sphere {
-			radius: Units::from(42.),
-		});
-		let entity = app
-			.world_mut()
-			.spawn(PhysicalBody(
-				Body::from_shape(shape).with_physics_type(physics_type(HashSet::default())),
-			))
-			.id();
+	mod sub_frames {
+		use super::*;
+		use common::traits::handles_physics::physical_bodies::InteractiveFrame;
+		use testing::assert_children_count;
 
-		assert_eq!(sensor, app.world().entity(entity).get::<Sensor>());
+		#[test]
+		fn insert_collider() {
+			let mut app = setup();
+			let shape = ShapeParameters::Sphere {
+				radius: Units::from(42.),
+			};
+			let entity = app
+				.world_mut()
+				.spawn(PhysicalBody(
+					Body::from_shape(Shape::StaticGltfMesh3d)
+						.with_sub_frames([InteractiveFrame(shape)]),
+				))
+				.id();
+
+			let [child] = assert_children_count!(1, app, entity);
+			assert_eq!(
+				Some(&ColliderShape::from(shape)),
+				child.get::<ColliderShape>(),
+			);
+		}
+
+		#[test]
+		fn insert_physics_constraints() {
+			let mut app = setup();
+			let shape = ShapeParameters::Sphere {
+				radius: Units::from(42.),
+			};
+			let entity = app
+				.world_mut()
+				.spawn(PhysicalBody(
+					Body::from_shape(Shape::StaticGltfMesh3d)
+						.with_sub_frames([InteractiveFrame(shape)]),
+				))
+				.id();
+
+			let [child] = assert_children_count!(1, app, entity);
+			assert_eq!(
+				(
+					None,
+					false,
+					Some(&ActiveEvents::COLLISION_EVENTS),
+					Some(&ActiveCollisionTypes::all()),
+				),
+				(
+					child.get::<RigidBody>(),
+					child.contains::<KinematicCharacterController>(),
+					child.get::<ActiveEvents>(),
+					child.get::<ActiveCollisionTypes>(),
+				)
+			);
+		}
+
+		#[test]
+		fn insert_collision_groups() {
+			let mut app = setup();
+			let shape = ShapeParameters::Sphere {
+				radius: Units::from(42.),
+			};
+			let entity = app
+				.world_mut()
+				.spawn(PhysicalBody(
+					Body::from_shape(Shape::StaticGltfMesh3d)
+						.with_sub_frames([InteractiveFrame(shape)]),
+				))
+				.id();
+
+			let [child] = assert_children_count!(1, app, entity);
+			assert_eq!(
+				Some(&CollisionGroups {
+					memberships: GENERIC_COLLISION_GROUP | INTERACTIVE_GROUP,
+					filters: GENERIC_COLLISION_GROUP | RAY_GROUP
+				}),
+				child.get::<CollisionGroups>(),
+			);
+		}
+
+		#[test]
+		fn insert_sensor() {
+			let mut app = setup();
+			let shape = ShapeParameters::Sphere {
+				radius: Units::from(42.),
+			};
+
+			let entity = app
+				.world_mut()
+				.spawn(PhysicalBody(
+					Body::from_shape(Shape::StaticGltfMesh3d)
+						.with_sub_frames([InteractiveFrame(shape)]),
+				))
+				.id();
+
+			let [child] = assert_children_count!(1, app, entity);
+			assert_eq!(Some(&Sensor), child.get::<Sensor>());
+		}
 	}
 }

--- a/src/plugins/physics/src/components/physical_body.rs
+++ b/src/plugins/physics/src/components/physical_body.rs
@@ -88,7 +88,7 @@ mod tests {
 	use common::{
 		tools::Units,
 		traits::{
-			handles_physics::physical_bodies::{Blocker, Body, Shape},
+			handles_physics::physical_bodies::{Blocker, Body, Shape, ShapeParameters},
 			prefab::AddPrefabObserver,
 		},
 	};
@@ -107,9 +107,9 @@ mod tests {
 	#[test]
 	fn insert_collider() {
 		let mut app = setup();
-		let shape = Shape::Sphere {
+		let shape = Shape::Parameters(ShapeParameters::Sphere {
 			radius: Units::from(42.),
-		};
+		});
 		let entity = app
 			.world_mut()
 			.spawn(PhysicalBody(Body::from_shape(shape)))
@@ -132,9 +132,9 @@ mod tests {
 		collision_types: Option<&ActiveCollisionTypes>,
 	) {
 		let mut app = setup();
-		let shape = Shape::Sphere {
+		let shape = Shape::Parameters(ShapeParameters::Sphere {
 			radius: Units::from(42.),
-		};
+		});
 		let entity = app
 			.world_mut()
 			.spawn(PhysicalBody(
@@ -168,9 +168,9 @@ mod tests {
 		blocks: fn(HashSet<Blocker>) -> Option<HashSet<Blocker>>,
 	) {
 		let mut app = setup();
-		let shape = Shape::Sphere {
+		let shape = Shape::Parameters(ShapeParameters::Sphere {
 			radius: Units::from(42.),
-		};
+		});
 		let entity = app
 			.world_mut()
 			.spawn(PhysicalBody(Body::from_shape(shape).with_physics_type(
@@ -192,9 +192,9 @@ mod tests {
 		memberships: Group,
 	) {
 		let mut app = setup();
-		let shape = Shape::Sphere {
+		let shape = Shape::Parameters(ShapeParameters::Sphere {
 			radius: Units::from(42.),
-		};
+		});
 		let entity = app
 			.world_mut()
 			.spawn(PhysicalBody(
@@ -216,9 +216,9 @@ mod tests {
 	#[test_case(|_| PhysicsType::InteractiveFrame, Some(&Sensor); "interactive object")]
 	fn insert_sensor(physics_type: fn(HashSet<Blocker>) -> PhysicsType, sensor: Option<&Sensor>) {
 		let mut app = setup();
-		let shape = Shape::Sphere {
+		let shape = Shape::Parameters(ShapeParameters::Sphere {
 			radius: Units::from(42.),
-		};
+		});
 		let entity = app
 			.world_mut()
 			.spawn(PhysicalBody(

--- a/src/plugins/physics/src/components/physical_body.rs
+++ b/src/plugins/physics/src/components/physical_body.rs
@@ -52,7 +52,7 @@ impl Prefab<()> for PhysicalBody {
 			sub_frames,
 		}) = self;
 
-		let specific_memberships_group = match physics_type {
+		match physics_type {
 			PhysicsType::Agent(blockers) => {
 				entity.try_insert((
 					RigidBody::KinematicPositionBased,
@@ -60,12 +60,21 @@ impl Prefab<()> for PhysicalBody {
 					ActiveEvents::COLLISION_EVENTS,
 					ActiveCollisionTypes::all(),
 					Self::agent_controller(),
+					CollisionGroups {
+						memberships: generic_and(MOUSE_HOVERABLE_GROUP),
+						filters: generic_and(RAY_GROUP),
+					},
 				));
-				MOUSE_HOVERABLE_GROUP
 			}
 			PhysicsType::Terrain(blockers) => {
-				entity.try_insert((RigidBody::Fixed, BlockerTypes(blockers.clone())));
-				TERRAIN_GROUP
+				entity.try_insert((
+					RigidBody::Fixed,
+					BlockerTypes(blockers.clone()),
+					CollisionGroups {
+						memberships: generic_and(TERRAIN_GROUP),
+						filters: generic_and(RAY_GROUP),
+					},
+				));
 			}
 			PhysicsType::InteractiveFrame => {
 				entity.try_insert((
@@ -73,18 +82,15 @@ impl Prefab<()> for PhysicalBody {
 					Sensor,
 					ActiveEvents::COLLISION_EVENTS,
 					ActiveCollisionTypes::all(),
+					CollisionGroups {
+						memberships: INTERACTIVE_GROUP,
+						filters: INTERACTIVE_GROUP | RAY_GROUP,
+					},
 				));
-				INTERACTIVE_GROUP
 			}
 		};
 
-		entity.try_insert((
-			CollisionGroups {
-				memberships: generic_and(specific_memberships_group),
-				filters: generic_and(RAY_GROUP),
-			},
-			ColliderShape::from(*shape),
-		));
+		entity.try_insert(ColliderShape::from(*shape));
 
 		for InteractiveFrame(shape) in sub_frames {
 			entity.with_child((
@@ -93,8 +99,8 @@ impl Prefab<()> for PhysicalBody {
 				ActiveEvents::COLLISION_EVENTS,
 				ActiveCollisionTypes::all(),
 				CollisionGroups {
-					memberships: generic_and(INTERACTIVE_GROUP),
-					filters: generic_and(RAY_GROUP),
+					memberships: INTERACTIVE_GROUP,
+					filters: INTERACTIVE_GROUP | RAY_GROUP,
 				},
 			));
 		}
@@ -207,12 +213,13 @@ mod tests {
 			);
 		}
 
-		#[test_case(PhysicsType::Terrain, GENERIC_COLLISION_GROUP | TERRAIN_GROUP; "terrain")]
-		#[test_case(PhysicsType::Agent, GENERIC_COLLISION_GROUP | MOUSE_HOVERABLE_GROUP; "agent")]
-		#[test_case(|_| PhysicsType::InteractiveFrame, GENERIC_COLLISION_GROUP | INTERACTIVE_GROUP; "interactive frame")]
+		#[test_case(PhysicsType::Terrain, generic_and(TERRAIN_GROUP) , generic_and(RAY_GROUP); "terrain")]
+		#[test_case(PhysicsType::Agent, generic_and(MOUSE_HOVERABLE_GROUP), generic_and(RAY_GROUP); "agent")]
+		#[test_case(|_| PhysicsType::InteractiveFrame, INTERACTIVE_GROUP, INTERACTIVE_GROUP | RAY_GROUP; "interactive frame")]
 		fn insert_collision_groups(
 			physics_type: fn(HashSet<Blocker>) -> PhysicsType,
 			memberships: Group,
+			filters: Group,
 		) {
 			let mut app = setup();
 			let shape = Shape::Parameters(ShapeParameters::Sphere {
@@ -225,7 +232,7 @@ mod tests {
 			assert_eq!(
 				Some(&CollisionGroups {
 					memberships,
-					filters: GENERIC_COLLISION_GROUP | RAY_GROUP
+					filters
 				}),
 				entity.get::<CollisionGroups>(),
 			);
@@ -325,8 +332,8 @@ mod tests {
 			let [child] = assert_children_count!(1, app, entity);
 			assert_eq!(
 				Some(&CollisionGroups {
-					memberships: GENERIC_COLLISION_GROUP | INTERACTIVE_GROUP,
-					filters: GENERIC_COLLISION_GROUP | RAY_GROUP
+					memberships: INTERACTIVE_GROUP,
+					filters: INTERACTIVE_GROUP | RAY_GROUP,
 				}),
 				child.get::<CollisionGroups>(),
 			);

--- a/src/plugins/physics/src/components/physical_body.rs
+++ b/src/plugins/physics/src/components/physical_body.rs
@@ -3,6 +3,7 @@ use crate::components::{
 	collider::{
 		ColliderShape,
 		GENERIC_COLLISION_GROUP,
+		INTERACTIVE_GROUP,
 		MOUSE_HOVERABLE_GROUP,
 		RAY_GROUP,
 		TERRAIN_GROUP,
@@ -46,12 +47,8 @@ impl Prefab<()> for PhysicalBody {
 		_: StaticSystemParam<()>,
 	) -> Result<(), Self::TError> {
 		let Self(Body { physics_type, .. }) = self;
-		let groups = match physics_type {
-			PhysicsType::Agent => GENERIC_COLLISION_GROUP | MOUSE_HOVERABLE_GROUP,
-			PhysicsType::Terrain => GENERIC_COLLISION_GROUP | TERRAIN_GROUP,
-		};
 
-		match self.0.physics_type {
+		let specific_memberships = match physics_type {
 			PhysicsType::Agent => {
 				entity.try_insert((
 					RigidBody::KinematicPositionBased,
@@ -59,15 +56,24 @@ impl Prefab<()> for PhysicalBody {
 					ActiveCollisionTypes::all(),
 					Self::agent_controller(),
 				));
+				MOUSE_HOVERABLE_GROUP
 			}
 			PhysicsType::Terrain => {
 				entity.try_insert(RigidBody::Fixed);
+				TERRAIN_GROUP
+			}
+			PhysicsType::InteractiveFrame => {
+				entity.try_insert((RigidBody::Fixed, Sensor));
+				INTERACTIVE_GROUP
 			}
 		};
 
 		entity.try_insert((
 			BlockerTypes(self.0.blocker_types.clone()),
-			CollisionGroups::new(groups, GENERIC_COLLISION_GROUP | RAY_GROUP),
+			CollisionGroups {
+				memberships: GENERIC_COLLISION_GROUP | specific_memberships,
+				filters: GENERIC_COLLISION_GROUP | RAY_GROUP,
+			},
 			ColliderShape::from(self.0.shape),
 		));
 
@@ -78,6 +84,7 @@ impl Prefab<()> for PhysicalBody {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate::components::collider::INTERACTIVE_GROUP;
 	use common::{
 		tools::Units,
 		traits::{
@@ -115,6 +122,7 @@ mod tests {
 
 	#[test_case(PhysicsType::Terrain, RigidBody::Fixed, false, None, None; "terrain")]
 	#[test_case(PhysicsType::Agent, RigidBody::KinematicPositionBased, true, Some(&ActiveEvents::COLLISION_EVENTS), Some(&ActiveCollisionTypes::all()); "agent")]
+	#[test_case(PhysicsType::InteractiveFrame, RigidBody::Fixed, false, None, None; "interactive object")]
 	fn insert_physics_constraints(
 		physics_type: PhysicsType,
 		rigid_body: RigidBody,
@@ -173,6 +181,7 @@ mod tests {
 
 	#[test_case(PhysicsType::Terrain, GENERIC_COLLISION_GROUP | TERRAIN_GROUP; "terrain")]
 	#[test_case(PhysicsType::Agent, GENERIC_COLLISION_GROUP | MOUSE_HOVERABLE_GROUP; "agent")]
+	#[test_case(PhysicsType::InteractiveFrame, GENERIC_COLLISION_GROUP | INTERACTIVE_GROUP; "interactive object")]
 	fn insert_collision_groups(physics_type: PhysicsType, memberships: Group) {
 		let mut app = setup();
 		let shape = Shape::Sphere {
@@ -192,5 +201,23 @@ mod tests {
 			}),
 			app.world().entity(entity).get::<CollisionGroups>(),
 		);
+	}
+
+	#[test_case(PhysicsType::Terrain, false; "terrain")]
+	#[test_case(PhysicsType::Agent, false; "agent")]
+	#[test_case(PhysicsType::InteractiveFrame, true; "interactive object")]
+	fn insert_sensor(physics_type: PhysicsType, has_sensor: bool) {
+		let mut app = setup();
+		let shape = Shape::Sphere {
+			radius: Units::from(42.),
+		};
+		let entity = app
+			.world_mut()
+			.spawn(PhysicalBody(
+				Body::from_shape(shape).with_physics_type(physics_type),
+			))
+			.id();
+
+		assert_eq!(has_sensor, app.world().entity(entity).contains::<Sensor>());
 	}
 }

--- a/src/plugins/physics/src/components/physical_body.rs
+++ b/src/plugins/physics/src/components/physical_body.rs
@@ -49,17 +49,18 @@ impl Prefab<()> for PhysicalBody {
 		let Self(Body { physics_type, .. }) = self;
 
 		let specific_memberships = match physics_type {
-			PhysicsType::Agent => {
+			PhysicsType::Agent(blockers) => {
 				entity.try_insert((
 					RigidBody::KinematicPositionBased,
+					BlockerTypes(blockers.clone()),
 					ActiveEvents::COLLISION_EVENTS,
 					ActiveCollisionTypes::all(),
 					Self::agent_controller(),
 				));
 				MOUSE_HOVERABLE_GROUP
 			}
-			PhysicsType::Terrain => {
-				entity.try_insert(RigidBody::Fixed);
+			PhysicsType::Terrain(blockers) => {
+				entity.try_insert((RigidBody::Fixed, BlockerTypes(blockers.clone())));
 				TERRAIN_GROUP
 			}
 			PhysicsType::InteractiveFrame => {
@@ -69,7 +70,6 @@ impl Prefab<()> for PhysicalBody {
 		};
 
 		entity.try_insert((
-			BlockerTypes(self.0.blocker_types.clone()),
 			CollisionGroups {
 				memberships: GENERIC_COLLISION_GROUP | specific_memberships,
 				filters: GENERIC_COLLISION_GROUP | RAY_GROUP,
@@ -92,6 +92,7 @@ mod tests {
 			prefab::AddPrefabObserver,
 		},
 	};
+	use std::collections::HashSet;
 	use test_case::test_case;
 	use testing::SingleThreadedApp;
 
@@ -122,9 +123,9 @@ mod tests {
 
 	#[test_case(PhysicsType::Terrain, RigidBody::Fixed, false, None, None; "terrain")]
 	#[test_case(PhysicsType::Agent, RigidBody::KinematicPositionBased, true, Some(&ActiveEvents::COLLISION_EVENTS), Some(&ActiveCollisionTypes::all()); "agent")]
-	#[test_case(PhysicsType::InteractiveFrame, RigidBody::Fixed, false, None, None; "interactive object")]
+	#[test_case(|_| PhysicsType::InteractiveFrame, RigidBody::Fixed, false, None, None; "interactive frame")]
 	fn insert_physics_constraints(
-		physics_type: PhysicsType,
+		physics_type: fn(HashSet<Blocker>) -> PhysicsType,
 		rigid_body: RigidBody,
 		has_character_controller: bool,
 		active_events: Option<&ActiveEvents>,
@@ -137,7 +138,7 @@ mod tests {
 		let entity = app
 			.world_mut()
 			.spawn(PhysicalBody(
-				Body::from_shape(shape).with_physics_type(physics_type),
+				Body::from_shape(shape).with_physics_type(physics_type(HashSet::default())),
 			))
 			.id();
 
@@ -159,30 +160,37 @@ mod tests {
 		);
 	}
 
-	#[test]
-	fn insert_blocker_types() {
+	#[test_case(PhysicsType::Terrain, Some; "terrain")]
+	#[test_case(PhysicsType::Agent, Some; "agent")]
+	#[test_case(|_| PhysicsType::InteractiveFrame, |_| None; "interactive frame")]
+	fn insert_blocker_types(
+		physics_type: fn(HashSet<Blocker>) -> PhysicsType,
+		blocks: fn(HashSet<Blocker>) -> Option<HashSet<Blocker>>,
+	) {
 		let mut app = setup();
-		let blocks = [Blocker::Force, Blocker::Physical];
 		let shape = Shape::Sphere {
 			radius: Units::from(42.),
 		};
 		let entity = app
 			.world_mut()
-			.spawn(PhysicalBody(
-				Body::from_shape(shape).with_blocker_types(blocks),
-			))
+			.spawn(PhysicalBody(Body::from_shape(shape).with_physics_type(
+				physics_type(HashSet::from([Blocker::Force, Blocker::Physical])),
+			)))
 			.id();
 
 		assert_eq!(
-			Some(&BlockerTypes::from(blocks)),
-			app.world().entity(entity).get::<BlockerTypes>(),
+			blocks(HashSet::from([Blocker::Force, Blocker::Physical])).map(BlockerTypes::from),
+			app.world().entity(entity).get::<BlockerTypes>().cloned(),
 		);
 	}
 
 	#[test_case(PhysicsType::Terrain, GENERIC_COLLISION_GROUP | TERRAIN_GROUP; "terrain")]
 	#[test_case(PhysicsType::Agent, GENERIC_COLLISION_GROUP | MOUSE_HOVERABLE_GROUP; "agent")]
-	#[test_case(PhysicsType::InteractiveFrame, GENERIC_COLLISION_GROUP | INTERACTIVE_GROUP; "interactive object")]
-	fn insert_collision_groups(physics_type: PhysicsType, memberships: Group) {
+	#[test_case(|_| PhysicsType::InteractiveFrame, GENERIC_COLLISION_GROUP | INTERACTIVE_GROUP; "interactive frame")]
+	fn insert_collision_groups(
+		physics_type: fn(HashSet<Blocker>) -> PhysicsType,
+		memberships: Group,
+	) {
 		let mut app = setup();
 		let shape = Shape::Sphere {
 			radius: Units::from(42.),
@@ -190,7 +198,7 @@ mod tests {
 		let entity = app
 			.world_mut()
 			.spawn(PhysicalBody(
-				Body::from_shape(shape).with_physics_type(physics_type),
+				Body::from_shape(shape).with_physics_type(physics_type(HashSet::default())),
 			))
 			.id();
 
@@ -203,10 +211,10 @@ mod tests {
 		);
 	}
 
-	#[test_case(PhysicsType::Terrain, false; "terrain")]
-	#[test_case(PhysicsType::Agent, false; "agent")]
-	#[test_case(PhysicsType::InteractiveFrame, true; "interactive object")]
-	fn insert_sensor(physics_type: PhysicsType, has_sensor: bool) {
+	#[test_case(PhysicsType::Terrain, None; "terrain")]
+	#[test_case(PhysicsType::Agent, None; "agent")]
+	#[test_case(|_| PhysicsType::InteractiveFrame, Some(&Sensor); "interactive object")]
+	fn insert_sensor(physics_type: fn(HashSet<Blocker>) -> PhysicsType, sensor: Option<&Sensor>) {
 		let mut app = setup();
 		let shape = Shape::Sphere {
 			radius: Units::from(42.),
@@ -214,10 +222,10 @@ mod tests {
 		let entity = app
 			.world_mut()
 			.spawn(PhysicalBody(
-				Body::from_shape(shape).with_physics_type(physics_type),
+				Body::from_shape(shape).with_physics_type(physics_type(HashSet::default())),
 			))
 			.id();
 
-		assert_eq!(has_sensor, app.world().entity(entity).contains::<Sensor>());
+		assert_eq!(sensor, app.world().entity(entity).get::<Sensor>());
 	}
 }

--- a/src/plugins/physics/src/observers/skill_prefab.rs
+++ b/src/plugins/physics/src/observers/skill_prefab.rs
@@ -128,7 +128,10 @@ mod tests {
 		effects::force::Force,
 		tools::Units,
 		traits::{
-			handles_physics::{PhysicalObject, physical_bodies::Shape},
+			handles_physics::{
+				PhysicalObject,
+				physical_bodies::{Shape, ShapeParameters},
+			},
 			handles_skill_physics::Effect,
 		},
 	};
@@ -162,18 +165,18 @@ mod tests {
 
 		fn default_contact_collider() -> ContactCollider {
 			ContactCollider {
-				shape: ColliderShape::from(Shape::Sphere {
+				shape: ColliderShape::from(Shape::Parameters(ShapeParameters::Sphere {
 					radius: Units::ZERO,
-				}),
+				})),
 				transform: Transform::default(),
 			}
 		}
 
 		fn default_projection_collider() -> ProjectionCollider {
 			ProjectionCollider {
-				shape: ColliderShape::from(Shape::Sphere {
+				shape: ColliderShape::from(Shape::Parameters(ShapeParameters::Sphere {
 					radius: Units::from(1.),
-				}),
+				})),
 				transform: Transform::default(),
 			}
 		}
@@ -358,9 +361,11 @@ mod tests {
 						_Skill::default_object(),
 						_Skill::default_model(),
 						ContactCollider {
-							shape: ColliderShape::from(Shape::Sphere {
-								radius: Units::from(42.),
-							}),
+							shape: ColliderShape::from(Shape::Parameters(
+								ShapeParameters::Sphere {
+									radius: Units::from(42.),
+								},
+							)),
 							transform: Transform::from_xyz(1., 2., 3.),
 						},
 						_Skill::default_effects(),
@@ -372,9 +377,11 @@ mod tests {
 			let [_, collider, _] = assert_children_count!(3, app, skill);
 			assert_eq!(
 				(
-					Some(&ColliderShape::from(Shape::Sphere {
-						radius: Units::from(42.),
-					})),
+					Some(&ColliderShape::from(Shape::Parameters(
+						ShapeParameters::Sphere {
+							radius: Units::from(42.),
+						}
+					))),
 					Some(&Transform::from_xyz(1., 2., 3.)),
 					Some(&CollisionGroups {
 						memberships: GENERIC_COLLISION_GROUP,
@@ -482,9 +489,11 @@ mod tests {
 					projection: (
 						_Skill::default_model(),
 						ProjectionCollider {
-							shape: ColliderShape::from(Shape::Sphere {
-								radius: Units::from(42.),
-							}),
+							shape: ColliderShape::from(Shape::Parameters(
+								ShapeParameters::Sphere {
+									radius: Units::from(42.),
+								},
+							)),
 							transform: Transform::from_xyz(1., 2., 3.),
 						},
 						_Skill::default_effects(),
@@ -497,9 +506,11 @@ mod tests {
 			let [.., collider] = assert_children_count!(2, app, projection);
 			assert_eq!(
 				(
-					Some(&ColliderShape::from(Shape::Sphere {
-						radius: Units::from(42.),
-					})),
+					Some(&ColliderShape::from(Shape::Parameters(
+						ShapeParameters::Sphere {
+							radius: Units::from(42.),
+						}
+					))),
 					Some(&Transform::from_xyz(1., 2., 3.)),
 					Some(&CollisionGroups {
 						memberships: GENERIC_COLLISION_GROUP,


### PR DESCRIPTION
In preparation for adding interactive objects:
- `Body` can now be an interactive object, which is basically a just a sensor
- `Body` can contain interactive sub frames, which allows adding additional sensors to entities like agents

Further steps are tracked in #782

