### PR TITLE
Remove get context changed

### DIFF
--- a/src/plugins/agents/src/systems/agent_config/animate_skills.rs
+++ b/src/plugins/agents/src/systems/agent_config/animate_skills.rs
@@ -3,7 +3,7 @@ use bevy::{ecs::system::StaticSystemParam, prelude::*};
 use common::{
 	tools::action_key::slot::SlotKey,
 	traits::{
-		accessors::get::{GetChangedContext, TryGetContext, TryGetContextMut},
+		accessors::get::{ContextChanged, TryGetContext, TryGetContextMut},
 		handles_animations::{
 			ActiveAnimationsMut,
 			AnimationKey,
@@ -26,9 +26,12 @@ impl AgentConfig {
 	{
 		for entity in agents {
 			let key = Skills { entity };
-			let Some(loadout) = TLoadout::get_changed_context(&loadout, key) else {
+			let Some(loadout) = TLoadout::try_get_context(&loadout, key) else {
 				continue;
 			};
+			if !loadout.context_changed() {
+				continue;
+			}
 
 			let key = Animations { entity };
 			let Some(mut animations) = TAnimations::try_get_context_mut(&mut animations, key)

--- a/src/plugins/agents/src/systems/enemy/animate_movement.rs
+++ b/src/plugins/agents/src/systems/enemy/animate_movement.rs
@@ -3,7 +3,7 @@ use bevy::{ecs::system::StaticSystemParam, prelude::*};
 use common::{
 	errors::Level,
 	traits::{
-		accessors::get::{GetChangedContext, Logged, TryGetContext, TryGetContextMut, View},
+		accessors::get::{ContextChanged, Logged, TryGetContext, TryGetContextMut, View},
 		handles_animations::{ActiveAnimationsMut, AnimationKey, Animations},
 		handles_movement::{Movement, MovementTarget},
 	},
@@ -23,9 +23,12 @@ impl Enemy {
 	{
 		for entity in enemies {
 			let key = Logged::key(Movement { entity }).with_level(Level::Error);
-			let Some(movement) = TMovement::get_changed_context(&movement, key) else {
+			let Some(movement) = TMovement::try_get_context(&movement, key) else {
 				continue;
 			};
+			if !movement.context_changed() {
+				continue;
+			}
 
 			let key = Logged::key(Animations { entity }).with_level(Level::Error);
 			let Some(mut animations) = TAnimations::try_get_context_mut(&mut animations, key)

--- a/src/plugins/agents/src/systems/player/animate_movement.rs
+++ b/src/plugins/agents/src/systems/player/animate_movement.rs
@@ -3,14 +3,7 @@ use bevy::{ecs::system::StaticSystemParam, prelude::*};
 use common::{
 	errors::Level,
 	traits::{
-		accessors::get::{
-			GetChangedContext,
-			Logged,
-			TryGetContext,
-			TryGetContextMut,
-			View,
-			ViewOf,
-		},
+		accessors::get::{ContextChanged, Logged, TryGetContext, TryGetContextMut, View, ViewOf},
 		handles_animations::{ActiveAnimationsMut, AnimationKey, AnimationPriority, Animations},
 		handles_movement::{CurrentMovement, Movement, MovementTarget, SpeedToggle},
 	},
@@ -29,9 +22,12 @@ impl Player {
 	{
 		for entity in players {
 			let key = Logged::key(Movement { entity }).with_level(Level::Error);
-			let Some(movement) = TMovement::get_changed_context(&movement, key) else {
+			let Some(movement) = TMovement::try_get_context(&movement, key) else {
 				continue;
 			};
+			if !movement.context_changed() {
+				continue;
+			}
 
 			let key = Logged::key(Animations { entity }).with_level(Level::Error);
 			let Some(mut animations) = TAnimations::try_get_context_mut(&mut animations, key)

--- a/src/plugins/common/src/traits/accessors/get.rs
+++ b/src/plugins/common/src/traits/accessors/get.rs
@@ -121,7 +121,7 @@ where
 	}
 }
 
-/// A wrapper for [`GetContext`] and [`GetContextMut`] keys.
+/// A wrapper for [`TryGetContext`] and [`TryGetContextMut`] keys.
 ///
 /// Both traits have a blanket implementation to log [`None`] cases.
 pub struct Logged<TKey>

--- a/src/plugins/common/src/traits/accessors/get.rs
+++ b/src/plugins/common/src/traits/accessors/get.rs
@@ -49,28 +49,6 @@ pub trait TryGetContext<TKey>: SystemParam + ThreadSafe {
 	) -> Option<Self::TContext<'ctx>>;
 }
 
-pub trait GetChangedContext<TKey>: TryGetContext<TKey> {
-	fn get_changed_context<'ctx>(
-		param: &'ctx SystemParamItem<Self>,
-		key: TKey,
-	) -> Option<Self::TContext<'ctx>>;
-}
-
-impl<T, TKey> GetChangedContext<TKey> for T
-where
-	T: TryGetContext<TKey>,
-{
-	fn get_changed_context<'ctx>(
-		param: &'ctx SystemParamItem<Self>,
-		key: TKey,
-	) -> Option<Self::TContext<'ctx>> {
-		match T::try_get_context(param, key) {
-			Some(ctx) if ctx.context_changed() => Some(ctx),
-			_ => None,
-		}
-	}
-}
-
 pub trait GetMut<TKey> {
 	type TValue<'a>
 	where


### PR DESCRIPTION
- removed `GetContextChanged`: It would get complicated if we wanted to also blanked implement this for future infallible context getters. It also removes the dependency of some systems on traits that aren't directly involved in its trait constraints
- fixed docs on `Logged` helper struct: Although the `Try..` pattern might change soon again, for now we fixed the docs there so we reference to current traits