### PR TITLE
Rename traits: `GetContext(Mut)` -> `TryGetContext(Mut)`

### DIFF
--- a/src/plugins/agents/src/components/agent.rs
+++ b/src/plugins/agents/src/components/agent.rs
@@ -7,7 +7,7 @@ use common::{
 	errors::{ErrorData, Level, Unreachable},
 	systems::register_animations::AnimationsMarker,
 	traits::{
-		accessors::get::{GetContextMut, View},
+		accessors::get::{TryGetContextMut, View},
 		handles_enemies::EnemyType,
 		handles_map_generation::{AgentType, GroundPosition, MapPrefabs, SetPrefab},
 		prefab::{Prefab, PrefabEntityCommands},
@@ -44,9 +44,10 @@ impl Agent {
 	) -> Result<(), NoPrefabContext>
 	where
 		TNewMapAgent:
-			for<'c> GetContextMut<MapPrefabs<AgentType>, TContext<'c>: SetPrefab<AgentType>>,
+			for<'c> TryGetContextMut<MapPrefabs<AgentType>, TContext<'c>: SetPrefab<AgentType>>,
 	{
-		let Some(mut ctx) = TNewMapAgent::get_context_mut(&mut new_agent, MapPrefabs::KEY) else {
+		let Some(mut ctx) = TNewMapAgent::try_get_context_mut(&mut new_agent, MapPrefabs::KEY)
+		else {
 			return Err(NoPrefabContext);
 		};
 

--- a/src/plugins/agents/src/systems/agent_config/animate_idle.rs
+++ b/src/plugins/agents/src/systems/agent_config/animate_idle.rs
@@ -2,7 +2,7 @@ use crate::components::animate_idle::AnimateIdle;
 use bevy::{ecs::system::StaticSystemParam, prelude::*};
 use common::{
 	traits::{
-		accessors::get::{GetContextMut, TryApplyOn},
+		accessors::get::{TryApplyOn, TryGetContextMut},
 		handles_animations::{ActiveAnimationsMut, AnimationKey, AnimationPriority, Animations},
 	},
 	zyheeda_commands::ZyheedaCommands,
@@ -15,11 +15,12 @@ impl AnimateIdle {
 		mut animations: StaticSystemParam<TAnimations>,
 		idlers: Query<Entity, With<Self>>,
 	) where
-		TAnimations: for<'c> GetContextMut<Animations, TContext<'c>: ActiveAnimationsMut>,
+		TAnimations: for<'c> TryGetContextMut<Animations, TContext<'c>: ActiveAnimationsMut>,
 	{
 		for entity in &idlers {
 			let key = Animations { entity };
-			let Some(mut animations) = TAnimations::get_context_mut(&mut animations, key) else {
+			let Some(mut animations) = TAnimations::try_get_context_mut(&mut animations, key)
+			else {
 				continue;
 			};
 

--- a/src/plugins/agents/src/systems/agent_config/animate_skills.rs
+++ b/src/plugins/agents/src/systems/agent_config/animate_skills.rs
@@ -3,7 +3,7 @@ use bevy::{ecs::system::StaticSystemParam, prelude::*};
 use common::{
 	tools::action_key::slot::SlotKey,
 	traits::{
-		accessors::get::{GetChangedContext, GetContext, GetContextMut},
+		accessors::get::{GetChangedContext, TryGetContext, TryGetContextMut},
 		handles_animations::{
 			ActiveAnimationsMut,
 			AnimationKey,
@@ -21,8 +21,8 @@ impl AgentConfig {
 		mut animations: StaticSystemParam<TAnimations>,
 		agents: Query<Entity, With<Self>>,
 	) where
-		TLoadout: for<'c> GetContext<Skills, TContext<'c>: ActiveSkills>,
-		TAnimations: for<'c> GetContextMut<Animations, TContext<'c>: ActiveAnimationsMut>,
+		TLoadout: for<'c> TryGetContext<Skills, TContext<'c>: ActiveSkills>,
+		TAnimations: for<'c> TryGetContextMut<Animations, TContext<'c>: ActiveAnimationsMut>,
 	{
 		for entity in agents {
 			let key = Skills { entity };
@@ -31,7 +31,8 @@ impl AgentConfig {
 			};
 
 			let key = Animations { entity };
-			let Some(mut animations) = TAnimations::get_context_mut(&mut animations, key) else {
+			let Some(mut animations) = TAnimations::try_get_context_mut(&mut animations, key)
+			else {
 				continue;
 			};
 

--- a/src/plugins/agents/src/systems/agent_config/apply_config_system.rs
+++ b/src/plugins/agents/src/systems/agent_config/apply_config_system.rs
@@ -13,7 +13,7 @@ use common::{
 	components::model::{Model, SceneId, UseGltfLookup},
 	tools::{Units, action_key::slot::SlotKey, inventory_key::InventoryKey},
 	traits::{
-		accessors::get::{GetContextMut, TryApplyOn},
+		accessors::get::{TryApplyOn, TryGetContextMut},
 		handles_loadout::{
 			LoadoutKey,
 			insert_default_loadout::{InsertDefaultLoadout, NotLoadedOut},
@@ -55,14 +55,15 @@ impl ApplyAgentConfig {
 		configs: Res<Assets<AgentMeta>>,
 	) where
 		TLoadout: SystemParam
-			+ for<'c> GetContextMut<NotLoadedOut, TContext<'c>: InsertDefaultLoadout>
-			+ for<'c> GetContextMut<NoBonesRegistered, TContext<'c>: RegisterLoadoutBones>,
-		TSkills: SystemParam + for<'c> GetContextMut<NotInitializedAgent, TContext<'c>: Initialize>,
+			+ for<'c> TryGetContextMut<NotLoadedOut, TContext<'c>: InsertDefaultLoadout>
+			+ for<'c> TryGetContextMut<NoBonesRegistered, TContext<'c>: RegisterLoadoutBones>,
+		TSkills:
+			SystemParam + for<'c> TryGetContextMut<NotInitializedAgent, TContext<'c>: Initialize>,
 		TMovement: SystemParam
-			+ for<'c> GetContextMut<NotConfiguredMovement, TContext<'c>: ConfigureMovement>,
+			+ for<'c> TryGetContextMut<NotConfiguredMovement, TContext<'c>: ConfigureMovement>,
 		TPhysics: SystemParam
-			+ for<'c> GetContextMut<NoDefaultAttributes, TContext<'c>: ConfigureDefaultAttributes>
-			+ for<'c> GetContextMut<NoBodyConfigured, TContext<'c>: ConfigureBody>,
+			+ for<'c> TryGetContextMut<NoDefaultAttributes, TContext<'c>: ConfigureDefaultAttributes>
+			+ for<'c> TryGetContextMut<NoBodyConfigured, TContext<'c>: ConfigureBody>,
 	{
 		for (entity, AgentConfig { config_handle }, mut transform, transform_dirty) in agents {
 			let Some(config) = configs.get(config_handle) else {
@@ -70,12 +71,14 @@ impl ApplyAgentConfig {
 			};
 
 			let no_loadout = NotLoadedOut { entity };
-			if let Some(mut ctx) = TLoadout::get_context_mut(&mut loadout_param, no_loadout) {
+			if let Some(mut ctx) = TLoadout::try_get_context_mut(&mut loadout_param, no_loadout) {
 				ctx.insert_default_loadout(&config.loadout);
 			};
 
 			let no_loadout_bones = NoBonesRegistered { entity };
-			if let Some(mut ctx) = TLoadout::get_context_mut(&mut loadout_param, no_loadout_bones) {
+			if let Some(mut ctx) =
+				TLoadout::try_get_context_mut(&mut loadout_param, no_loadout_bones)
+			{
 				ctx.register_loadout_bones(
 					config.bones.forearm_slots.clone(),
 					config.bones.hand_slots.clone(),
@@ -84,22 +87,23 @@ impl ApplyAgentConfig {
 			};
 
 			let not_initialized = NotInitializedAgent { entity };
-			if let Some(mut ctx) = TSkills::get_context_mut(&mut skills_param, not_initialized) {
+			if let Some(mut ctx) = TSkills::try_get_context_mut(&mut skills_param, not_initialized)
+			{
 				ctx.initialize(config.bones.skill_mounts.clone());
 			};
 
 			let not_configured = NotConfiguredMovement { entity };
-			if let Some(mut ctx) = TMovement::get_context_mut(&mut movement, not_configured) {
+			if let Some(mut ctx) = TMovement::try_get_context_mut(&mut movement, not_configured) {
 				ctx.configure(config.speed.with_fastest_left(), config.required_clearance);
 			}
 
 			let no_default_attr = NoDefaultAttributes { entity };
-			if let Some(mut ctx) = TPhysics::get_context_mut(&mut physics, no_default_attr) {
+			if let Some(mut ctx) = TPhysics::try_get_context_mut(&mut physics, no_default_attr) {
 				ctx.configure_default_attributes(config.attributes);
 			}
 
 			let no_body = NoBodyConfigured { entity };
-			if let Some(mut ctx) = TPhysics::get_context_mut(&mut physics, no_body) {
+			if let Some(mut ctx) = TPhysics::try_get_context_mut(&mut physics, no_body) {
 				let half_y = Units::from(
 					*config.required_clearance.vertical - *config.required_clearance.horizontal,
 				);

--- a/src/plugins/agents/src/systems/enemy/animate_movement.rs
+++ b/src/plugins/agents/src/systems/enemy/animate_movement.rs
@@ -3,7 +3,7 @@ use bevy::{ecs::system::StaticSystemParam, prelude::*};
 use common::{
 	errors::Level,
 	traits::{
-		accessors::get::{GetChangedContext, GetContext, GetContextMut, Logged, View},
+		accessors::get::{GetChangedContext, Logged, TryGetContext, TryGetContextMut, View},
 		handles_animations::{ActiveAnimationsMut, AnimationKey, Animations},
 		handles_movement::{Movement, MovementTarget},
 	},
@@ -16,8 +16,10 @@ impl Enemy {
 		mut animations: StaticSystemParam<TAnimations>,
 		enemies: Query<Entity, With<Self>>,
 	) where
-		TMovement: for<'c> GetContext<Logged<Movement>, TContext<'c>: View<Option<MovementTarget>>>,
-		TAnimations: for<'c> GetContextMut<Logged<Animations>, TContext<'c>: ActiveAnimationsMut>,
+		TMovement:
+			for<'c> TryGetContext<Logged<Movement>, TContext<'c>: View<Option<MovementTarget>>>,
+		TAnimations:
+			for<'c> TryGetContextMut<Logged<Animations>, TContext<'c>: ActiveAnimationsMut>,
 	{
 		for entity in enemies {
 			let key = Logged::key(Movement { entity }).with_level(Level::Error);
@@ -26,7 +28,8 @@ impl Enemy {
 			};
 
 			let key = Logged::key(Animations { entity }).with_level(Level::Error);
-			let Some(mut animations) = TAnimations::get_context_mut(&mut animations, key) else {
+			let Some(mut animations) = TAnimations::try_get_context_mut(&mut animations, key)
+			else {
 				continue;
 			};
 

--- a/src/plugins/agents/src/systems/enemy/chase_player.rs
+++ b/src/plugins/agents/src/systems/enemy/chase_player.rs
@@ -1,7 +1,7 @@
 use crate::components::enemy::{Enemy, chasing::Chasing};
 use bevy::{ecs::system::StaticSystemParam, prelude::*};
 use common::traits::{
-	accessors::get::{GetContextMut, View},
+	accessors::get::{TryGetContextMut, View},
 	handles_movement::{ConfiguredMovement, MovementTarget, StartMovement, StopMovement},
 };
 
@@ -11,14 +11,14 @@ impl Enemy {
 		enemies: Query<(Entity, Option<&Chasing>), With<Self>>,
 		transforms: Query<&Transform>,
 	) where
-		TMovement: for<'c> GetContextMut<
+		TMovement: for<'c> TryGetContextMut<
 				ConfiguredMovement,
 				TContext<'c>: StartMovement + StopMovement + View<Option<MovementTarget>>,
 			>,
 	{
 		for (entity, chasing) in &enemies {
 			let key = ConfiguredMovement { entity };
-			let Some(mut ctx) = TMovement::get_context_mut(&mut movement, key) else {
+			let Some(mut ctx) = TMovement::try_get_context_mut(&mut movement, key) else {
 				continue;
 			};
 

--- a/src/plugins/agents/src/systems/enemy/hold_attack.rs
+++ b/src/plugins/agents/src/systems/enemy/hold_attack.rs
@@ -1,7 +1,7 @@
 use crate::components::enemy::{Enemy, attack_phase::EnemyAttackPhase, attacking::Attacking};
 use bevy::{ecs::system::StaticSystemParam, prelude::*};
 use common::traits::{
-	accessors::get::GetContextMut,
+	accessors::get::TryGetContextMut,
 	handles_loadout::{HeldSkillsMut, skills::Skills},
 	handles_skill_physics::{InitializedAgent, SkillTarget, TargetMut},
 };
@@ -13,17 +13,17 @@ impl Enemy {
 		attacking: Query<(Entity, &EnemyAttackPhase, &Attacking), Changed<EnemyAttackPhase>>,
 		mut stopped_attacking: RemovedComponents<EnemyAttackPhase>,
 	) where
-		TPhysics: for<'c> GetContextMut<InitializedAgent, TContext<'c>: TargetMut>,
-		TLoadout: for<'c> GetContextMut<Skills, TContext<'c>: HeldSkillsMut>,
+		TPhysics: for<'c> TryGetContextMut<InitializedAgent, TContext<'c>: TargetMut>,
+		TLoadout: for<'c> TryGetContextMut<Skills, TContext<'c>: HeldSkillsMut>,
 	{
 		for (entity, phase, Attacking { player, .. }) in &attacking {
 			let agent = InitializedAgent { entity };
-			if let Some(mut ctx) = TPhysics::get_context_mut(&mut physics, agent) {
+			if let Some(mut ctx) = TPhysics::try_get_context_mut(&mut physics, agent) {
 				*ctx.target_mut() = Some(SkillTarget::Entity(*player));
 			}
 
 			let skills = Skills { entity };
-			let Some(mut ctx) = TLoadout::get_context_mut(&mut loadout, skills) else {
+			let Some(mut ctx) = TLoadout::try_get_context_mut(&mut loadout, skills) else {
 				continue;
 			};
 
@@ -36,7 +36,7 @@ impl Enemy {
 
 		for entity in stopped_attacking.read() {
 			let skills = Skills { entity };
-			let Some(mut ctx) = TLoadout::get_context_mut(&mut loadout, skills) else {
+			let Some(mut ctx) = TLoadout::try_get_context_mut(&mut loadout, skills) else {
 				continue;
 			};
 

--- a/src/plugins/agents/src/systems/player/animate_movement.rs
+++ b/src/plugins/agents/src/systems/player/animate_movement.rs
@@ -3,7 +3,14 @@ use bevy::{ecs::system::StaticSystemParam, prelude::*};
 use common::{
 	errors::Level,
 	traits::{
-		accessors::get::{GetChangedContext, GetContext, GetContextMut, Logged, View, ViewOf},
+		accessors::get::{
+			GetChangedContext,
+			Logged,
+			TryGetContext,
+			TryGetContextMut,
+			View,
+			ViewOf,
+		},
 		handles_animations::{ActiveAnimationsMut, AnimationKey, AnimationPriority, Animations},
 		handles_movement::{CurrentMovement, Movement, MovementTarget, SpeedToggle},
 	},
@@ -16,8 +23,9 @@ impl Player {
 		mut animations: StaticSystemParam<TAnimations>,
 		players: Query<Entity, With<Self>>,
 	) where
-		TMovement: for<'c> GetContext<Logged<Movement>, TContext<'c>: CurrentMovement>,
-		TAnimations: for<'c> GetContextMut<Logged<Animations>, TContext<'c>: ActiveAnimationsMut>,
+		TMovement: for<'c> TryGetContext<Logged<Movement>, TContext<'c>: CurrentMovement>,
+		TAnimations:
+			for<'c> TryGetContextMut<Logged<Animations>, TContext<'c>: ActiveAnimationsMut>,
 	{
 		for entity in players {
 			let key = Logged::key(Movement { entity }).with_level(Level::Error);
@@ -26,7 +34,8 @@ impl Player {
 			};
 
 			let key = Logged::key(Animations { entity }).with_level(Level::Error);
-			let Some(mut animations) = TAnimations::get_context_mut(&mut animations, key) else {
+			let Some(mut animations) = TAnimations::try_get_context_mut(&mut animations, key)
+			else {
 				continue;
 			};
 

--- a/src/plugins/agents/src/systems/player/movement.rs
+++ b/src/plugins/agents/src/systems/player/movement.rs
@@ -7,7 +7,7 @@ use bevy::{
 use common::{
 	tools::action_key::movement::MovementKey,
 	traits::{
-		accessors::get::GetContextMut,
+		accessors::get::TryGetContextMut,
 		handles_input::{GetAllInputStates, InputState},
 		handles_movement::{ConfiguredMovement, StartMovement, StopMovement},
 		handles_physics::{MouseTerrainHover, MouseTerrainPoint, Raycast},
@@ -25,7 +25,7 @@ impl Player {
 		for<'w, 's> TInput: SystemParam<Item<'w, 's>: GetAllInputStates>,
 		for<'w, 's> TRaycast: SystemParam<Item<'w, 's>: Raycast<MouseTerrainHover>>,
 		for<'c> TMovement:
-			GetContextMut<ConfiguredMovement, TContext<'c>: StartMovement + StopMovement>,
+			TryGetContextMut<ConfiguredMovement, TContext<'c>: StartMovement + StopMovement>,
 	{
 		let Some(cam_transform) = cameras.iter().next() else {
 			return;
@@ -33,7 +33,8 @@ impl Player {
 		let inputs = || input.get_all_input_states::<MovementKey>();
 
 		for entity in &players {
-			let Some(mut ctx) = TMovement::get_context_mut(&mut m, ConfiguredMovement { entity })
+			let Some(mut ctx) =
+				TMovement::try_get_context_mut(&mut m, ConfiguredMovement { entity })
 			else {
 				continue;
 			};

--- a/src/plugins/agents/src/systems/player/toggle_speed.rs
+++ b/src/plugins/agents/src/systems/player/toggle_speed.rs
@@ -6,7 +6,7 @@ use bevy::{
 use common::{
 	tools::action_key::movement::MovementKey,
 	traits::{
-		accessors::get::GetContextMut,
+		accessors::get::TryGetContextMut,
 		handles_input::{GetAllInputStates, InputState},
 		handles_movement::{ConfiguredMovement, ToggleSpeed},
 	},
@@ -20,7 +20,7 @@ impl Player {
 	) where
 		for<'w, 's> TInput: SystemParam<Item<'w, 's>: GetAllInputStates>,
 		for<'c> TMovement:
-			SystemParam + GetContextMut<ConfiguredMovement, TContext<'c>: ToggleSpeed>,
+			SystemParam + TryGetContextMut<ConfiguredMovement, TContext<'c>: ToggleSpeed>,
 	{
 		let just_toggled = input
 			.get_all_input_states::<MovementKey>()
@@ -32,7 +32,7 @@ impl Player {
 
 		for entity in players {
 			let key = ConfiguredMovement { entity };
-			let Some(mut ctx) = TMovement::get_context_mut(&mut movement, key) else {
+			let Some(mut ctx) = TMovement::try_get_context_mut(&mut movement, key) else {
 				continue;
 			};
 

--- a/src/plugins/agents/src/systems/player/use_skills.rs
+++ b/src/plugins/agents/src/systems/player/use_skills.rs
@@ -9,7 +9,7 @@ use common::{
 		targeting::TerrainTargeting,
 	},
 	traits::{
-		accessors::get::GetContextMut,
+		accessors::get::TryGetContextMut,
 		handles_input::{GetAllInputStates, InputState},
 		handles_loadout::{HeldSkills, HeldSkillsMut, skills::Skills},
 		handles_skill_physics::{Cursor, InitializedAgent, SkillTarget, Target, TargetMut},
@@ -24,8 +24,8 @@ impl Player {
 		players: Query<Entity, With<Self>>,
 	) where
 		TInput: for<'w, 's> SystemParam<Item<'w, 's>: GetAllInputStates>,
-		TPhysics: for<'c> GetContextMut<InitializedAgent, TContext<'c>: TargetMut>,
-		TLoadout: for<'c> GetContextMut<Skills, TContext<'c>: HeldSkillsMut>,
+		TPhysics: for<'c> TryGetContextMut<InitializedAgent, TContext<'c>: TargetMut>,
+		TLoadout: for<'c> TryGetContextMut<Skills, TContext<'c>: HeldSkillsMut>,
 	{
 		let held = || {
 			input
@@ -55,14 +55,14 @@ impl Player {
 			let new_held_skills = held().map(SlotKey::from).collect();
 
 			let agent = InitializedAgent { entity };
-			if let Some(mut ctx) = TPhysics::get_context_mut(&mut physics, agent)
+			if let Some(mut ctx) = TPhysics::try_get_context_mut(&mut physics, agent)
 				&& ctx.target() != Some(&skill_target)
 			{
 				*ctx.target_mut() = Some(skill_target);
 			};
 
 			let skills = Skills { entity };
-			if let Some(mut ctx) = TLoadout::get_context_mut(&mut loadout, skills)
+			if let Some(mut ctx) = TLoadout::try_get_context_mut(&mut loadout, skills)
 				&& ctx.held_skills() != &new_held_skills
 			{
 				*ctx.held_skills_mut() = new_held_skills;

--- a/src/plugins/animations/src/system_params/animations.rs
+++ b/src/plugins/animations/src/system_params/animations.rs
@@ -12,7 +12,7 @@ use crate::components::{
 use bevy::{ecs::system::SystemParam, prelude::*};
 use common::{
 	traits::{
-		accessors::get::{GetContextMut, GetMut},
+		accessors::get::{GetMut, TryGetContextMut},
 		handles_animations::{AnimationClips, Animations, WithoutAnimations},
 	},
 	zyheeda_commands::{ZyheedaCommands, ZyheedaEntityCommands},
@@ -37,14 +37,14 @@ where
 	graphs: ResMut<'w, Assets<TAnimationGraph>>,
 }
 
-impl<TAnimationGraph> GetContextMut<WithoutAnimations>
+impl<TAnimationGraph> TryGetContextMut<WithoutAnimations>
 	for AnimationsParamMut<'static, 'static, TAnimationGraph>
 where
 	TAnimationGraph: Asset,
 {
 	type TContext<'ctx> = AnimationsRegisterContextMut<'ctx, TAnimationGraph>;
 
-	fn get_context_mut<'ctx>(
+	fn try_get_context_mut<'ctx>(
 		param: &'ctx mut AnimationsParamMut<TAnimationGraph>,
 		WithoutAnimations { entity }: WithoutAnimations,
 	) -> Option<Self::TContext<'ctx>> {
@@ -59,14 +59,14 @@ where
 	}
 }
 
-impl<TAnimationGraph> GetContextMut<Animations>
+impl<TAnimationGraph> TryGetContextMut<Animations>
 	for AnimationsParamMut<'static, 'static, TAnimationGraph>
 where
 	TAnimationGraph: Asset,
 {
 	type TContext<'ctx> = AnimationsContextMut<'ctx>;
 
-	fn get_context_mut<'ctx>(
+	fn try_get_context_mut<'ctx>(
 		param: &'ctx mut AnimationsParamMut<TAnimationGraph>,
 		Animations { entity }: Animations,
 	) -> Option<Self::TContext<'ctx>> {
@@ -127,8 +127,11 @@ mod tests {
 			let ctx =
 				app.world_mut()
 					.run_system_once(move |mut p: AnimationsParamMut<_Graph>| {
-						AnimationsParamMut::get_context_mut(&mut p, WithoutAnimations { entity })
-							.is_some()
+						AnimationsParamMut::try_get_context_mut(
+							&mut p,
+							WithoutAnimations { entity },
+						)
+						.is_some()
 					})?;
 
 			assert!(ctx);
@@ -146,8 +149,11 @@ mod tests {
 			let ctx =
 				app.world_mut()
 					.run_system_once(move |mut p: AnimationsParamMut<_Graph>| {
-						AnimationsParamMut::get_context_mut(&mut p, WithoutAnimations { entity })
-							.is_some()
+						AnimationsParamMut::try_get_context_mut(
+							&mut p,
+							WithoutAnimations { entity },
+						)
+						.is_some()
 					})?;
 
 			assert!(!ctx);
@@ -166,7 +172,8 @@ mod tests {
 			let ctx =
 				app.world_mut()
 					.run_system_once(move |mut p: AnimationsParamMut<_Graph>| {
-						AnimationsParamMut::get_context_mut(&mut p, Animations { entity }).is_some()
+						AnimationsParamMut::try_get_context_mut(&mut p, Animations { entity })
+							.is_some()
 					})?;
 
 			assert!(!ctx);
@@ -187,7 +194,8 @@ mod tests {
 			let ctx =
 				app.world_mut()
 					.run_system_once(move |mut p: AnimationsParamMut<_Graph>| {
-						AnimationsParamMut::get_context_mut(&mut p, Animations { entity }).is_some()
+						AnimationsParamMut::try_get_context_mut(&mut p, Animations { entity })
+							.is_some()
 					})?;
 
 			assert!(ctx);

--- a/src/plugins/animations/src/system_params/animations/active_animations.rs
+++ b/src/plugins/animations/src/system_params/animations/active_animations.rs
@@ -40,7 +40,7 @@ mod tests {
 	use common::{
 		tools::action_key::slot::SlotKey,
 		traits::{
-			accessors::get::GetContextMut,
+			accessors::get::TryGetContextMut,
 			handles_animations::{AnimationClips, Animations, SkillAnimation},
 		},
 	};
@@ -88,7 +88,7 @@ mod tests {
 		app.world_mut()
 			.run_system_once(move |mut p: AnimationsParamMut| {
 				let key = Animations { entity };
-				let mut ctx = AnimationsParamMut::get_context_mut(&mut p, key).unwrap();
+				let mut ctx = AnimationsParamMut::try_get_context_mut(&mut p, key).unwrap();
 				ctx.active_animations_mut(animation_priority)
 					.extend(animations);
 			})?;
@@ -123,7 +123,7 @@ mod tests {
 		app.world_mut()
 			.run_system_once(move |mut p: AnimationsParamMut| {
 				let key = Animations { entity };
-				let ctx = AnimationsParamMut::get_context_mut(&mut p, key).unwrap();
+				let ctx = AnimationsParamMut::try_get_context_mut(&mut p, key).unwrap();
 
 				assert_eq!(
 					&OrderedSet::from(animations),

--- a/src/plugins/animations/src/system_params/animations/get_forward_pitch.rs
+++ b/src/plugins/animations/src/system_params/animations/get_forward_pitch.rs
@@ -30,7 +30,7 @@ mod tests {
 		prelude::*,
 	};
 	use common::traits::{
-		accessors::get::GetContextMut,
+		accessors::get::TryGetContextMut,
 		handles_animations::{AnimationClips, Animations, ForwardPitch},
 	};
 	use testing::SingleThreadedApp;
@@ -61,7 +61,7 @@ mod tests {
 		app.world_mut()
 			.run_system_once(move |mut p: AnimationsParamMut| {
 				let key = Animations { entity };
-				let ctx = AnimationsParamMut::get_context_mut(&mut p, key).unwrap();
+				let ctx = AnimationsParamMut::try_get_context_mut(&mut p, key).unwrap();
 
 				assert_eq!(
 					Some(DirForwardPitch::Up(ForwardPitch::try_from(0.4).unwrap())),
@@ -85,7 +85,7 @@ mod tests {
 		app.world_mut()
 			.run_system_once(move |mut p: AnimationsParamMut| {
 				let key = Animations { entity };
-				let mut ctx = AnimationsParamMut::get_context_mut(&mut p, key).unwrap();
+				let mut ctx = AnimationsParamMut::try_get_context_mut(&mut p, key).unwrap();
 				*ctx.get_forward_pitch_mut() =
 					Some(DirForwardPitch::Up(ForwardPitch::try_from(0.4).unwrap()));
 			})?;

--- a/src/plugins/animations/src/system_params/animations/get_move_direction.rs
+++ b/src/plugins/animations/src/system_params/animations/get_move_direction.rs
@@ -32,7 +32,7 @@ mod tests {
 		ecs::system::{RunSystemError, RunSystemOnce},
 	};
 	use common::traits::{
-		accessors::get::GetContextMut,
+		accessors::get::TryGetContextMut,
 		handles_animations::{AnimationClips, Animations},
 	};
 	use testing::SingleThreadedApp;
@@ -61,7 +61,7 @@ mod tests {
 		app.world_mut()
 			.run_system_once(move |mut p: AnimationsParamMut| {
 				let key = Animations { entity };
-				let ctx = AnimationsParamMut::get_context_mut(&mut p, key).unwrap();
+				let ctx = AnimationsParamMut::try_get_context_mut(&mut p, key).unwrap();
 
 				assert_eq!(Some(Dir3::NEG_Z), ctx.get_move_direction());
 			})
@@ -82,7 +82,7 @@ mod tests {
 		app.world_mut()
 			.run_system_once(move |mut p: AnimationsParamMut| {
 				let key = Animations { entity };
-				let mut ctx = AnimationsParamMut::get_context_mut(&mut p, key).unwrap();
+				let mut ctx = AnimationsParamMut::try_get_context_mut(&mut p, key).unwrap();
 				*ctx.get_move_direction_mut() = Some(Dir3::NEG_Z);
 			})?;
 

--- a/src/plugins/animations/src/system_params/animations/register_animations.rs
+++ b/src/plugins/animations/src/system_params/animations/register_animations.rs
@@ -66,7 +66,7 @@ mod tests {
 		bit_mask_index,
 		tools::{action_key::slot::SlotKey, bone_name::BoneName},
 		traits::{
-			accessors::get::GetContextMut,
+			accessors::get::TryGetContextMut,
 			handles_animations::{
 				AffectedAnimationBones,
 				AnimationClips,
@@ -146,7 +146,7 @@ mod tests {
 		app.world_mut()
 			.run_system_once(move |mut p: AnimationsParamMut<_Graph>| {
 				let key = WithoutAnimations { entity };
-				let mut ctx = AnimationsParamMut::get_context_mut(&mut p, key).unwrap();
+				let mut ctx = AnimationsParamMut::try_get_context_mut(&mut p, key).unwrap();
 				ctx.register_animations(&HashMap::default(), &HashMap::default());
 			})?;
 
@@ -162,7 +162,7 @@ mod tests {
 		app.world_mut()
 			.run_system_once(move |mut p: AnimationsParamMut<_Graph>| {
 				let key = WithoutAnimations { entity };
-				let mut ctx = AnimationsParamMut::get_context_mut(&mut p, key).unwrap();
+				let mut ctx = AnimationsParamMut::try_get_context_mut(&mut p, key).unwrap();
 				ctx.register_animations(&HashMap::default(), &HashMap::default());
 			})?;
 
@@ -181,7 +181,7 @@ mod tests {
 		app.world_mut()
 			.run_system_once(move |mut p: AnimationsParamMut<_Graph>| {
 				let key = WithoutAnimations { entity };
-				let mut ctx = AnimationsParamMut::get_context_mut(&mut p, key).unwrap();
+				let mut ctx = AnimationsParamMut::try_get_context_mut(&mut p, key).unwrap();
 				let a = Animation {
 					clips: AnimationClips::Single(CLIP_A.clone()),
 					play_mode: PlayMode::Repeat,
@@ -259,7 +259,7 @@ mod tests {
 		app.world_mut()
 			.run_system_once(move |mut p: AnimationsParamMut<_Graph>| {
 				let key = WithoutAnimations { entity };
-				let mut ctx = AnimationsParamMut::get_context_mut(&mut p, key).unwrap();
+				let mut ctx = AnimationsParamMut::try_get_context_mut(&mut p, key).unwrap();
 				let a = Animation {
 					clips: AnimationClips::Single(CLIP_A.clone()),
 					play_mode: PlayMode::Repeat,

--- a/src/plugins/common/src/systems/register_animations.rs
+++ b/src/plugins/common/src/systems/register_animations.rs
@@ -2,7 +2,7 @@ use crate::{
 	components::gltf::GltfLookup,
 	errors::{ErrorData, Level, Unreachable},
 	traits::{
-		accessors::get::{GetContextMut, TryApplyOn, View},
+		accessors::get::{TryApplyOn, TryGetContextMut, View},
 		handles_animations::{
 			AffectedAnimationBones,
 			Animation,
@@ -45,13 +45,13 @@ pub trait RegisterAnimationsSystem: AnimationsMarker + Sized {
 	) -> Result<(), Vec<RegisterAnimationsError<Self>>>
 	where
 		TAnimations: SystemParam
-			+ for<'c> GetContextMut<WithoutAnimations, TContext<'c>: RegisterAnimations>,
+			+ for<'c> TryGetContextMut<WithoutAnimations, TContext<'c>: RegisterAnimations>,
 	{
 		let mut errors = vec![];
 
 		for (entity, config, gltf) in agents {
 			let key = WithoutAnimations { entity };
-			let Some(mut ctx) = TAnimations::get_context_mut(&mut animations, key) else {
+			let Some(mut ctx) = TAnimations::try_get_context_mut(&mut animations, key) else {
 				continue;
 			};
 

--- a/src/plugins/common/src/traits/accessors/get.rs
+++ b/src/plugins/common/src/traits/accessors/get.rs
@@ -40,16 +40,16 @@ pub trait ContextChanged {
 /// Retrieve a context for data inspection.
 ///
 /// It is up to the implementor, what kind of system parameters are involved.
-pub trait GetContext<TKey>: SystemParam + ThreadSafe {
+pub trait TryGetContext<TKey>: SystemParam + ThreadSafe {
 	type TContext<'ctx>: ContextChanged;
 
-	fn get_context<'ctx>(
+	fn try_get_context<'ctx>(
 		param: &'ctx SystemParamItem<Self>,
 		key: TKey,
 	) -> Option<Self::TContext<'ctx>>;
 }
 
-pub trait GetChangedContext<TKey>: GetContext<TKey> {
+pub trait GetChangedContext<TKey>: TryGetContext<TKey> {
 	fn get_changed_context<'ctx>(
 		param: &'ctx SystemParamItem<Self>,
 		key: TKey,
@@ -58,13 +58,13 @@ pub trait GetChangedContext<TKey>: GetContext<TKey> {
 
 impl<T, TKey> GetChangedContext<TKey> for T
 where
-	T: GetContext<TKey>,
+	T: TryGetContext<TKey>,
 {
 	fn get_changed_context<'ctx>(
 		param: &'ctx SystemParamItem<Self>,
 		key: TKey,
 	) -> Option<Self::TContext<'ctx>> {
-		match T::get_context(param, key) {
+		match T::try_get_context(param, key) {
 			Some(ctx) if ctx.context_changed() => Some(ctx),
 			_ => None,
 		}
@@ -82,28 +82,28 @@ pub trait GetMut<TKey> {
 /// Retrieve a context for data mutation.
 ///
 /// It is up to the implementor, what kind of system parameters are involved.
-pub trait GetContextMut<TKey>: SystemParam + ThreadSafe {
+pub trait TryGetContextMut<TKey>: SystemParam + ThreadSafe {
 	type TContext<'ctx>;
 
-	fn get_context_mut<'ctx>(
+	fn try_get_context_mut<'ctx>(
 		param: &'ctx mut SystemParamItem<Self>,
 		key: TKey,
 	) -> Option<Self::TContext<'ctx>>;
 }
 
-impl<T, TKey> GetContext<Logged<TKey>> for T
+impl<T, TKey> TryGetContext<Logged<TKey>> for T
 where
-	T: GetContext<TKey>,
+	T: TryGetContext<TKey>,
 	TKey: View<Entity>,
 {
 	type TContext<'ctx> = T::TContext<'ctx>;
 
-	fn get_context<'ctx>(
+	fn try_get_context<'ctx>(
 		param: &'ctx SystemParamItem<Self>,
 		Logged { key, level }: Logged<TKey>,
 	) -> Option<Self::TContext<'ctx>> {
 		let entity = key.view();
-		let ctx = T::get_context(param, key);
+		let ctx = T::try_get_context(param, key);
 
 		if ctx.is_none() {
 			output::log(MissingContext {
@@ -117,19 +117,19 @@ where
 	}
 }
 
-impl<T, TKey> GetContextMut<Logged<TKey>> for T
+impl<T, TKey> TryGetContextMut<Logged<TKey>> for T
 where
-	T: GetContextMut<TKey>,
+	T: TryGetContextMut<TKey>,
 	TKey: View<Entity>,
 {
 	type TContext<'ctx> = T::TContext<'ctx>;
 
-	fn get_context_mut<'ctx>(
+	fn try_get_context_mut<'ctx>(
 		param: &'ctx mut SystemParamItem<Self>,
 		Logged { key, level }: Logged<TKey>,
 	) -> Option<Self::TContext<'ctx>> {
 		let entity = key.view();
-		let ctx = T::get_context_mut(param, key);
+		let ctx = T::try_get_context_mut(param, key);
 
 		if ctx.is_none() {
 			output::log(MissingContext {

--- a/src/plugins/common/src/traits/accessors/get/components.rs
+++ b/src/plugins/common/src/traits/accessors/get/components.rs
@@ -1,4 +1,4 @@
-use crate::traits::accessors::get::{ContextChanged, GetContext, GetContextMut, View};
+use crate::traits::accessors::get::{ContextChanged, TryGetContext, TryGetContextMut, View};
 use bevy::{ecs::component::Mutable, prelude::*};
 
 impl<T> ContextChanged for Ref<'_, T>
@@ -10,26 +10,29 @@ where
 	}
 }
 
-impl<T, TKey> GetContext<TKey> for Query<'static, 'static, Ref<'static, T>>
+impl<T, TKey> TryGetContext<TKey> for Query<'static, 'static, Ref<'static, T>>
 where
 	T: Component,
 	TKey: View<Entity>,
 {
 	type TContext<'ctx> = Ref<'ctx, T>;
 
-	fn get_context<'ctx>(query: &'ctx Query<Ref<T>>, key: TKey) -> Option<Self::TContext<'ctx>> {
+	fn try_get_context<'ctx>(
+		query: &'ctx Query<Ref<T>>,
+		key: TKey,
+	) -> Option<Self::TContext<'ctx>> {
 		query.get(key.view()).ok()
 	}
 }
 
-impl<T, TKey> GetContextMut<TKey> for Query<'static, 'static, Mut<'static, T>>
+impl<T, TKey> TryGetContextMut<TKey> for Query<'static, 'static, Mut<'static, T>>
 where
 	T: Component<Mutability = Mutable>,
 	TKey: View<Entity>,
 {
 	type TContext<'ctx> = Mut<'ctx, T>;
 
-	fn get_context_mut<'ctx>(
+	fn try_get_context_mut<'ctx>(
 		query: &'ctx mut Query<Mut<T>>,
 		key: TKey,
 	) -> Option<Self::TContext<'ctx>> {
@@ -37,14 +40,14 @@ where
 	}
 }
 
-impl<T, TKey> GetContextMut<TKey> for Query<'static, 'static, &'static mut T>
+impl<T, TKey> TryGetContextMut<TKey> for Query<'static, 'static, &'static mut T>
 where
 	T: Component<Mutability = Mutable>,
 	TKey: View<Entity>,
 {
 	type TContext<'ctx> = Mut<'ctx, T>;
 
-	fn get_context_mut<'ctx>(
+	fn try_get_context_mut<'ctx>(
 		query: &'ctx mut Query<&mut T>,
 
 		key: TKey,

--- a/src/plugins/common/src/traits/handles_animations.rs
+++ b/src/plugins/common/src/traits/handles_animations.rs
@@ -3,7 +3,7 @@ mod priority_order;
 use crate::{
 	tools::{action_key::slot::SlotKey, bone_name::BoneName},
 	traits::{
-		accessors::get::GetContextMut,
+		accessors::get::TryGetContextMut,
 		handles_animations::priority_order::DescendingAnimationPriorities,
 	},
 };
@@ -20,10 +20,10 @@ use zyheeda_core::prelude::*;
 
 pub trait HandlesAnimations {
 	type TAnimationsMut: SystemParam
-		+ for<'c> GetContextMut<WithoutAnimations, TContext<'c>: RegisterAnimations>
-		+ for<'c> GetContextMut<Animations, TContext<'c>: ActiveAnimationsMut>
-		+ for<'c> GetContextMut<Animations, TContext<'c>: GetMoveDirectionMut>
-		+ for<'c> GetContextMut<Animations, TContext<'c>: GetForwardPitchMut>;
+		+ for<'c> TryGetContextMut<WithoutAnimations, TContext<'c>: RegisterAnimations>
+		+ for<'c> TryGetContextMut<Animations, TContext<'c>: ActiveAnimationsMut>
+		+ for<'c> TryGetContextMut<Animations, TContext<'c>: GetMoveDirectionMut>
+		+ for<'c> TryGetContextMut<Animations, TContext<'c>: GetForwardPitchMut>;
 }
 
 #[derive(EntityKey)]

--- a/src/plugins/common/src/traits/handles_loadout.rs
+++ b/src/plugins/common/src/traits/handles_loadout.rs
@@ -11,7 +11,7 @@ use crate::{
 		inventory_key::InventoryKey,
 	},
 	traits::{
-		accessors::get::{GetContext, GetContextMut},
+		accessors::get::{TryGetContext, TryGetContextMut},
 		handles_animations::SkillAnimation,
 		handles_loadout::{
 			available_skills::{AvailableSkills, ReadAvailableSkills},
@@ -35,25 +35,25 @@ pub trait HandlesLoadout {
 	type TSkillID: Debug + PartialEq + Copy + ThreadSafe;
 
 	type TLoadoutPrep: SystemParam
-		+ for<'c> GetContextMut<NotLoadedOut, TContext<'c>: InsertDefaultLoadout>
-		+ for<'c> GetContextMut<NoBonesRegistered, TContext<'c>: RegisterLoadoutBones>;
+		+ for<'c> TryGetContextMut<NotLoadedOut, TContext<'c>: InsertDefaultLoadout>
+		+ for<'c> TryGetContextMut<NoBonesRegistered, TContext<'c>: RegisterLoadoutBones>;
 
 	type TLoadout: SystemParam
-		+ for<'c> GetContext<Items, TContext<'c>: ReadItems>
-		+ for<'c> GetContext<Skills, TContext<'c>: ReadSkills>
-		+ for<'c> GetContext<Combos, TContext<'c>: ReadCombos<Self::TSkillID>>
-		+ for<'c> GetContext<AvailableSkills, TContext<'c>: ReadAvailableSkills<Self::TSkillID>>;
+		+ for<'c> TryGetContext<Items, TContext<'c>: ReadItems>
+		+ for<'c> TryGetContext<Skills, TContext<'c>: ReadSkills>
+		+ for<'c> TryGetContext<Combos, TContext<'c>: ReadCombos<Self::TSkillID>>
+		+ for<'c> TryGetContext<AvailableSkills, TContext<'c>: ReadAvailableSkills<Self::TSkillID>>;
 
 	type TLoadoutMut: SystemParam
-		+ for<'c> GetContextMut<Items, TContext<'c>: SwapItems>
-		+ for<'c> GetContextMut<Combos, TContext<'c>: UpdateCombos<Self::TSkillID>>;
+		+ for<'c> TryGetContextMut<Items, TContext<'c>: SwapItems>
+		+ for<'c> TryGetContextMut<Combos, TContext<'c>: UpdateCombos<Self::TSkillID>>;
 
 	type TLoadoutActivity: SystemParam
-		+ for<'c> GetContext<Skills, TContext<'c>: ActiveSkills>
-		+ for<'c> GetContext<Skills, TContext<'c>: HeldSkills>;
+		+ for<'c> TryGetContext<Skills, TContext<'c>: ActiveSkills>
+		+ for<'c> TryGetContext<Skills, TContext<'c>: HeldSkills>;
 
 	type TLoadoutActivityMut: SystemParam
-		+ for<'c> GetContextMut<Skills, TContext<'c>: HeldSkillsMut>;
+		+ for<'c> TryGetContextMut<Skills, TContext<'c>: HeldSkillsMut>;
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]

--- a/src/plugins/common/src/traits/handles_map_generation.rs
+++ b/src/plugins/common/src/traits/handles_map_generation.rs
@@ -2,7 +2,7 @@ use super::thread_safe::ThreadSafe;
 use crate::{
 	tools::Units,
 	traits::{
-		accessors::get::{GetContextMut, View, ViewField},
+		accessors::get::{TryGetContextMut, View, ViewField},
 		handles_enemies::EnemyType,
 		system_set_definition::SystemSetDefinition,
 	},
@@ -19,8 +19,11 @@ use std::{
 
 pub trait HandlesMapGeneration: SystemSetDefinition {
 	type TMapPrefabs: SystemParam
-		+ for<'c> GetContextMut<MapPrefabs<AgentType>, TContext<'c>: SetPrefab<AgentType>>
-		+ for<'c> GetContextMut<MapPrefabs<InteractiveType>, TContext<'c>: SetPrefab<InteractiveType>>;
+		+ for<'c> TryGetContextMut<MapPrefabs<AgentType>, TContext<'c>: SetPrefab<AgentType>>
+		+ for<'c> TryGetContextMut<
+			MapPrefabs<InteractiveType>,
+			TContext<'c>: SetPrefab<InteractiveType>,
+		>;
 
 	type TGraph: Graph + for<'a> From<&'a Self::TMap> + ThreadSafe;
 

--- a/src/plugins/common/src/traits/handles_movement.rs
+++ b/src/plugins/common/src/traits/handles_movement.rs
@@ -1,7 +1,7 @@
 use crate::{
 	tools::{Units, UnitsPerSecond},
 	traits::{
-		accessors::get::{GetContext, GetContextMut, View, ViewField},
+		accessors::get::{TryGetContext, TryGetContextMut, View, ViewField},
 		system_set_definition::SystemSetDefinition,
 	},
 };
@@ -11,11 +11,11 @@ use serde::{Deserialize, Serialize};
 use std::ops::DerefMut;
 
 pub trait HandlesMovement: SystemSetDefinition {
-	type TMovement: SystemParam + for<'c> GetContext<Movement, TContext<'c>: CurrentMovement>;
+	type TMovement: SystemParam + for<'c> TryGetContext<Movement, TContext<'c>: CurrentMovement>;
 	type TMovementMut: SystemParam
-		+ for<'c> GetContextMut<ConfiguredMovement, TContext<'c>: ControlMovement>;
+		+ for<'c> TryGetContextMut<ConfiguredMovement, TContext<'c>: ControlMovement>;
 	type TMovementConfig: SystemParam
-		+ for<'c> GetContextMut<NotConfiguredMovement, TContext<'c>: ConfigureMovement>;
+		+ for<'c> TryGetContextMut<NotConfiguredMovement, TContext<'c>: ConfigureMovement>;
 }
 
 pub trait ControlMovement: StartMovement + StopMovement + ToggleSpeed + CurrentMovement {}

--- a/src/plugins/common/src/traits/handles_orientation.rs
+++ b/src/plugins/common/src/traits/handles_orientation.rs
@@ -1,6 +1,6 @@
 use crate::{
 	components::persistent_entity::PersistentEntity,
-	traits::accessors::get::GetContextMut,
+	traits::accessors::get::TryGetContextMut,
 };
 use bevy::{ecs::system::SystemParam, prelude::*};
 use macros::EntityKey;
@@ -8,7 +8,8 @@ use serde::{Deserialize, Serialize};
 use std::ops::DerefMut;
 
 pub trait HandlesOrientation {
-	type TFaceSystemParam: SystemParam + for<'c> GetContextMut<Facing, TContext<'c>: OverrideFace>;
+	type TFaceSystemParam: SystemParam
+		+ for<'c> TryGetContextMut<Facing, TContext<'c>: OverrideFace>;
 }
 
 #[derive(EntityKey)]

--- a/src/plugins/common/src/traits/handles_physics.rs
+++ b/src/plugins/common/src/traits/handles_physics.rs
@@ -6,7 +6,7 @@ use crate::{
 	toi,
 	tools::{Units, speed::Speed},
 	traits::{
-		accessors::get::{GetContext, GetContextMut, View, ViewField},
+		accessors::get::{TryGetContext, TryGetContextMut, View, ViewField},
 		handles_physics::physical_bodies::{Blocker, BodyConfig},
 	},
 };
@@ -55,8 +55,8 @@ pub trait RaycastResult {
 
 pub trait HandlesPhysicsConfig {
 	type TConfigMut: SystemParam
-		+ for<'c> GetContextMut<NoDefaultAttributes, TContext<'c>: ConfigureDefaultAttributes>
-		+ for<'c> GetContextMut<NoBodyConfigured, TContext<'c>: ConfigureBody>;
+		+ for<'c> TryGetContextMut<NoDefaultAttributes, TContext<'c>: ConfigureDefaultAttributes>
+		+ for<'c> TryGetContextMut<NoBodyConfigured, TContext<'c>: ConfigureBody>;
 }
 
 #[derive(EntityKey)]
@@ -110,7 +110,7 @@ impl TranslationOffsets {
 
 pub trait HandlesInteractiveDetection {
 	type TInteractive: SystemParam
-		+ for<'c> GetContext<IsInteracting, TContext<'c>: IterInteractions>;
+		+ for<'c> TryGetContext<IsInteracting, TContext<'c>: IterInteractions>;
 }
 
 #[derive(EntityKey)]

--- a/src/plugins/common/src/traits/handles_skill_physics.rs
+++ b/src/plugins/common/src/traits/handles_skill_physics.rs
@@ -8,7 +8,7 @@ use crate::{
 	effects::{force::Force, gravity::Gravity, health_damage::HealthDamage},
 	tools::{action_key::slot::SlotKey, bone_name::BoneName},
 	traits::{
-		accessors::get::{GetContext, GetContextMut},
+		accessors::get::{TryGetContext, TryGetContextMut},
 		handles_skill_physics::{
 			beam::Beam,
 			ground_target::SphereAoE,
@@ -74,10 +74,10 @@ where
 }
 
 pub trait HandlesPhysicalSkillAgent {
-	type TAgent: SystemParam + for<'c> GetContext<InitializedAgent, TContext<'c>: Target>;
+	type TAgent: SystemParam + for<'c> TryGetContext<InitializedAgent, TContext<'c>: Target>;
 	type TAgentMut: SystemParam
-		+ for<'c> GetContextMut<NotInitializedAgent, TContext<'c>: Initialize>
-		+ for<'c> GetContextMut<InitializedAgent, TContext<'c>: TargetMut>;
+		+ for<'c> TryGetContextMut<NotInitializedAgent, TContext<'c>: Initialize>
+		+ for<'c> TryGetContextMut<InitializedAgent, TContext<'c>: TargetMut>;
 }
 
 #[derive(EntityKey)]

--- a/src/plugins/interactive/src/components/interactive.rs
+++ b/src/plugins/interactive/src/components/interactive.rs
@@ -2,7 +2,7 @@ use bevy::{ecs::system::StaticSystemParam, prelude::*};
 use common::{
 	errors::{ErrorData, Level},
 	traits::{
-		accessors::get::GetContextMut,
+		accessors::get::TryGetContextMut,
 		handles_map_generation::{InteractiveType, MapPrefabs, SetPrefab},
 	},
 	zyheeda_commands::ZyheedaEntityCommands,
@@ -40,12 +40,13 @@ impl Interactive {
 		mut new_agent: StaticSystemParam<TNewMapAgent>,
 	) -> Result<(), NoPrefabContext>
 	where
-		TNewMapAgent: for<'c> GetContextMut<
+		TNewMapAgent: for<'c> TryGetContextMut<
 				MapPrefabs<InteractiveType>,
 				TContext<'c>: SetPrefab<InteractiveType>,
 			>,
 	{
-		let Some(mut ctx) = TNewMapAgent::get_context_mut(&mut new_agent, MapPrefabs::KEY) else {
+		let Some(mut ctx) = TNewMapAgent::try_get_context_mut(&mut new_agent, MapPrefabs::KEY)
+		else {
 			return Err(NoPrefabContext);
 		};
 

--- a/src/plugins/interactive/src/systems/animate_door.rs
+++ b/src/plugins/interactive/src/systems/animate_door.rs
@@ -1,7 +1,7 @@
 use crate::components::door::Door;
 use bevy::{ecs::system::StaticSystemParam, prelude::*};
 use common::traits::{
-	accessors::get::{GetContext, GetContextMut},
+	accessors::get::{TryGetContext, TryGetContextMut},
 	handles_animations::{ActiveAnimationsMut, AnimationKey, AnimationPriority, Animations},
 	handles_physics::{IsInteracting, IterInteractions},
 };
@@ -13,15 +13,16 @@ impl Door {
 		interactions: StaticSystemParam<TInteractions>,
 		mut animations: StaticSystemParam<TAnimations>,
 	) where
-		TInteractions: for<'c> GetContext<IsInteracting, TContext<'c>: IterInteractions>,
-		TAnimations: for<'c> GetContextMut<Animations, TContext<'c>: ActiveAnimationsMut>,
+		TInteractions: for<'c> TryGetContext<IsInteracting, TContext<'c>: IterInteractions>,
+		TAnimations: for<'c> TryGetContextMut<Animations, TContext<'c>: ActiveAnimationsMut>,
 	{
 		for entity in doors {
 			let key = IsInteracting { entity };
-			let interactions = TInteractions::get_context(&interactions, key);
+			let interactions = TInteractions::try_get_context(&interactions, key);
 
 			let key = Animations { entity };
-			let Some(mut animations) = TAnimations::get_context_mut(&mut animations, key) else {
+			let Some(mut animations) = TAnimations::try_get_context_mut(&mut animations, key)
+			else {
 				continue;
 			};
 

--- a/src/plugins/interactive/src/systems/apply_door_frame.rs
+++ b/src/plugins/interactive/src/systems/apply_door_frame.rs
@@ -5,7 +5,7 @@ use crate::{
 use bevy::{ecs::system::StaticSystemParam, prelude::*};
 use common::{
 	traits::{
-		accessors::get::{GetContextMut, TryApplyOn},
+		accessors::get::{TryApplyOn, TryGetContextMut},
 		handles_physics::{
 			ConfigureBody,
 			NoBodyConfigured,
@@ -23,7 +23,7 @@ impl ApplyDoorFrame {
 		mut commands: ZyheedaCommands,
 		mut body: StaticSystemParam<TBody>,
 	) where
-		TBody: for<'c> GetContextMut<NoBodyConfigured, TContext<'c>: ConfigureBody>,
+		TBody: for<'c> TryGetContextMut<NoBodyConfigured, TContext<'c>: ConfigureBody>,
 	{
 		for (entity, handle) in doors {
 			let Some(meta) = assets.get(handle) else {
@@ -35,7 +35,7 @@ impl ApplyDoorFrame {
 			});
 
 			let key = NoBodyConfigured { entity };
-			let Some(mut ctx) = TBody::get_context_mut(&mut body, key) else {
+			let Some(mut ctx) = TBody::try_get_context_mut(&mut body, key) else {
 				continue;
 			};
 

--- a/src/plugins/loadout/src/system_parameters/loadout/read/available_skills.rs
+++ b/src/plugins/loadout/src/system_parameters/loadout/read/available_skills.rs
@@ -8,7 +8,7 @@ use bevy::prelude::*;
 use common::{
 	tools::action_key::slot::SlotKey,
 	traits::{
-		accessors::get::{ContextChanged, GetContext, View},
+		accessors::get::{ContextChanged, TryGetContext, View},
 		handles_loadout::{
 			available_skills::{AvailableSkills, ReadAvailableSkills},
 			skills::{GetSkillId, SkillIcon, SkillToken},
@@ -17,10 +17,10 @@ use common::{
 	},
 };
 
-impl GetContext<AvailableSkills> for LoadoutReader<'static, 'static> {
+impl TryGetContext<AvailableSkills> for LoadoutReader<'static, 'static> {
 	type TContext<'ctx> = AvailableSkillsView<'ctx>;
 
-	fn get_context<'ctx>(
+	fn try_get_context<'ctx>(
 		param: &'ctx LoadoutReader,
 		AvailableSkills { entity }: AvailableSkills,
 	) -> Option<Self::TContext<'ctx>> {
@@ -213,8 +213,8 @@ mod tests {
 
 			app.world_mut()
 				.run_system_once(move |loadout: LoadoutReader| {
-					let ctx =
-						LoadoutReader::get_context(&loadout, AvailableSkills { entity }).unwrap();
+					let ctx = LoadoutReader::try_get_context(&loadout, AvailableSkills { entity })
+						.unwrap();
 					let skills = ctx.get_available_skills(SlotKey(44));
 
 					assert_eq_unordered!(

--- a/src/plugins/loadout/src/system_parameters/loadout/read/combos.rs
+++ b/src/plugins/loadout/src/system_parameters/loadout/read/combos.rs
@@ -3,7 +3,7 @@ use bevy::prelude::*;
 use common::{
 	tools::action_key::slot::SlotKey,
 	traits::{
-		accessors::get::{ContextChanged, GetContext},
+		accessors::get::{ContextChanged, TryGetContext},
 		handles_loadout::combos::{
 			Combo,
 			Combos as CombosMarker,
@@ -14,10 +14,10 @@ use common::{
 };
 use std::{collections::HashSet, ops::Deref};
 
-impl GetContext<CombosMarker> for LoadoutReader<'static, 'static> {
+impl TryGetContext<CombosMarker> for LoadoutReader<'static, 'static> {
 	type TContext<'ctx> = CombosView<'ctx>;
 
-	fn get_context<'ctx>(
+	fn try_get_context<'ctx>(
 		param: &'ctx LoadoutReader,
 		CombosMarker { entity }: CombosMarker,
 	) -> Option<Self::TContext<'ctx>> {
@@ -110,7 +110,7 @@ mod tests {
 
 		app.world_mut().run_system_once(
 			move |loadout: LoadoutReader, combos: Query<Ref<Combos>>| {
-				let ctx = LoadoutReader::get_context(&loadout, CombosMarker { entity });
+				let ctx = LoadoutReader::try_get_context(&loadout, CombosMarker { entity });
 				let combos = combos.get(entity).unwrap();
 
 				assert_eq!(Some(CombosView { combos }), ctx);

--- a/src/plugins/loadout/src/system_parameters/loadout/read/items.rs
+++ b/src/plugins/loadout/src/system_parameters/loadout/read/items.rs
@@ -7,7 +7,7 @@ use bevy::prelude::*;
 use common::{
 	tools::inventory_key::InventoryKey,
 	traits::{
-		accessors::get::{ContextChanged, GetContext, View},
+		accessors::get::{ContextChanged, TryGetContext, View},
 		handles_loadout::{
 			LoadoutKey,
 			items::{ItemToken, Items, ReadItems},
@@ -16,10 +16,10 @@ use common::{
 	},
 };
 
-impl GetContext<Items> for LoadoutReader<'static, 'static> {
+impl TryGetContext<Items> for LoadoutReader<'static, 'static> {
 	type TContext<'ctx> = ItemsView<'ctx>;
 
-	fn get_context<'ctx>(
+	fn try_get_context<'ctx>(
 		param: &'ctx LoadoutReader,
 		Items { entity }: Items,
 	) -> Option<Self::TContext<'ctx>> {
@@ -125,7 +125,7 @@ mod tests {
 
 			app.world_mut()
 				.run_system_once(move |loadout: LoadoutReader| {
-					let ctx = LoadoutReader::get_context(&loadout, Items { entity }).unwrap();
+					let ctx = LoadoutReader::try_get_context(&loadout, Items { entity }).unwrap();
 					let item = ctx.get_item(SlotKey(11));
 
 					assert_eq!(
@@ -157,7 +157,7 @@ mod tests {
 
 			app.world_mut()
 				.run_system_once(move |loadout: LoadoutReader| {
-					let ctx = LoadoutReader::get_context(&loadout, Items { entity }).unwrap();
+					let ctx = LoadoutReader::try_get_context(&loadout, Items { entity }).unwrap();
 					let item = ctx.get_item(InventoryKey(3));
 
 					assert_eq!(

--- a/src/plugins/loadout/src/system_parameters/loadout/read/skills.rs
+++ b/src/plugins/loadout/src/system_parameters/loadout/read/skills.rs
@@ -9,7 +9,7 @@ use bevy::prelude::*;
 use common::{
 	tools::{inventory_key::InventoryKey, skill_execution::SkillExecution},
 	traits::{
-		accessors::get::{ContextChanged, GetContext, View},
+		accessors::get::{ContextChanged, TryGetContext, View},
 		handles_loadout::{
 			LoadoutKey,
 			skills::{ReadSkills, SkillIcon, SkillToken, Skills},
@@ -19,10 +19,10 @@ use common::{
 };
 use zyheeda_core::prelude::*;
 
-impl GetContext<Skills> for LoadoutReader<'static, 'static> {
+impl TryGetContext<Skills> for LoadoutReader<'static, 'static> {
 	type TContext<'ctx> = SkillsView<'ctx>;
 
-	fn get_context<'ctx>(
+	fn try_get_context<'ctx>(
 		param: &'ctx LoadoutReader,
 		Skills { entity }: Skills,
 	) -> Option<Self::TContext<'ctx>> {
@@ -205,7 +205,7 @@ mod tests {
 
 			app.world_mut()
 				.run_system_once(move |loadout: LoadoutReader| {
-					let ctx = LoadoutReader::get_context(&loadout, Skills { entity }).unwrap();
+					let ctx = LoadoutReader::try_get_context(&loadout, Skills { entity }).unwrap();
 					let item = ctx.get_skill(InventoryKey(3));
 
 					assert_eq!(
@@ -246,7 +246,7 @@ mod tests {
 
 			app.world_mut()
 				.run_system_once(move |loadout: LoadoutReader| {
-					let ctx = LoadoutReader::get_context(&loadout, Skills { entity }).unwrap();
+					let ctx = LoadoutReader::try_get_context(&loadout, Skills { entity }).unwrap();
 					let item = ctx.get_skill(SlotKey(11));
 
 					assert_eq!(
@@ -302,7 +302,7 @@ mod tests {
 
 			app.world_mut()
 				.run_system_once(move |loadout: LoadoutReader| {
-					let ctx = LoadoutReader::get_context(&loadout, Skills { entity }).unwrap();
+					let ctx = LoadoutReader::try_get_context(&loadout, Skills { entity }).unwrap();
 					let item = ctx.get_skill(SlotKey(11));
 
 					assert_eq!(
@@ -351,7 +351,7 @@ mod tests {
 
 			app.world_mut()
 				.run_system_once(move |loadout: LoadoutReader| {
-					let ctx = LoadoutReader::get_context(&loadout, Skills { entity }).unwrap();
+					let ctx = LoadoutReader::try_get_context(&loadout, Skills { entity }).unwrap();
 					let item = ctx.get_skill(SlotKey(11));
 
 					assert_eq!(
@@ -411,7 +411,7 @@ mod tests {
 
 			app.world_mut()
 				.run_system_once(move |loadout: LoadoutReader| {
-					let ctx = LoadoutReader::get_context(&loadout, Skills { entity }).unwrap();
+					let ctx = LoadoutReader::try_get_context(&loadout, Skills { entity }).unwrap();
 					let item = ctx.get_skill(SlotKey(11));
 
 					assert_eq!(
@@ -465,7 +465,7 @@ mod tests {
 
 			app.world_mut()
 				.run_system_once(move |loadout: LoadoutReader| {
-					let ctx = LoadoutReader::get_context(&loadout, Skills { entity }).unwrap();
+					let ctx = LoadoutReader::try_get_context(&loadout, Skills { entity }).unwrap();
 					let item = ctx.get_skill(SlotKey(11));
 
 					assert_eq!(

--- a/src/plugins/loadout/src/system_parameters/loadout/write/combos.rs
+++ b/src/plugins/loadout/src/system_parameters/loadout/write/combos.rs
@@ -8,15 +8,15 @@ use bevy::prelude::*;
 use common::{
 	tools::action_key::slot::SlotKey,
 	traits::{
-		accessors::get::GetContextMut,
+		accessors::get::TryGetContextMut,
 		handles_loadout::combos::{Combo, Combos as CombosMarker, UpdateCombos},
 	},
 };
 
-impl GetContextMut<CombosMarker> for LoadoutWriter<'static, 'static> {
+impl TryGetContextMut<CombosMarker> for LoadoutWriter<'static, 'static> {
 	type TContext<'ctx> = CombosMut<'ctx>;
 
-	fn get_context_mut<'ctx>(
+	fn try_get_context_mut<'ctx>(
 		param: &'ctx mut LoadoutWriter,
 		CombosMarker { entity }: CombosMarker,
 	) -> Option<Self::TContext<'ctx>> {

--- a/src/plugins/loadout/src/system_parameters/loadout/write/insert_default_loadout.rs
+++ b/src/plugins/loadout/src/system_parameters/loadout/write/insert_default_loadout.rs
@@ -6,7 +6,7 @@ use bevy::prelude::*;
 use common::{
 	tools::inventory_key::InventoryKey,
 	traits::{
-		accessors::get::{GetContextMut, GetMut, TryApplyOn},
+		accessors::get::{GetMut, TryApplyOn, TryGetContextMut},
 		handles_loadout::{
 			LoadoutKey,
 			insert_default_loadout::{InsertDefaultLoadout, NotLoadedOut},
@@ -69,10 +69,10 @@ impl DefaultLoadout<'_> {
 	}
 }
 
-impl GetContextMut<NotLoadedOut> for LoadoutPrep<'static, 'static> {
+impl TryGetContextMut<NotLoadedOut> for LoadoutPrep<'static, 'static> {
 	type TContext<'ctx> = DefaultLoadout<'ctx>;
 
-	fn get_context_mut<'ctx>(
+	fn try_get_context_mut<'ctx>(
 		param: &'ctx mut LoadoutPrep,
 		NotLoadedOut { entity }: NotLoadedOut,
 	) -> Option<Self::TContext<'ctx>> {
@@ -141,7 +141,7 @@ mod tests {
 		app.world_mut()
 			.run_system_once(move |mut loadout: LoadoutPrep| {
 				let key = NotLoadedOut { entity };
-				let mut ctx = LoadoutPrep::get_context_mut(&mut loadout, key).unwrap();
+				let mut ctx = LoadoutPrep::try_get_context_mut(&mut loadout, key).unwrap();
 				ctx.insert_default_loadout([
 					(
 						LoadoutKey::from(InventoryKey(0)),
@@ -190,7 +190,7 @@ mod tests {
 		app.world_mut()
 			.run_system_once(move |mut loadout: LoadoutPrep| {
 				let key = NotLoadedOut { entity };
-				let mut ctx = LoadoutPrep::get_context_mut(&mut loadout, key).unwrap();
+				let mut ctx = LoadoutPrep::try_get_context_mut(&mut loadout, key).unwrap();
 				ctx.insert_default_loadout([
 					(
 						LoadoutKey::from(InventoryKey(3)),
@@ -226,7 +226,7 @@ mod tests {
 		let ctx_is_none = app
 			.world_mut()
 			.run_system_once(move |mut loadout: LoadoutPrep| {
-				LoadoutPrep::get_context_mut(&mut loadout, NotLoadedOut { entity }).is_none()
+				LoadoutPrep::try_get_context_mut(&mut loadout, NotLoadedOut { entity }).is_none()
 			})?;
 
 		assert!(ctx_is_none);
@@ -266,7 +266,7 @@ mod tests {
 		app.world_mut()
 			.run_system_once(move |mut loadout: LoadoutPrep| {
 				let key = NotLoadedOut { entity };
-				let mut ctx = LoadoutPrep::get_context_mut(&mut loadout, key).unwrap();
+				let mut ctx = LoadoutPrep::try_get_context_mut(&mut loadout, key).unwrap();
 				ctx.insert_default_loadout([
 					(LoadoutKey::from(SlotKey(2)), Some(ItemName::from("item_2"))),
 					(LoadoutKey::from(SlotKey(3)), Some(ItemName::from("item_3"))),
@@ -326,7 +326,7 @@ mod tests {
 		app.world_mut()
 			.run_system_once(move |mut loadout: LoadoutPrep| {
 				let key = NotLoadedOut { entity };
-				let mut ctx = LoadoutPrep::get_context_mut(&mut loadout, key).unwrap();
+				let mut ctx = LoadoutPrep::try_get_context_mut(&mut loadout, key).unwrap();
 				ctx.insert_default_loadout([
 					(
 						LoadoutKey::from(InventoryKey(2)),
@@ -364,7 +364,7 @@ mod tests {
 		app.world_mut()
 			.run_system_once(move |mut loadout: LoadoutPrep| {
 				let key = NotLoadedOut { entity };
-				let mut ctx = LoadoutPrep::get_context_mut(&mut loadout, key).unwrap();
+				let mut ctx = LoadoutPrep::try_get_context_mut(&mut loadout, key).unwrap();
 				ctx.insert_default_loadout([]);
 			})?;
 

--- a/src/plugins/loadout/src/system_parameters/loadout/write/items.rs
+++ b/src/plugins/loadout/src/system_parameters/loadout/write/items.rs
@@ -6,7 +6,7 @@ use bevy::prelude::*;
 use common::{
 	tools::inventory_key::InventoryKey,
 	traits::{
-		accessors::get::GetContextMut,
+		accessors::get::TryGetContextMut,
 		handles_loadout::{
 			LoadoutKey,
 			items::{Items, SwapItems},
@@ -14,10 +14,10 @@ use common::{
 	},
 };
 
-impl GetContextMut<Items> for LoadoutWriter<'static, 'static> {
+impl TryGetContextMut<Items> for LoadoutWriter<'static, 'static> {
 	type TContext<'ctx> = ItemsMut<'ctx>;
 
-	fn get_context_mut<'ctx>(
+	fn try_get_context_mut<'ctx>(
 		param: &'ctx mut LoadoutWriter,
 		Items { entity }: Items,
 	) -> Option<Self::TContext<'ctx>> {
@@ -126,7 +126,7 @@ mod tests {
 			app.world_mut()
 				.run_system_once(move |mut loadout: LoadoutWriter| {
 					let ctx =
-						LoadoutWriter::get_context_mut(&mut loadout, Items { entity }).unwrap();
+						LoadoutWriter::try_get_context_mut(&mut loadout, Items { entity }).unwrap();
 
 					assert_eq!(
 						(
@@ -160,7 +160,8 @@ mod tests {
 
 			app.world_mut()
 				.run_system_once(move |mut p: LoadoutWriter| {
-					let mut ctx = LoadoutWriter::get_context_mut(&mut p, Items { entity }).unwrap();
+					let mut ctx =
+						LoadoutWriter::try_get_context_mut(&mut p, Items { entity }).unwrap();
 					ctx.swap_items(InventoryKey(0), InventoryKey(1));
 				})?;
 
@@ -191,7 +192,8 @@ mod tests {
 
 			app.world_mut()
 				.run_system_once(move |mut p: LoadoutWriter| {
-					let mut ctx = LoadoutWriter::get_context_mut(&mut p, Items { entity }).unwrap();
+					let mut ctx =
+						LoadoutWriter::try_get_context_mut(&mut p, Items { entity }).unwrap();
 					ctx.swap_items(key_a, key_b);
 				})?;
 
@@ -222,7 +224,8 @@ mod tests {
 
 			app.world_mut()
 				.run_system_once(move |mut p: LoadoutWriter| {
-					let mut ctx = LoadoutWriter::get_context_mut(&mut p, Items { entity }).unwrap();
+					let mut ctx =
+						LoadoutWriter::try_get_context_mut(&mut p, Items { entity }).unwrap();
 					ctx.swap_items(key_a, key_b);
 				})?;
 
@@ -253,7 +256,8 @@ mod tests {
 
 			app.world_mut()
 				.run_system_once(move |mut p: LoadoutWriter| {
-					let mut ctx = LoadoutWriter::get_context_mut(&mut p, Items { entity }).unwrap();
+					let mut ctx =
+						LoadoutWriter::try_get_context_mut(&mut p, Items { entity }).unwrap();
 					ctx.swap_items(key_a, key_b);
 				})?;
 
@@ -283,7 +287,8 @@ mod tests {
 
 			app.world_mut()
 				.run_system_once(move |mut p: LoadoutWriter| {
-					let mut ctx = LoadoutWriter::get_context_mut(&mut p, Items { entity }).unwrap();
+					let mut ctx =
+						LoadoutWriter::try_get_context_mut(&mut p, Items { entity }).unwrap();
 					ctx.swap_items(SlotKey(11), SlotKey(42));
 				})?;
 
@@ -313,7 +318,8 @@ mod tests {
 
 			app.world_mut()
 				.run_system_once(move |mut p: LoadoutWriter| {
-					let mut ctx = LoadoutWriter::get_context_mut(&mut p, Items { entity }).unwrap();
+					let mut ctx =
+						LoadoutWriter::try_get_context_mut(&mut p, Items { entity }).unwrap();
 					ctx.swap_items(key_a, key_b);
 				})?;
 
@@ -347,7 +353,8 @@ mod tests {
 
 			app.world_mut()
 				.run_system_once(move |mut p: LoadoutWriter| {
-					let mut ctx = LoadoutWriter::get_context_mut(&mut p, Items { entity }).unwrap();
+					let mut ctx =
+						LoadoutWriter::try_get_context_mut(&mut p, Items { entity }).unwrap();
 					ctx.swap_items(key_a, key_b);
 				})?;
 
@@ -383,7 +390,8 @@ mod tests {
 
 			app.world_mut()
 				.run_system_once(move |mut p: LoadoutWriter| {
-					let mut ctx = LoadoutWriter::get_context_mut(&mut p, Items { entity }).unwrap();
+					let mut ctx =
+						LoadoutWriter::try_get_context_mut(&mut p, Items { entity }).unwrap();
 					ctx.swap_items(key_a, key_b);
 				})?;
 
@@ -419,7 +427,8 @@ mod tests {
 
 			app.world_mut()
 				.run_system_once(move |mut p: LoadoutWriter| {
-					let mut ctx = LoadoutWriter::get_context_mut(&mut p, Items { entity }).unwrap();
+					let mut ctx =
+						LoadoutWriter::try_get_context_mut(&mut p, Items { entity }).unwrap();
 					ctx.swap_items(key_a, key_b);
 				})?;
 
@@ -455,7 +464,8 @@ mod tests {
 
 			app.world_mut()
 				.run_system_once(move |mut p: LoadoutWriter| {
-					let mut ctx = LoadoutWriter::get_context_mut(&mut p, Items { entity }).unwrap();
+					let mut ctx =
+						LoadoutWriter::try_get_context_mut(&mut p, Items { entity }).unwrap();
 					ctx.swap_items(key_a, key_b);
 				})?;
 
@@ -491,7 +501,8 @@ mod tests {
 
 			app.world_mut()
 				.run_system_once(move |mut p: LoadoutWriter| {
-					let mut ctx = LoadoutWriter::get_context_mut(&mut p, Items { entity }).unwrap();
+					let mut ctx =
+						LoadoutWriter::try_get_context_mut(&mut p, Items { entity }).unwrap();
 					ctx.swap_items(key_a, key_b);
 				})?;
 
@@ -526,7 +537,8 @@ mod tests {
 			app.add_systems(
 				Update,
 				(move |mut p: LoadoutWriter| {
-					let mut ctx = LoadoutWriter::get_context_mut(&mut p, Items { entity }).unwrap();
+					let mut ctx =
+						LoadoutWriter::try_get_context_mut(&mut p, Items { entity }).unwrap();
 					ctx.swap_items(key_a, key_b);
 				})
 				.before(_ChangeDetection),

--- a/src/plugins/loadout/src/system_parameters/loadout/write/register_loadout_bones.rs
+++ b/src/plugins/loadout/src/system_parameters/loadout/write/register_loadout_bones.rs
@@ -5,17 +5,17 @@ use crate::{
 use common::{
 	tools::{action_key::slot::SlotKey, bone_name::BoneName, mesh_name::MeshName},
 	traits::{
-		accessors::get::{GetContextMut, GetMut},
+		accessors::get::{GetMut, TryGetContextMut},
 		handles_loadout::register_loadout_bones::{NoBonesRegistered, RegisterLoadoutBones},
 	},
 	zyheeda_commands::ZyheedaEntityCommands,
 };
 use std::collections::HashMap;
 
-impl GetContextMut<NoBonesRegistered> for LoadoutPrep<'static, 'static> {
+impl TryGetContextMut<NoBonesRegistered> for LoadoutPrep<'static, 'static> {
 	type TContext<'ctx> = PrepareLoadoutBones<'ctx>;
 
-	fn get_context_mut<'ctx>(
+	fn try_get_context_mut<'ctx>(
 		param: &'ctx mut LoadoutPrep,
 		NoBonesRegistered { entity }: NoBonesRegistered,
 	) -> Option<Self::TContext<'ctx>> {
@@ -75,7 +75,7 @@ mod tests {
 
 		app.world_mut().run_system_once(move |mut p: LoadoutPrep| {
 			let key = NoBonesRegistered { entity };
-			let mut ctx = LoadoutPrep::get_context_mut(&mut p, key).unwrap();
+			let mut ctx = LoadoutPrep::try_get_context_mut(&mut p, key).unwrap();
 			ctx.register_loadout_bones(
 				HashMap::from([(BoneName::from("a"), SlotKey(0))]),
 				HashMap::from([(BoneName::from("b"), SlotKey(1))]),
@@ -100,7 +100,7 @@ mod tests {
 		let entity = app.world_mut().spawn(SlotDefinitions::default()).id();
 
 		let ctx_is_none = app.world_mut().run_system_once(move |mut p: LoadoutPrep| {
-			LoadoutPrep::get_context_mut(&mut p, NoBonesRegistered { entity }).is_none()
+			LoadoutPrep::try_get_context_mut(&mut p, NoBonesRegistered { entity }).is_none()
 		})?;
 
 		assert!(ctx_is_none);

--- a/src/plugins/loadout/src/system_parameters/loadout_activity.rs
+++ b/src/plugins/loadout/src/system_parameters/loadout_activity.rs
@@ -4,7 +4,7 @@ mod write;
 use crate::{components::queue::Queue, systems::enqueue::held_slots::HeldSlots};
 use bevy::{ecs::system::SystemParam, prelude::*};
 use common::traits::{
-	accessors::get::{ContextChanged, GetContext, GetContextMut},
+	accessors::get::{ContextChanged, TryGetContext, TryGetContextMut},
 	handles_loadout::skills::Skills,
 };
 use zyheeda_core::prelude::*;
@@ -15,10 +15,10 @@ pub struct LoadoutActivityReader<'w, 's> {
 	loadout: Query<'w, 's, (Ref<'static, Queue>, Ref<'static, HeldSlots>)>,
 }
 
-impl GetContext<Skills> for LoadoutActivityReader<'static, 'static> {
+impl TryGetContext<Skills> for LoadoutActivityReader<'static, 'static> {
 	type TContext<'ctx> = LoadoutActivityReadContext<'ctx>;
 
-	fn get_context<'ctx>(
+	fn try_get_context<'ctx>(
 		param: &'ctx LoadoutActivityReader,
 		Skills { entity }: Skills,
 	) -> Option<Self::TContext<'ctx>> {
@@ -44,10 +44,10 @@ pub struct LoadoutActivityWriter<'w, 's> {
 	held_slots: Query<'w, 's, &'static mut HeldSlots>,
 }
 
-impl GetContextMut<Skills> for LoadoutActivityWriter<'static, 'static> {
+impl TryGetContextMut<Skills> for LoadoutActivityWriter<'static, 'static> {
 	type TContext<'ctx> = LoadoutActivityWriteContext<'ctx>;
 
-	fn get_context_mut<'ctx>(
+	fn try_get_context_mut<'ctx>(
 		param: &'ctx mut LoadoutActivityWriter,
 		Skills { entity }: Skills,
 	) -> Option<Self::TContext<'ctx>> {

--- a/src/plugins/loadout/src/system_parameters/loadout_activity/read/active_skills.rs
+++ b/src/plugins/loadout/src/system_parameters/loadout_activity/read/active_skills.rs
@@ -52,7 +52,7 @@ mod tests {
 	use common::{
 		tools::action_key::slot::SlotKey,
 		traits::{
-			accessors::get::GetContext,
+			accessors::get::TryGetContext,
 			handles_animations::SkillAnimation,
 			handles_loadout::skills::Skills,
 		},
@@ -77,7 +77,7 @@ mod tests {
 		let active_skills = app
 			.world_mut()
 			.run_system_once(move |p: LoadoutActivityReader| {
-				let ctx = LoadoutActivityReader::get_context(&p, Skills { entity }).unwrap();
+				let ctx = LoadoutActivityReader::try_get_context(&p, Skills { entity }).unwrap();
 				ctx.active_skills().collect::<Vec<_>>()
 			})?;
 
@@ -105,7 +105,7 @@ mod tests {
 		let active_skills = app
 			.world_mut()
 			.run_system_once(move |p: LoadoutActivityReader| {
-				let ctx = LoadoutActivityReader::get_context(&p, Skills { entity }).unwrap();
+				let ctx = LoadoutActivityReader::try_get_context(&p, Skills { entity }).unwrap();
 				ctx.active_skills().collect::<Vec<_>>()
 			})?;
 
@@ -136,7 +136,7 @@ mod tests {
 		let active_skills = app
 			.world_mut()
 			.run_system_once(move |p: LoadoutActivityReader| {
-				let ctx = LoadoutActivityReader::get_context(&p, Skills { entity }).unwrap();
+				let ctx = LoadoutActivityReader::try_get_context(&p, Skills { entity }).unwrap();
 				ctx.active_skills().collect::<Vec<_>>()
 			})?;
 

--- a/src/plugins/loadout/src/system_parameters/loadout_activity/read/held_skills.rs
+++ b/src/plugins/loadout/src/system_parameters/loadout_activity/read/held_skills.rs
@@ -21,7 +21,7 @@ mod tests {
 		ecs::system::{RunSystemError, RunSystemOnce},
 		prelude::*,
 	};
-	use common::traits::{accessors::get::GetContext, handles_loadout::skills::Skills};
+	use common::traits::{accessors::get::TryGetContext, handles_loadout::skills::Skills};
 	use testing::SingleThreadedApp;
 
 	fn setup() -> App {
@@ -39,7 +39,7 @@ mod tests {
 		let active_skills = app
 			.world_mut()
 			.run_system_once(move |l: LoadoutActivityReader| {
-				let ctx = LoadoutActivityReader::get_context(&l, Skills { entity }).unwrap();
+				let ctx = LoadoutActivityReader::try_get_context(&l, Skills { entity }).unwrap();
 				ctx.held_skills().clone()
 			})?;
 

--- a/src/plugins/loadout/src/system_parameters/loadout_activity/write/held_skills.rs
+++ b/src/plugins/loadout/src/system_parameters/loadout_activity/write/held_skills.rs
@@ -29,7 +29,7 @@ mod tests {
 		ecs::system::{RunSystemError, RunSystemOnce},
 		prelude::*,
 	};
-	use common::traits::{accessors::get::GetContextMut, handles_loadout::skills::Skills};
+	use common::traits::{accessors::get::TryGetContextMut, handles_loadout::skills::Skills};
 	use testing::SingleThreadedApp;
 
 	fn setup() -> App {
@@ -47,8 +47,8 @@ mod tests {
 		let active_skills =
 			app.world_mut()
 				.run_system_once(move |mut l: LoadoutActivityWriter| {
-					let ctx =
-						LoadoutActivityWriter::get_context_mut(&mut l, Skills { entity }).unwrap();
+					let ctx = LoadoutActivityWriter::try_get_context_mut(&mut l, Skills { entity })
+						.unwrap();
 					ctx.held_skills().clone()
 				})?;
 
@@ -67,7 +67,7 @@ mod tests {
 		app.world_mut()
 			.run_system_once(move |mut l: LoadoutActivityWriter| {
 				let mut ctx =
-					LoadoutActivityWriter::get_context_mut(&mut l, Skills { entity }).unwrap();
+					LoadoutActivityWriter::try_get_context_mut(&mut l, Skills { entity }).unwrap();
 				ctx.held_skills_mut().insert(SlotKey(2));
 			})?;
 

--- a/src/plugins/loadout/src/systems/schedule_active_skill.rs
+++ b/src/plugins/loadout/src/systems/schedule_active_skill.rs
@@ -9,7 +9,7 @@ use bevy::{
 use common::{
 	tools::action_key::slot::SlotKey,
 	traits::{
-		accessors::get::GetContextMut,
+		accessors::get::TryGetContextMut,
 		handles_orientation::{Face, Facing, OverrideFace},
 		state_duration::{StateMeta, UpdatedStates},
 		thread_safe::ThreadSafe,
@@ -29,14 +29,14 @@ pub(crate) fn schedule_active_skill<TGetSkill, TFacing, TActiveSkill, TTime>(
 	mut facing: StaticSystemParam<TFacing>,
 ) where
 	TGetSkill: GetActiveSkill<SkillState> + Component<Mutability = Mutable>,
-	TFacing: for<'c> GetContextMut<Facing, TContext<'c>: OverrideFace>,
+	TFacing: for<'c> TryGetContextMut<Facing, TContext<'c>: OverrideFace>,
 	TActiveSkill: Component<Mutability = Mutable> + Schedule<SkillBehaviorConfig> + Flush,
 	TTime: Default + ThreadSafe,
 {
 	let delta = time.delta();
 
 	for (entity, mut dequeue, skill_executer) in &mut agents {
-		let Some(mut ctx) = TFacing::get_context_mut(&mut facing, Facing { entity }) else {
+		let Some(mut ctx) = TFacing::try_get_context_mut(&mut facing, Facing { entity }) else {
 			continue;
 		};
 		let advancement = match dequeue.get_active() {

--- a/src/plugins/map_generation/src/components/mesh_collider.rs
+++ b/src/plugins/map_generation/src/components/mesh_collider.rs
@@ -2,7 +2,7 @@ use bevy::{ecs::system::StaticSystemParam, prelude::*};
 use common::{
 	errors::{ErrorData, Level},
 	traits::{
-		accessors::get::GetContextMut,
+		accessors::get::TryGetContextMut,
 		handles_physics::{
 			ConfigureBody,
 			NoBodyConfigured,
@@ -20,7 +20,7 @@ pub(crate) struct MeshCollider;
 
 impl<TPhysics> Prefab<TPhysics> for MeshCollider
 where
-	for<'c> TPhysics: GetContextMut<NoBodyConfigured, TContext<'c>: ConfigureBody>,
+	for<'c> TPhysics: TryGetContextMut<NoBodyConfigured, TContext<'c>: ConfigureBody>,
 {
 	type TError = HasAlreadyBody;
 	type TSystemParam<'w, 's> = TPhysics;
@@ -33,7 +33,7 @@ where
 		let entity = entity.entity_id();
 		let key = NoBodyConfigured { entity };
 
-		let Some(mut ctx) = TPhysics::get_context_mut(&mut physics, key) else {
+		let Some(mut ctx) = TPhysics::try_get_context_mut(&mut physics, key) else {
 			return Ok(());
 		};
 

--- a/src/plugins/map_generation/src/system_params/set_agent_prefab.rs
+++ b/src/plugins/map_generation/src/system_params/set_agent_prefab.rs
@@ -2,7 +2,7 @@ use crate::resources::agents::prefab::PrefabRegister;
 use bevy::{ecs::system::SystemParam, prelude::*};
 use common::{
 	traits::{
-		accessors::get::GetContextMut,
+		accessors::get::TryGetContextMut,
 		handles_map_generation::{AgentType, InteractiveType, MapPrefabs, PrefabType, SetPrefab},
 	},
 	zyheeda_commands::ZyheedaEntityCommands,
@@ -23,10 +23,10 @@ where
 	}
 }
 
-impl GetContextMut<MapPrefabs<AgentType>> for SetAgentPrefab<'static> {
+impl TryGetContextMut<MapPrefabs<AgentType>> for SetAgentPrefab<'static> {
 	type TContext<'ctx> = &'ctx mut PrefabRegister<AgentType>;
 
-	fn get_context_mut<'ctx>(
+	fn try_get_context_mut<'ctx>(
 		param: &'ctx mut SetAgentPrefab,
 		_: MapPrefabs<AgentType>,
 	) -> Option<Self::TContext<'ctx>> {
@@ -34,10 +34,10 @@ impl GetContextMut<MapPrefabs<AgentType>> for SetAgentPrefab<'static> {
 	}
 }
 
-impl GetContextMut<MapPrefabs<InteractiveType>> for SetAgentPrefab<'static> {
+impl TryGetContextMut<MapPrefabs<InteractiveType>> for SetAgentPrefab<'static> {
 	type TContext<'ctx> = &'ctx mut PrefabRegister<InteractiveType>;
 
-	fn get_context_mut<'ctx>(
+	fn try_get_context_mut<'ctx>(
 		param: &'ctx mut SetAgentPrefab,
 		_: MapPrefabs<InteractiveType>,
 	) -> Option<Self::TContext<'ctx>> {

--- a/src/plugins/menu/src/systems/combos/delete_skill.rs
+++ b/src/plugins/menu/src/systems/combos/delete_skill.rs
@@ -1,7 +1,7 @@
 use crate::components::DeleteSkill;
 use bevy::{ecs::system::StaticSystemParam, prelude::*};
 use common::traits::{
-	accessors::get::GetContextMut,
+	accessors::get::TryGetContextMut,
 	handles_loadout::combos::{Combos, UpdateCombos},
 };
 
@@ -12,10 +12,10 @@ impl DeleteSkill {
 		mut param: StaticSystemParam<TLoadout>,
 	) where
 		TAgent: Component,
-		TLoadout: for<'c> GetContextMut<Combos, TContext<'c>: UpdateCombos<TId>>,
+		TLoadout: for<'c> TryGetContextMut<Combos, TContext<'c>: UpdateCombos<TId>>,
 	{
 		for entity in &agents {
-			let Some(mut ctx) = TLoadout::get_context_mut(&mut param, Combos { entity }) else {
+			let Some(mut ctx) = TLoadout::try_get_context_mut(&mut param, Combos { entity }) else {
 				continue;
 			};
 			let deletes = deletes

--- a/src/plugins/menu/src/systems/combos/update.rs
+++ b/src/plugins/menu/src/systems/combos/update.rs
@@ -1,7 +1,7 @@
 use crate::components::combo_skill_button::{ComboSkillButton, DropdownItem};
 use bevy::{ecs::system::StaticSystemParam, prelude::*, ui::Interaction};
 use common::traits::{
-	accessors::get::GetContextMut,
+	accessors::get::TryGetContextMut,
 	handles_loadout::combos::{Combos, UpdateCombos},
 	thread_safe::ThreadSafe,
 };
@@ -18,7 +18,7 @@ where
 		mut param: StaticSystemParam<TLoadout>,
 	) where
 		TAgent: Component,
-		TLoadout: for<'c> GetContextMut<Combos, TContext<'c>: UpdateCombos<TId>>,
+		TLoadout: for<'c> TryGetContextMut<Combos, TContext<'c>: UpdateCombos<TId>>,
 	{
 		for entity in &agents {
 			let new_combos = skill_buttons
@@ -29,7 +29,7 @@ where
 			if new_combos.is_empty() {
 				continue;
 			}
-			let Some(mut ctx) = TLoadout::get_context_mut(&mut param, Combos { entity }) else {
+			let Some(mut ctx) = TLoadout::try_get_context_mut(&mut param, Combos { entity }) else {
 				continue;
 			};
 

--- a/src/plugins/menu/src/systems/combos/update_combos_view.rs
+++ b/src/plugins/menu/src/systems/combos/update_combos_view.rs
@@ -4,7 +4,7 @@ use bevy::{
 	prelude::*,
 };
 use common::traits::{
-	accessors::get::{ContextChanged, GetContext},
+	accessors::get::{ContextChanged, TryGetContext},
 	handles_loadout::combos::Combos,
 };
 use std::fmt::Debug;
@@ -19,11 +19,11 @@ pub(crate) trait UpdateComboOverview: Component<Mutability = Mutable> + Sized {
 	) where
 		Self: UpdateCombosView<TId>,
 		TAgent: Component,
-		TLoadout: for<'c> GetContext<Combos, TContext<'c>: BuildComboTreeLayout<TId>>,
+		TLoadout: for<'c> TryGetContext<Combos, TContext<'c>: BuildComboTreeLayout<TId>>,
 		TId: Debug + PartialEq + Clone,
 	{
 		for entity in &agents {
-			let Some(ctx) = TLoadout::get_context(&param, Combos { entity }) else {
+			let Some(ctx) = TLoadout::try_get_context(&param, Combos { entity }) else {
 				continue;
 			};
 
@@ -69,10 +69,10 @@ mod tests {
 	#[derive(SystemParam)]
 	struct _Param<'w, 's>(Query<'w, 's, Ref<'static, _Combos>>);
 
-	impl GetContext<Combos> for _Param<'static, 'static> {
+	impl TryGetContext<Combos> for _Param<'static, 'static> {
 		type TContext<'ctx> = _CombosContext<'ctx>;
 
-		fn get_context<'ctx>(
+		fn try_get_context<'ctx>(
 			param: &'ctx _Param,
 			Combos { entity }: Combos,
 		) -> Option<Self::TContext<'ctx>> {

--- a/src/plugins/menu/src/systems/combos/visualize_invalid_skill.rs
+++ b/src/plugins/menu/src/systems/combos/visualize_invalid_skill.rs
@@ -5,7 +5,7 @@ use crate::{
 use bevy::{ecs::system::StaticSystemParam, prelude::*};
 use common::{
 	traits::{
-		accessors::get::{GetContext, TryApplyOn},
+		accessors::get::{TryApplyOn, TryGetContext},
 		handles_loadout::{
 			available_skills::{AvailableSkills, ReadAvailableSkills},
 			skills::GetSkillId,
@@ -28,10 +28,10 @@ where
 	) where
 		TVisualize: InsertContentOn,
 		TAgent: Component,
-		TLoadout: for<'c> GetContext<AvailableSkills, TContext<'c>: ReadAvailableSkills<TId>>,
+		TLoadout: for<'c> TryGetContext<AvailableSkills, TContext<'c>: ReadAvailableSkills<TId>>,
 	{
 		for entity in &agents {
-			let Some(ctx) = TLoadout::get_context(&param, AvailableSkills { entity }) else {
+			let Some(ctx) = TLoadout::try_get_context(&param, AvailableSkills { entity }) else {
 				continue;
 			};
 

--- a/src/plugins/menu/src/systems/dad/drop_item.rs
+++ b/src/plugins/menu/src/systems/dad/drop_item.rs
@@ -24,7 +24,7 @@ pub fn drop_item<TAgent, TLoadout>(
 
 	for (entity, dad) in &agents {
 		let Some(mut ctx) = TLoadout::try_get_context_mut(&mut param, Items { entity }) else {
-			return;
+			continue;
 		};
 
 		for (.., keyed_panel) in panels.iter().filter(is_hovered) {

--- a/src/plugins/menu/src/systems/dad/drop_item.rs
+++ b/src/plugins/menu/src/systems/dad/drop_item.rs
@@ -2,7 +2,7 @@ use crate::components::{Dad, KeyedPanel};
 use bevy::{ecs::system::StaticSystemParam, prelude::*};
 use common::{
 	traits::{
-		accessors::get::{GetContextMut, TryApplyOn},
+		accessors::get::{TryApplyOn, TryGetContextMut},
 		handles_loadout::items::{Items, SwapItems},
 	},
 	zyheeda_commands::ZyheedaCommands,
@@ -16,14 +16,14 @@ pub fn drop_item<TAgent, TLoadout>(
 	mut param: StaticSystemParam<TLoadout>,
 ) where
 	TAgent: Component,
-	TLoadout: for<'c> GetContextMut<Items, TContext<'c>: SwapItems>,
+	TLoadout: for<'c> TryGetContextMut<Items, TContext<'c>: SwapItems>,
 {
 	if !mouse.just_released(MouseButton::Left) {
 		return;
 	}
 
 	for (entity, dad) in &agents {
-		let Some(mut ctx) = TLoadout::get_context_mut(&mut param, Items { entity }) else {
+		let Some(mut ctx) = TLoadout::try_get_context_mut(&mut param, Items { entity }) else {
 			return;
 		};
 

--- a/src/plugins/menu/src/systems/dropdown/insert_key_select_dropdown.rs
+++ b/src/plugins/menu/src/systems/dropdown/insert_key_select_dropdown.rs
@@ -7,7 +7,7 @@ use bevy::{ecs::system::StaticSystemParam, prelude::*};
 use common::{
 	tools::action_key::slot::SlotKey,
 	traits::{
-		accessors::get::{GetContext, TryApplyOn},
+		accessors::get::{TryApplyOn, TryGetContext},
 		handles_loadout::combos::{Combos, NextConfiguredKeys},
 		thread_safe::ThreadSafe,
 	},
@@ -22,7 +22,7 @@ impl KeySelectDropdownCommand<AppendSkillCommand> {
 		param: StaticSystemParam<TLoadout>,
 	) where
 		TAgent: Component,
-		TLoadout: for<'c> GetContext<Combos, TContext<'c>: NextConfiguredKeys<SlotKey>>,
+		TLoadout: for<'c> TryGetContext<Combos, TContext<'c>: NextConfiguredKeys<SlotKey>>,
 	{
 		insert_key_select_dropdown(commands, dropdown_commands, agents, param);
 	}
@@ -35,11 +35,11 @@ fn insert_key_select_dropdown<TAgent, TLoadout, TExtra>(
 	param: StaticSystemParam<TLoadout>,
 ) where
 	TAgent: Component,
-	TLoadout: for<'c> GetContext<Combos, TContext<'c>: NextConfiguredKeys<SlotKey>>,
+	TLoadout: for<'c> TryGetContext<Combos, TContext<'c>: NextConfiguredKeys<SlotKey>>,
 	KeySelectDropdownCommand<TExtra>: ThreadSafe + GetComponent<TInput = ExcludeKeys<SlotKey>>,
 {
 	for entity in &agents {
-		let Some(ctx) = TLoadout::get_context(&param, Combos { entity }) else {
+		let Some(ctx) = TLoadout::try_get_context(&param, Combos { entity }) else {
 			continue;
 		};
 

--- a/src/plugins/menu/src/systems/dropdown/insert_skill_select_dropdown.rs
+++ b/src/plugins/menu/src/systems/dropdown/insert_skill_select_dropdown.rs
@@ -7,7 +7,7 @@ use crate::components::{
 use bevy::{ecs::system::StaticSystemParam, prelude::*};
 use common::{
 	traits::{
-		accessors::get::{GetContext, TryApplyOn, ViewOf},
+		accessors::get::{TryApplyOn, TryGetContext, ViewOf},
 		handles_loadout::{
 			available_skills::{AvailableSkills, ReadAvailableSkills},
 			skills::{GetSkillId, SkillIcon, SkillToken},
@@ -28,14 +28,15 @@ impl<TLayout> SkillSelectDropdownCommand<TLayout> {
 		TLayout: ThreadSafe + Sized,
 		TAgent: Component,
 		TId: Debug + PartialEq + Clone + ThreadSafe,
-		TLoadout: for<'c> GetContext<AvailableSkills, TContext<'c>: ReadAvailableSkills<TId>>,
+		TLoadout: for<'c> TryGetContext<AvailableSkills, TContext<'c>: ReadAvailableSkills<TId>>,
 	{
 		for entity in &agents {
 			for (dropdown_entity, command) in &dropdown_commands {
 				let Some(key) = command.key_path.last() else {
 					continue;
 				};
-				let Some(ctx) = TLoadout::get_context(&param, AvailableSkills { entity }) else {
+				let Some(ctx) = TLoadout::try_get_context(&param, AvailableSkills { entity })
+				else {
 					continue;
 				};
 				let items = ctx

--- a/src/plugins/menu/src/systems/inventory_panel/set_label.rs
+++ b/src/plugins/menu/src/systems/inventory_panel/set_label.rs
@@ -5,7 +5,7 @@ use crate::{
 use bevy::{ecs::system::StaticSystemParam, prelude::*};
 use common::{
 	traits::{
-		accessors::get::{GetContext, TryApplyOn, View},
+		accessors::get::{TryApplyOn, TryGetContext, View},
 		handles_loadout::items::{Items, ReadItems},
 	},
 	zyheeda_commands::ZyheedaCommands,
@@ -19,10 +19,10 @@ impl InventoryPanel {
 		param: StaticSystemParam<TLoadout>,
 	) where
 		TAgent: Component,
-		TLoadout: for<'c> GetContext<Items, TContext<'c>: ReadItems>,
+		TLoadout: for<'c> TryGetContext<Items, TContext<'c>: ReadItems>,
 	{
 		for entity in &agents {
-			let Some(ctx) = TLoadout::get_context(&param, Items { entity }) else {
+			let Some(ctx) = TLoadout::try_get_context(&param, Items { entity }) else {
 				continue;
 			};
 

--- a/src/plugins/menu/src/systems/quickbar_panel/set_color.rs
+++ b/src/plugins/menu/src/systems/quickbar_panel/set_color.rs
@@ -10,7 +10,7 @@ use bevy::{ecs::system::StaticSystemParam, prelude::*};
 use common::{
 	tools::skill_execution::SkillExecution,
 	traits::{
-		accessors::get::{GetContext, TryApplyOn, View, ViewOf},
+		accessors::get::{TryApplyOn, TryGetContext, View, ViewOf},
 		handles_input::MouseOverrideActive,
 		handles_loadout::skills::{ReadSkills, Skills},
 	},
@@ -26,7 +26,7 @@ impl QuickbarPanel {
 	) where
 		TAgent: Component,
 		TActionKeyButton: Component + View<MouseOverrideActive>,
-		TLoadout: for<'c> GetContext<Skills, TContext<'c>: ReadSkills>,
+		TLoadout: for<'c> TryGetContext<Skills, TContext<'c>: ReadSkills>,
 	{
 		set_color(commands, buttons, agents, param)
 	}
@@ -40,10 +40,10 @@ fn set_color<TAgent, TActionKeyButton, TLoadout>(
 ) where
 	TAgent: Component,
 	TActionKeyButton: Component + View<MouseOverrideActive>,
-	TLoadout: for<'c> GetContext<Skills, TContext<'c>: ReadSkills>,
+	TLoadout: for<'c> TryGetContext<Skills, TContext<'c>: ReadSkills>,
 {
 	for entity in &agents {
-		let Some(ctx) = TLoadout::get_context(&param, Skills { entity }) else {
+		let Some(ctx) = TLoadout::try_get_context(&param, Skills { entity }) else {
 			continue;
 		};
 

--- a/src/plugins/menu/src/systems/quickbar_panel/set_icon.rs
+++ b/src/plugins/menu/src/systems/quickbar_panel/set_icon.rs
@@ -2,7 +2,7 @@ use crate::components::{icon::Icon, label::UILabel, quickbar_panel::QuickbarPane
 use bevy::{ecs::system::StaticSystemParam, prelude::*};
 use common::{
 	traits::{
-		accessors::get::{GetContext, TryApplyOn, ViewOf},
+		accessors::get::{TryApplyOn, TryGetContext, ViewOf},
 		handles_loadout::skills::{ReadSkills, SkillIcon, SkillToken, Skills},
 		handles_localization::Token,
 	},
@@ -17,10 +17,10 @@ impl QuickbarPanel {
 		agents: Query<Entity, With<TAgent>>,
 	) where
 		TAgent: Component,
-		TLoadout: for<'c> GetContext<Skills, TContext<'c>: ReadSkills>,
+		TLoadout: for<'c> TryGetContext<Skills, TContext<'c>: ReadSkills>,
 	{
 		for entity in &agents {
-			let Some(ctx) = TLoadout::get_context(&param, Skills { entity }) else {
+			let Some(ctx) = TLoadout::try_get_context(&param, Skills { entity }) else {
 				continue;
 			};
 

--- a/src/plugins/movement/src/system_param/face_param.rs
+++ b/src/plugins/movement/src/system_param/face_param.rs
@@ -3,7 +3,7 @@ mod override_face;
 use bevy::{ecs::system::SystemParam, prelude::*};
 use common::{
 	traits::{
-		accessors::get::{GetContextMut, GetMut},
+		accessors::get::{GetMut, TryGetContextMut},
 		handles_orientation::Facing,
 	},
 	zyheeda_commands::{ZyheedaCommands, ZyheedaEntityCommands},
@@ -14,10 +14,10 @@ pub struct FaceParamMut<'w, 's> {
 	commands: ZyheedaCommands<'w, 's>,
 }
 
-impl GetContextMut<Facing> for FaceParamMut<'static, 'static> {
+impl TryGetContextMut<Facing> for FaceParamMut<'static, 'static> {
 	type TContext<'ctx> = FaceContextMut<'ctx>;
 
-	fn get_context_mut<'ctx>(
+	fn try_get_context_mut<'ctx>(
 		param: &'ctx mut FaceParamMut,
 		Facing { entity }: Facing,
 	) -> Option<Self::TContext<'ctx>> {

--- a/src/plugins/movement/src/system_param/face_param/override_face.rs
+++ b/src/plugins/movement/src/system_param/face_param/override_face.rs
@@ -19,7 +19,7 @@ mod tests {
 		app::{App, Update},
 		ecs::system::{RunSystemError, RunSystemOnce},
 	};
-	use common::traits::{accessors::get::GetContextMut, handles_orientation::Facing};
+	use common::traits::{accessors::get::TryGetContextMut, handles_orientation::Facing};
 	use testing::SingleThreadedApp;
 
 	fn setup() -> App {
@@ -33,7 +33,7 @@ mod tests {
 
 		app.world_mut()
 			.run_system_once(move |mut p: FaceParamMut| {
-				let mut ctx = FaceParamMut::get_context_mut(&mut p, Facing { entity }).unwrap();
+				let mut ctx = FaceParamMut::try_get_context_mut(&mut p, Facing { entity }).unwrap();
 				ctx.override_face(Face::SkillTarget);
 			})?;
 
@@ -51,7 +51,7 @@ mod tests {
 
 		app.world_mut()
 			.run_system_once(move |mut p: FaceParamMut| {
-				let mut ctx = FaceParamMut::get_context_mut(&mut p, Facing { entity }).unwrap();
+				let mut ctx = FaceParamMut::try_get_context_mut(&mut p, Facing { entity }).unwrap();
 				ctx.stop_override_face();
 			})?;
 

--- a/src/plugins/movement/src/system_param/movement_config_param.rs
+++ b/src/plugins/movement/src/system_param/movement_config_param.rs
@@ -4,7 +4,7 @@ use crate::components::config::Config;
 use bevy::{ecs::system::SystemParam, prelude::*};
 use common::{
 	traits::{
-		accessors::get::{GetContextMut, GetMut},
+		accessors::get::{GetMut, TryGetContextMut},
 		handles_movement::NotConfiguredMovement,
 	},
 	zyheeda_commands::{ZyheedaCommands, ZyheedaEntityCommands},
@@ -16,10 +16,10 @@ pub struct MovementConfigParamMut<'w, 's> {
 	configured: Query<'w, 's, (), With<Config>>,
 }
 
-impl GetContextMut<NotConfiguredMovement> for MovementConfigParamMut<'static, 'static> {
+impl TryGetContextMut<NotConfiguredMovement> for MovementConfigParamMut<'static, 'static> {
 	type TContext<'ctx> = MovementConfigContextMut<'ctx>;
 
-	fn get_context_mut<'ctx>(
+	fn try_get_context_mut<'ctx>(
 		param: &'ctx mut bevy::ecs::system::SystemParamItem<Self>,
 		NotConfiguredMovement { entity }: NotConfiguredMovement,
 	) -> Option<Self::TContext<'ctx>> {
@@ -56,7 +56,7 @@ mod tests {
 		let ctx = app
 			.world_mut()
 			.run_system_once(move |mut p: MovementConfigParamMut| {
-				let ctx = MovementConfigParamMut::get_context_mut(
+				let ctx = MovementConfigParamMut::try_get_context_mut(
 					&mut p,
 					NotConfiguredMovement { entity },
 				);
@@ -75,7 +75,7 @@ mod tests {
 		let ctx = app
 			.world_mut()
 			.run_system_once(move |mut p: MovementConfigParamMut| {
-				let ctx = MovementConfigParamMut::get_context_mut(
+				let ctx = MovementConfigParamMut::try_get_context_mut(
 					&mut p,
 					NotConfiguredMovement { entity },
 				);

--- a/src/plugins/movement/src/system_param/movement_config_param/configure_movement.rs
+++ b/src/plugins/movement/src/system_param/movement_config_param/configure_movement.rs
@@ -24,7 +24,7 @@ mod tests {
 	};
 	use common::{
 		tools::{Units, UnitsPerSecond},
-		traits::{accessors::get::GetContextMut, handles_movement::NotConfiguredMovement},
+		traits::{accessors::get::TryGetContextMut, handles_movement::NotConfiguredMovement},
 	};
 	use testing::SingleThreadedApp;
 
@@ -39,7 +39,7 @@ mod tests {
 
 		app.world_mut()
 			.run_system_once(move |mut p: MovementConfigParamMut| {
-				let mut ctx = MovementConfigParamMut::get_context_mut(
+				let mut ctx = MovementConfigParamMut::try_get_context_mut(
 					&mut p,
 					NotConfiguredMovement { entity },
 				)

--- a/src/plugins/movement/src/system_param/movement_param.rs
+++ b/src/plugins/movement/src/system_param/movement_param.rs
@@ -11,7 +11,7 @@ use crate::{
 use bevy::{ecs::system::SystemParam, prelude::*};
 use common::{
 	traits::{
-		accessors::get::{GetContext, GetContextMut, GetMut},
+		accessors::get::{GetMut, TryGetContext, TryGetContextMut},
 		handles_movement::{ConfiguredMovement, Movement},
 	},
 	zyheeda_commands::{ZyheedaCommands, ZyheedaEntityCommands},
@@ -27,13 +27,13 @@ where
 	just_removed_movements: Res<'w, JustRemovedMovements>,
 }
 
-impl<TMotion> GetContext<Movement> for MovementParam<'static, 'static, TMotion>
+impl<TMotion> TryGetContext<Movement> for MovementParam<'static, 'static, TMotion>
 where
 	TMotion: Component,
 {
 	type TContext<'ctx> = MovementContext<'ctx, TMotion>;
 
-	fn get_context<'ctx>(
+	fn try_get_context<'ctx>(
 		param: &'ctx MovementParam<TMotion>,
 		Movement { entity }: Movement,
 	) -> Option<Self::TContext<'ctx>> {
@@ -68,13 +68,13 @@ where
 	>,
 }
 
-impl<TMotion> GetContextMut<ConfiguredMovement> for MovementParamMut<'static, 'static, TMotion>
+impl<TMotion> TryGetContextMut<ConfiguredMovement> for MovementParamMut<'static, 'static, TMotion>
 where
 	TMotion: Component,
 {
 	type TContext<'ctx> = MovementContextMut<'ctx, TMotion>;
 
-	fn get_context_mut<'ctx>(
+	fn try_get_context_mut<'ctx>(
 		param: &'ctx mut MovementParamMut<TMotion>,
 		ConfiguredMovement { entity }: ConfiguredMovement,
 	) -> Option<Self::TContext<'ctx>> {
@@ -139,7 +139,7 @@ mod tests {
 		let ctx = app
 			.world_mut()
 			.run_system_once(move |mut p: MovementParamMut<_Motion>| {
-				let ctx = MovementParamMut::<_Motion>::get_context_mut(
+				let ctx = MovementParamMut::<_Motion>::try_get_context_mut(
 					&mut p,
 					ConfiguredMovement { entity },
 				);
@@ -158,7 +158,7 @@ mod tests {
 		let ctx = app
 			.world_mut()
 			.run_system_once(move |mut p: MovementParamMut<_Motion>| {
-				let ctx = MovementParamMut::<_Motion>::get_context_mut(
+				let ctx = MovementParamMut::<_Motion>::try_get_context_mut(
 					&mut p,
 					ConfiguredMovement { entity },
 				);

--- a/src/plugins/movement/src/system_param/movement_param/context_changed.rs
+++ b/src/plugins/movement/src/system_param/movement_param/context_changed.rs
@@ -49,7 +49,7 @@ pub(crate) struct JustRemovedMovements(pub(crate) HashSet<Entity>);
 mod tests {
 	use super::*;
 	use crate::{components::config::SpeedIndex, system_param::movement_param::MovementParam};
-	use common::traits::{accessors::get::GetContext, handles_movement::Movement};
+	use common::traits::{accessors::get::TryGetContext, handles_movement::Movement};
 	use testing::SingleThreadedApp;
 
 	#[derive(Component)]
@@ -68,7 +68,7 @@ mod tests {
 				|mut commands: Commands, m: MovementParam<_Motion>, entities: Query<Entity>| {
 					for entity in &entities {
 						let key = Movement { entity };
-						let Some(ctx) = MovementParam::get_context(&m, key) else {
+						let Some(ctx) = MovementParam::try_get_context(&m, key) else {
 							continue;
 						};
 

--- a/src/plugins/movement/src/system_param/movement_param/start_movement.rs
+++ b/src/plugins/movement/src/system_param/movement_param/start_movement.rs
@@ -25,7 +25,7 @@ mod tests {
 		prelude::*,
 	};
 	use common::traits::{
-		accessors::get::GetContextMut,
+		accessors::get::TryGetContextMut,
 		handles_movement::ConfiguredMovement,
 		thread_safe::ThreadSafe,
 	};
@@ -50,7 +50,7 @@ mod tests {
 		app.world_mut()
 			.run_system_once(move |mut p: MovementParamMut<_Motion>| {
 				let mut ctx =
-					MovementParamMut::get_context_mut(&mut p, ConfiguredMovement { entity })
+					MovementParamMut::try_get_context_mut(&mut p, ConfiguredMovement { entity })
 						.unwrap();
 				ctx.start(target);
 			})?;

--- a/src/plugins/movement/src/system_param/movement_param/stop_movement.rs
+++ b/src/plugins/movement/src/system_param/movement_param/stop_movement.rs
@@ -20,7 +20,7 @@ mod tests {
 		ecs::system::{RunSystemError, RunSystemOnce},
 		prelude::*,
 	};
-	use common::traits::{accessors::get::GetContextMut, handles_movement::ConfiguredMovement};
+	use common::traits::{accessors::get::TryGetContextMut, handles_movement::ConfiguredMovement};
 	use testing::SingleThreadedApp;
 
 	#[derive(Component)]
@@ -38,7 +38,7 @@ mod tests {
 		app.world_mut()
 			.run_system_once(move |mut p: MovementParamMut<_Motion>| {
 				let mut ctx =
-					MovementParamMut::get_context_mut(&mut p, ConfiguredMovement { entity })
+					MovementParamMut::try_get_context_mut(&mut p, ConfiguredMovement { entity })
 						.unwrap();
 				ctx.stop();
 			})?;

--- a/src/plugins/movement/src/system_param/movement_param/toggle_speed.rs
+++ b/src/plugins/movement/src/system_param/movement_param/toggle_speed.rs
@@ -30,7 +30,7 @@ mod tests {
 	use common::{
 		tools::UnitsPerSecond,
 		traits::{
-			accessors::get::GetContextMut,
+			accessors::get::TryGetContextMut,
 			handles_movement::{ConfiguredMovement as MovementMarker, MovementSpeed},
 		},
 	};
@@ -61,7 +61,7 @@ mod tests {
 			app.world_mut()
 				.run_system_once(move |mut p: MovementParamMut<_Motion>| {
 					let mut ctx =
-						MovementParamMut::get_context_mut(&mut p, MovementMarker { entity })
+						MovementParamMut::try_get_context_mut(&mut p, MovementMarker { entity })
 							.unwrap();
 					ctx.toggle_speed()
 				})?;
@@ -91,7 +91,7 @@ mod tests {
 			app.world_mut()
 				.run_system_once(move |mut p: MovementParamMut<_Motion>| {
 					let mut ctx =
-						MovementParamMut::get_context_mut(&mut p, MovementMarker { entity })
+						MovementParamMut::try_get_context_mut(&mut p, MovementMarker { entity })
 							.unwrap();
 					ctx.toggle_speed();
 					ctx.toggle_speed()
@@ -119,7 +119,7 @@ mod tests {
 			app.world_mut()
 				.run_system_once(move |mut p: MovementParamMut<_Motion>| {
 					let mut ctx =
-						MovementParamMut::get_context_mut(&mut p, MovementMarker { entity })
+						MovementParamMut::try_get_context_mut(&mut p, MovementMarker { entity })
 							.unwrap();
 					ctx.toggle_speed()
 				})?;
@@ -149,7 +149,7 @@ mod tests {
 			app.world_mut()
 				.run_system_once(move |mut p: MovementParamMut<_Motion>| {
 					let mut ctx =
-						MovementParamMut::get_context_mut(&mut p, MovementMarker { entity })
+						MovementParamMut::try_get_context_mut(&mut p, MovementMarker { entity })
 							.unwrap();
 					ctx.toggle_speed()
 				})?;

--- a/src/plugins/movement/src/systems/animate_forward.rs
+++ b/src/plugins/movement/src/systems/animate_forward.rs
@@ -1,6 +1,6 @@
 use bevy::{ecs::system::StaticSystemParam, prelude::*};
 use common::traits::{
-	accessors::get::{GetContextMut, View},
+	accessors::get::{TryGetContextMut, View},
 	handles_animations::{Animations, GetMoveDirectionMut},
 	handles_physics::CharacterMotion,
 };
@@ -14,7 +14,7 @@ pub(crate) trait SetForwardAnimationDirection:
 		mut animations: StaticSystemParam<TAnimations>,
 		movements: Query<(Entity, &Self, &Transform), Changed<Self>>,
 	) where
-		TAnimations: for<'c> GetContextMut<Animations, TContext<'c>: GetMoveDirectionMut>,
+		TAnimations: for<'c> TryGetContextMut<Animations, TContext<'c>: GetMoveDirectionMut>,
 	{
 		for (entity, movement, transform) in &movements {
 			let key = Animations { entity };
@@ -22,7 +22,8 @@ pub(crate) trait SetForwardAnimationDirection:
 			let Some(forward) = get_forward_direction(movement, transform) else {
 				continue;
 			};
-			let Some(mut animations) = TAnimations::get_context_mut(&mut animations, key) else {
+			let Some(mut animations) = TAnimations::try_get_context_mut(&mut animations, key)
+			else {
 				continue;
 			};
 

--- a/src/plugins/movement/src/systems/face/execute_face.rs
+++ b/src/plugins/movement/src/systems/face/execute_face.rs
@@ -5,7 +5,7 @@ use bevy::{
 use common::{
 	self,
 	traits::{
-		accessors::get::{Get, GetContext},
+		accessors::get::{Get, TryGetContext},
 		handles_orientation::Face,
 		handles_physics::{HoverMode, MouseHover, MouseHoversOver, Raycast},
 		handles_skill_physics::{Cursor, InitializedAgent, SkillTarget, Target},
@@ -22,7 +22,7 @@ pub(crate) fn execute_face<TMouseHover, TTarget>(
 	target: StaticSystemParam<TTarget>,
 ) where
 	TMouseHover: for<'w, 's> SystemParam<Item<'w, 's>: Raycast<MouseHover>>,
-	TTarget: for<'c> GetContext<InitializedAgent, TContext<'c>: Target>,
+	TTarget: for<'c> TryGetContext<InitializedAgent, TContext<'c>: Target>,
 {
 	for (entity, face) in faces {
 		let target = match face {
@@ -60,9 +60,9 @@ fn get_target<TMouseHover, TTarget>(
 ) -> Option<Vec3>
 where
 	TMouseHover: Raycast<MouseHover>,
-	TTarget: for<'c> GetContext<InitializedAgent, TContext<'c>: Target>,
+	TTarget: for<'c> TryGetContext<InitializedAgent, TContext<'c>: Target>,
 {
-	let ctx = TTarget::get_context(target, InitializedAgent { entity })?;
+	let ctx = TTarget::try_get_context(target, InitializedAgent { entity })?;
 	let target = ctx.target()?;
 
 	let cursor = match target {

--- a/src/plugins/physics/src/system_params/config.rs
+++ b/src/plugins/physics/src/system_params/config.rs
@@ -5,7 +5,7 @@ use crate::components::{body::Body, default_attributes::DefaultAttributes};
 use bevy::{ecs::system::SystemParam, prelude::*};
 use common::{
 	traits::{
-		accessors::get::{GetContextMut, GetMut},
+		accessors::get::{GetMut, TryGetContextMut},
 		handles_physics::{NoBodyConfigured, NoDefaultAttributes},
 	},
 	zyheeda_commands::{ZyheedaCommands, ZyheedaEntityCommands},
@@ -18,10 +18,10 @@ pub struct ConfigParamMut<'w, 's> {
 	commands: ZyheedaCommands<'w, 's>,
 }
 
-impl GetContextMut<NoDefaultAttributes> for ConfigParamMut<'static, 'static> {
+impl TryGetContextMut<NoDefaultAttributes> for ConfigParamMut<'static, 'static> {
 	type TContext<'ctx> = ConfigContextMut<'ctx>;
 
-	fn get_context_mut<'ctx>(
+	fn try_get_context_mut<'ctx>(
 		param: &'ctx mut ConfigParamMut,
 		NoDefaultAttributes { entity }: NoDefaultAttributes,
 	) -> Option<Self::TContext<'ctx>> {
@@ -35,10 +35,10 @@ impl GetContextMut<NoDefaultAttributes> for ConfigParamMut<'static, 'static> {
 	}
 }
 
-impl GetContextMut<NoBodyConfigured> for ConfigParamMut<'static, 'static> {
+impl TryGetContextMut<NoBodyConfigured> for ConfigParamMut<'static, 'static> {
 	type TContext<'ctx> = ConfigContextMut<'ctx>;
 
-	fn get_context_mut<'ctx>(
+	fn try_get_context_mut<'ctx>(
 		param: &'ctx mut bevy::ecs::system::SystemParamItem<Self>,
 		NoBodyConfigured { entity }: NoBodyConfigured,
 	) -> Option<Self::TContext<'ctx>> {
@@ -82,7 +82,7 @@ mod tests {
 				.world_mut()
 				.run_system_once(move |mut p: ConfigParamMut| {
 					let key = NoDefaultAttributes { entity };
-					let ctx = ConfigParamMut::get_context_mut(&mut p, key);
+					let ctx = ConfigParamMut::try_get_context_mut(&mut p, key);
 					ctx.map(|c| c.entity.id())
 				})?;
 
@@ -102,7 +102,7 @@ mod tests {
 				.world_mut()
 				.run_system_once(move |mut p: ConfigParamMut| {
 					let key = NoDefaultAttributes { entity };
-					let ctx = ConfigParamMut::get_context_mut(&mut p, key);
+					let ctx = ConfigParamMut::try_get_context_mut(&mut p, key);
 					ctx.map(|c| c.entity.id())
 				})?;
 
@@ -123,7 +123,7 @@ mod tests {
 				.world_mut()
 				.run_system_once(move |mut p: ConfigParamMut| {
 					let key = NoBodyConfigured { entity };
-					let ctx = ConfigParamMut::get_context_mut(&mut p, key);
+					let ctx = ConfigParamMut::try_get_context_mut(&mut p, key);
 					ctx.map(|c| c.entity.id())
 				})?;
 
@@ -143,7 +143,7 @@ mod tests {
 				.world_mut()
 				.run_system_once(move |mut p: ConfigParamMut| {
 					let key = NoBodyConfigured { entity };
-					let ctx = ConfigParamMut::get_context_mut(&mut p, key);
+					let ctx = ConfigParamMut::try_get_context_mut(&mut p, key);
 					ctx.map(|c| c.entity.id())
 				})?;
 

--- a/src/plugins/physics/src/system_params/config/body.rs
+++ b/src/plugins/physics/src/system_params/config/body.rs
@@ -34,7 +34,7 @@ mod tests {
 		prelude::*,
 	};
 	use common::traits::{
-		accessors::get::GetContextMut,
+		accessors::get::TryGetContextMut,
 		handles_physics::{NoBodyConfigured, physical_bodies::Shape},
 	};
 	use testing::SingleThreadedApp;
@@ -51,7 +51,7 @@ mod tests {
 		app.world_mut()
 			.run_system_once(move |mut p: ConfigParamMut| {
 				let key = NoBodyConfigured { entity };
-				let mut ctx = ConfigParamMut::get_context_mut(&mut p, key).unwrap();
+				let mut ctx = ConfigParamMut::try_get_context_mut(&mut p, key).unwrap();
 				ctx.configure_body(
 					BodyConfig::from_shape(Shape::StaticGltfMesh3d),
 					TranslationOffsets::ZERO,
@@ -73,7 +73,7 @@ mod tests {
 		app.world_mut()
 			.run_system_once(move |mut p: ConfigParamMut| {
 				let key = NoBodyConfigured { entity };
-				let mut ctx = ConfigParamMut::get_context_mut(&mut p, key).unwrap();
+				let mut ctx = ConfigParamMut::try_get_context_mut(&mut p, key).unwrap();
 				ctx.configure_body(
 					BodyConfig::from_shape(Shape::StaticGltfMesh3d),
 					TranslationOffsets {

--- a/src/plugins/physics/src/system_params/config/default_attributes.rs
+++ b/src/plugins/physics/src/system_params/config/default_attributes.rs
@@ -25,7 +25,7 @@ mod tests {
 	};
 	use common::{
 		attributes::{effect_target::EffectTarget, health::Health},
-		traits::{accessors::get::GetContextMut, handles_physics::NoDefaultAttributes},
+		traits::{accessors::get::TryGetContextMut, handles_physics::NoDefaultAttributes},
 	};
 	use testing::SingleThreadedApp;
 
@@ -41,7 +41,7 @@ mod tests {
 		app.world_mut()
 			.run_system_once(move |mut p: ConfigParamMut| {
 				let key = NoDefaultAttributes { entity };
-				let mut ctx = ConfigParamMut::get_context_mut(&mut p, key).unwrap();
+				let mut ctx = ConfigParamMut::try_get_context_mut(&mut p, key).unwrap();
 				ctx.configure_default_attributes(PhysicalDefaultAttributes {
 					health: Health::new(11.),
 					force_interaction: EffectTarget::Affected,

--- a/src/plugins/physics/src/system_params/interactive.rs
+++ b/src/plugins/physics/src/system_params/interactive.rs
@@ -9,7 +9,7 @@ use bevy::{
 	prelude::*,
 };
 use common::traits::{
-	accessors::get::{ContextChanged, GetContext},
+	accessors::get::{ContextChanged, TryGetContext},
 	handles_physics::IsInteracting,
 };
 use std::collections::HashSet;
@@ -19,10 +19,10 @@ pub struct InteractiveParam<'w> {
 	child_colliders: Res<'w, OngoingInteractions<Interactive>>,
 }
 
-impl GetContext<IsInteracting> for InteractiveParam<'static> {
+impl TryGetContext<IsInteracting> for InteractiveParam<'static> {
 	type TContext<'ctx> = InteractiveContext<'ctx>;
 
-	fn get_context<'ctx>(
+	fn try_get_context<'ctx>(
 		param: &'ctx SystemParamItem<Self>,
 		IsInteracting { entity }: IsInteracting,
 	) -> Option<Self::TContext<'ctx>> {

--- a/src/plugins/physics/src/system_params/interactive/iter_interactions.rs
+++ b/src/plugins/physics/src/system_params/interactive/iter_interactions.rs
@@ -30,7 +30,7 @@ mod tests {
 	};
 	use bevy::ecs::system::{RunSystemError, RunSystemOnce};
 	use bevy_rapier3d::prelude::*;
-	use common::traits::{accessors::get::GetContext, handles_physics::IsInteracting};
+	use common::traits::{accessors::get::TryGetContext, handles_physics::IsInteracting};
 	use testing::SingleThreadedApp;
 
 	fn setup() -> App {
@@ -80,7 +80,8 @@ mod tests {
 		let interactions = app
 			.world_mut()
 			.run_system_once(move |i: InteractiveParam| {
-				let ctx = InteractiveParam::get_context(&i, IsInteracting { entity: a }).unwrap();
+				let ctx =
+					InteractiveParam::try_get_context(&i, IsInteracting { entity: a }).unwrap();
 				ctx.iter_interactions().collect::<Vec<_>>()
 			})?;
 
@@ -116,7 +117,8 @@ mod tests {
 		let interactions = app
 			.world_mut()
 			.run_system_once(move |i: InteractiveParam| {
-				let ctx = InteractiveParam::get_context(&i, IsInteracting { entity: a }).unwrap();
+				let ctx =
+					InteractiveParam::try_get_context(&i, IsInteracting { entity: a }).unwrap();
 				ctx.iter_interactions().collect::<Vec<_>>()
 			})?;
 

--- a/src/plugins/physics/src/system_params/skill_agent.rs
+++ b/src/plugins/physics/src/system_params/skill_agent.rs
@@ -7,7 +7,7 @@ use crate::components::{mount_points::MountPointsDefinition, skill::Skill, targe
 use bevy::{ecs::system::SystemParam, prelude::*};
 use common::{
 	traits::{
-		accessors::get::{ContextChanged, GetContext, GetContextMut, GetMut},
+		accessors::get::{ContextChanged, GetMut, TryGetContext, TryGetContextMut},
 		handles_skill_physics::{InitializedAgent, NotInitializedAgent, SkillMountBone},
 	},
 	zyheeda_commands::{ZyheedaCommands, ZyheedaEntityCommands},
@@ -18,10 +18,10 @@ pub struct SkillAgent<'w, 's> {
 	targets: Query<'w, 's, Ref<'static, Target>>,
 }
 
-impl GetContext<InitializedAgent> for SkillAgent<'static, 'static> {
+impl TryGetContext<InitializedAgent> for SkillAgent<'static, 'static> {
 	type TContext<'ctx> = SkillAgentContext<'ctx>;
 
-	fn get_context<'ctx>(
+	fn try_get_context<'ctx>(
 		param: &'ctx SkillAgent,
 		InitializedAgent { entity }: InitializedAgent,
 	) -> Option<Self::TContext<'ctx>> {
@@ -39,10 +39,10 @@ pub struct SkillAgentMut<'w, 's> {
 	commands: ZyheedaCommands<'w, 's>,
 }
 
-impl GetContextMut<NotInitializedAgent> for SkillAgentMut<'static, 'static> {
+impl TryGetContextMut<NotInitializedAgent> for SkillAgentMut<'static, 'static> {
 	type TContext<'ctx> = SkillAgentInitializerContext<'ctx>;
 
-	fn get_context_mut<'ctx>(
+	fn try_get_context_mut<'ctx>(
 		param: &'ctx mut SkillAgentMut,
 		NotInitializedAgent { entity }: NotInitializedAgent,
 	) -> Option<Self::TContext<'ctx>> {
@@ -56,10 +56,10 @@ impl GetContextMut<NotInitializedAgent> for SkillAgentMut<'static, 'static> {
 	}
 }
 
-impl GetContextMut<InitializedAgent> for SkillAgentMut<'static, 'static> {
+impl TryGetContextMut<InitializedAgent> for SkillAgentMut<'static, 'static> {
 	type TContext<'ctx> = SkillAgentContextMut<'ctx>;
 
-	fn get_context_mut<'ctx>(
+	fn try_get_context_mut<'ctx>(
 		param: &'ctx mut SkillAgentMut,
 		InitializedAgent { entity }: InitializedAgent,
 	) -> Option<Self::TContext<'ctx>> {
@@ -116,7 +116,8 @@ mod tests {
 			let ctx = app
 				.world_mut()
 				.run_system_once(move |mut p: SkillAgentMut| {
-					SkillAgentMut::get_context_mut(&mut p, NotInitializedAgent { entity }).is_some()
+					SkillAgentMut::try_get_context_mut(&mut p, NotInitializedAgent { entity })
+						.is_some()
 				})?;
 
 			assert!(ctx);
@@ -131,7 +132,8 @@ mod tests {
 			let ctx = app
 				.world_mut()
 				.run_system_once(move |mut p: SkillAgentMut| {
-					SkillAgentMut::get_context_mut(&mut p, NotInitializedAgent { entity }).is_some()
+					SkillAgentMut::try_get_context_mut(&mut p, NotInitializedAgent { entity })
+						.is_some()
 				})?;
 
 			assert!(ctx);
@@ -152,7 +154,8 @@ mod tests {
 			let ctx = app
 				.world_mut()
 				.run_system_once(move |mut p: SkillAgentMut| {
-					SkillAgentMut::get_context_mut(&mut p, NotInitializedAgent { entity }).is_some()
+					SkillAgentMut::try_get_context_mut(&mut p, NotInitializedAgent { entity })
+						.is_some()
 				})?;
 
 			assert!(!ctx);
@@ -174,7 +177,8 @@ mod tests {
 			let ctx = app
 				.world_mut()
 				.run_system_once(move |mut p: SkillAgentMut| {
-					SkillAgentMut::get_context_mut(&mut p, InitializedAgent { entity }).is_some()
+					SkillAgentMut::try_get_context_mut(&mut p, InitializedAgent { entity })
+						.is_some()
 				})?;
 
 			assert!(!ctx);
@@ -189,7 +193,8 @@ mod tests {
 			let ctx = app
 				.world_mut()
 				.run_system_once(move |mut p: SkillAgentMut| {
-					SkillAgentMut::get_context_mut(&mut p, InitializedAgent { entity }).is_some()
+					SkillAgentMut::try_get_context_mut(&mut p, InitializedAgent { entity })
+						.is_some()
 				})?;
 
 			assert!(!ctx);
@@ -210,7 +215,8 @@ mod tests {
 			let ctx = app
 				.world_mut()
 				.run_system_once(move |mut p: SkillAgentMut| {
-					SkillAgentMut::get_context_mut(&mut p, InitializedAgent { entity }).is_some()
+					SkillAgentMut::try_get_context_mut(&mut p, InitializedAgent { entity })
+						.is_some()
 				})?;
 
 			assert!(ctx);

--- a/src/plugins/physics/src/system_params/skill_agent/initialize.rs
+++ b/src/plugins/physics/src/system_params/skill_agent/initialize.rs
@@ -26,7 +26,7 @@ mod tests {
 	};
 	use common::{
 		tools::action_key::slot::SlotKey,
-		traits::{accessors::get::GetContextMut, handles_skill_physics::NotInitializedAgent},
+		traits::{accessors::get::TryGetContextMut, handles_skill_physics::NotInitializedAgent},
 	};
 	use testing::SingleThreadedApp;
 
@@ -47,7 +47,8 @@ mod tests {
 		app.world_mut()
 			.run_system_once(move |mut p: SkillAgentMut| {
 				let mut ctx =
-					SkillAgentMut::get_context_mut(&mut p, NotInitializedAgent { entity }).unwrap();
+					SkillAgentMut::try_get_context_mut(&mut p, NotInitializedAgent { entity })
+						.unwrap();
 
 				ctx.initialize(map_clone.clone());
 			})?;
@@ -71,7 +72,8 @@ mod tests {
 		app.world_mut()
 			.run_system_once(move |mut p: SkillAgentMut| {
 				let mut ctx =
-					SkillAgentMut::get_context_mut(&mut p, NotInitializedAgent { entity }).unwrap();
+					SkillAgentMut::try_get_context_mut(&mut p, NotInitializedAgent { entity })
+						.unwrap();
 
 				ctx.initialize(map_clone.clone());
 			})?;

--- a/src/plugins/physics/src/system_params/skill_agent/target.rs
+++ b/src/plugins/physics/src/system_params/skill_agent/target.rs
@@ -34,7 +34,7 @@ mod tests {
 	use common::{
 		components::persistent_entity::PersistentEntity,
 		traits::{
-			accessors::get::{GetContext, GetContextMut},
+			accessors::get::{TryGetContext, TryGetContextMut},
 			handles_skill_physics::{InitializedAgent, SkillMountBone, Target as _},
 		},
 	};
@@ -58,7 +58,7 @@ mod tests {
 
 		let target = app.world_mut().run_system_once(move |p: SkillAgent| {
 			let key = InitializedAgent { entity };
-			let ctx = SkillAgent::get_context(&p, key).unwrap();
+			let ctx = SkillAgent::try_get_context(&p, key).unwrap();
 			ctx.target().copied()
 		})?;
 
@@ -82,7 +82,7 @@ mod tests {
 			.world_mut()
 			.run_system_once(move |mut p: SkillAgentMut| {
 				let key = InitializedAgent { entity };
-				let ctx = SkillAgentMut::get_context_mut(&mut p, key).unwrap();
+				let ctx = SkillAgentMut::try_get_context_mut(&mut p, key).unwrap();
 				ctx.target().copied()
 			})?;
 
@@ -105,7 +105,7 @@ mod tests {
 		app.world_mut()
 			.run_system_once(move |mut p: SkillAgentMut| {
 				let key = InitializedAgent { entity };
-				let mut ctx = SkillAgentMut::get_context_mut(&mut p, key).unwrap();
+				let mut ctx = SkillAgentMut::try_get_context_mut(&mut p, key).unwrap();
 				*ctx.target_mut() = Some(SkillTarget::Entity(target_entity));
 			})?;
 

--- a/src/plugins/physics/src/systems/update_target_pitch.rs
+++ b/src/plugins/physics/src/systems/update_target_pitch.rs
@@ -8,7 +8,7 @@ use bevy::{
 };
 use common::{
 	traits::{
-		accessors::get::{Get, GetContextMut},
+		accessors::get::{Get, TryGetContextMut},
 		handles_animations::{Animations, DirForwardPitch, ForwardPitch, GetForwardPitchMut},
 		handles_physics::{MouseHover, MouseHoversOver, Raycast},
 		handles_skill_physics::{Cursor, SkillTarget},
@@ -27,11 +27,11 @@ impl Target {
 	) where
 		for<'w, 's> TRayCast: SystemParam<Item<'w, 's>: Raycast<MouseHover>>,
 		for<'c> TAnimations:
-			SystemParam + GetContextMut<Animations, TContext<'c>: GetForwardPitchMut>,
+			SystemParam + TryGetContextMut<Animations, TContext<'c>: GetForwardPitchMut>,
 	{
 		for (entity, target, transform, offset) in targets {
 			let key = Animations { entity };
-			let Some(mut ctx) = TAnimations::get_context_mut(&mut animations, key) else {
+			let Some(mut ctx) = TAnimations::try_get_context_mut(&mut animations, key) else {
 				continue;
 			};
 			let pitch = target.get_pitch(


### PR DESCRIPTION
In preparation of  adding infallible system param getter traits: renamed  `GetContext(Mut)` to `TryGetContext(Mut)`