### PR TITLE
Fix faulty hollow sphere collider path

### DIFF
--- a/src/plugins/physics/src/components/collider.rs
+++ b/src/plugins/physics/src/components/collider.rs
@@ -12,6 +12,7 @@ use common::{
 		prefab::{Prefab, PrefabEntityCommands, Reapply},
 	},
 };
+use macros::asset_path;
 use std::marker::PhantomData;
 
 pub(crate) const GENERIC_COLLISION_GROUP: Group = Group::GROUP_1;
@@ -109,7 +110,10 @@ impl Prefab<()> for ColliderShape {
 				radius,
 				hollow: true,
 			} => SyncOrAsync::Async(AsyncCollider {
-				source: Source::Path("models/icosphere.glb#Mesh0/Primitive0"),
+				source: Source::Path(concat!(
+					asset_path!("generic/models/icosphere.glb"),
+					"#Mesh0/Primitive0"
+				)),
 				scale: Some(ColliderScale::Absolute(Vec3::splat(*radius * 2.))),
 				collider_type: ColliderType::Concave,
 			}),


### PR DESCRIPTION
Collider path for hollow colliders pointed to non existing asset. Fixed and validated with `asset_path!`.