### PR TITLE
Simplify `InteractiveType` and add variant

### DIFF
--- a/src/plugins/common/src/traits/handles_map_generation.rs
+++ b/src/plugins/common/src/traits/handles_map_generation.rs
@@ -156,14 +156,10 @@ impl PrefabType for AgentType {
 
 #[derive(Debug, PartialEq, Clone, Copy, Serialize, Deserialize)]
 pub enum InteractiveType {
-	Door(DoorType),
+	Door,
+	Container,
 }
 
 impl PrefabType for InteractiveType {
 	type TTranslation = Vec3;
-}
-
-#[derive(Debug, PartialEq, Clone, Copy, Serialize, Deserialize)]
-pub enum DoorType {
-	SlideDoor,
 }

--- a/src/plugins/interactive/src/components.rs
+++ b/src/plugins/interactive/src/components.rs
@@ -1,3 +1,4 @@
+pub(crate) mod container;
 pub(crate) mod door;
 pub(crate) mod door_meta_handle;
 pub(crate) mod interactive;

--- a/src/plugins/interactive/src/components/container.rs
+++ b/src/plugins/interactive/src/components/container.rs
@@ -1,0 +1,4 @@
+use bevy::prelude::*;
+
+#[derive(Component, Debug, PartialEq)]
+pub(crate) struct Container;

--- a/src/plugins/interactive/src/components/door.rs
+++ b/src/plugins/interactive/src/components/door.rs
@@ -4,17 +4,14 @@ use common::{
 	components::model::{Model, SceneId, UseGltfLookup},
 	errors::Unreachable,
 	systems::register_animations::AnimationsMarker,
-	traits::{
-		handles_map_generation::DoorType,
-		prefab::{Prefab, PrefabEntityCommands},
-	},
+	traits::prefab::{Prefab, PrefabEntityCommands},
 };
 use macros::asset_path;
 
 #[derive(Component, Debug, PartialEq)]
 #[component(immutable)]
 #[require(DoorMetaHandle, Transform, ApplyDoorAnimations, ApplyDoorFrame)]
-pub(crate) struct Door(pub(crate) DoorType);
+pub(crate) struct Door;
 
 impl Prefab<()> for Door {
 	type TError = Unreachable;
@@ -25,19 +22,15 @@ impl Prefab<()> for Door {
 		entity: &mut impl PrefabEntityCommands,
 		assets: StaticSystemParam<Res<AssetServer>>,
 	) -> Result<(), Self::TError> {
-		let bundle = match self.0 {
-			DoorType::SlideDoor => (
-				Name::from("SlideDoor"),
-				Model::scene((
-					asset_path!("maps/assets/slide_door/model.glb"),
-					SceneId(0),
-					UseGltfLookup(true),
-				)),
-				DoorMetaHandle(assets.load(asset_path!("maps/assets/slide_door/meta.door"))),
-			),
-		};
-
-		entity.try_insert(bundle);
+		entity.try_insert((
+			Name::from("SlideDoor"),
+			Model::scene((
+				asset_path!("maps/assets/slide_door/model.glb"),
+				SceneId(0),
+				UseGltfLookup(true),
+			)),
+			DoorMetaHandle(assets.load(asset_path!("maps/assets/slide_door/meta.door"))),
+		));
 
 		Ok(())
 	}

--- a/src/plugins/interactive/src/components/interactive.rs
+++ b/src/plugins/interactive/src/components/interactive.rs
@@ -11,7 +11,7 @@ use macros::SavableComponent;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
-use crate::components::door::Door;
+use crate::components::{container::Container, door::Door};
 
 #[derive(Component, SavableComponent, Debug, PartialEq, Clone, Serialize, Deserialize)]
 #[component(immutable)]
@@ -32,7 +32,8 @@ impl Interactive {
 		));
 
 		match interactive_type {
-			InteractiveType::Door(door_type) => entity.try_insert(Door(door_type)),
+			InteractiveType::Door => entity.try_insert(Door),
+			InteractiveType::Container => entity.try_insert(Container),
 		};
 	}
 

--- a/src/plugins/interactive/src/systems/animate_door.rs
+++ b/src/plugins/interactive/src/systems/animate_door.rs
@@ -50,10 +50,7 @@ impl From<OpenClose> for AnimationPriority {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use common::traits::{
-		handles_animations::{ActiveAnimations, AnimationKey, AnimationPriority},
-		handles_map_generation::DoorType,
-	};
+	use common::traits::handles_animations::{ActiveAnimations, AnimationKey, AnimationPriority};
 	use std::{collections::HashMap, iter::Copied, ops::DerefMut, slice::Iter};
 	use testing::{IsChanged, SingleThreadedApp, fake_entity};
 	use zyheeda_core::collections::ordered::OrderedSet;
@@ -117,7 +114,7 @@ mod tests {
 		let entity = app
 			.world_mut()
 			.spawn((
-				Door(DoorType::SlideDoor),
+				Door,
 				_Animations(HashMap::from([(
 					AnimationPriority::High,
 					OrderedSet::from([AnimationKey::Close, AnimationKey::Idle]),
@@ -142,7 +139,7 @@ mod tests {
 		let entity = app
 			.world_mut()
 			.spawn((
-				Door(DoorType::SlideDoor),
+				Door,
 				_Animations(HashMap::from([(
 					AnimationPriority::High,
 					OrderedSet::from([AnimationKey::Open, AnimationKey::Idle]),
@@ -177,10 +174,7 @@ mod tests {
 	#[test]
 	fn act_only_once() {
 		let mut app = setup(_Interaction(vec![fake_entity!(42)]));
-		let entity = app
-			.world_mut()
-			.spawn((Door(DoorType::SlideDoor), _Animations::default()))
-			.id();
+		let entity = app.world_mut().spawn((Door, _Animations::default())).id();
 
 		app.update();
 		app.world_mut()
@@ -197,10 +191,7 @@ mod tests {
 	#[test]
 	fn act_again_if_interactions_changed() {
 		let mut app = setup(_Interaction(vec![fake_entity!(42)]));
-		let entity = app
-			.world_mut()
-			.spawn((Door(DoorType::SlideDoor), _Animations::default()))
-			.id();
+		let entity = app.world_mut().spawn((Door, _Animations::default())).id();
 
 		app.update();
 		app.world_mut()

--- a/src/plugins/map_generation/src/lib.rs
+++ b/src/plugins/map_generation/src/lib.rs
@@ -33,7 +33,7 @@ use common::{
 		handles_enemies::EnemyType,
 		handles_lights::HandlesLights,
 		handles_load_tracking::{AssetsProgress, HandlesLoadTracking, LoadTrackingInApp},
-		handles_map_generation::{AgentType, DoorType, HandlesMapGeneration, InteractiveType},
+		handles_map_generation::{AgentType, HandlesMapGeneration, InteractiveType},
 		handles_physics::{HandlesPhysicsConfig, HandlesRaycast},
 		handles_saving::HandlesSaving,
 		prefab::AddPrefabObserver,
@@ -65,7 +65,7 @@ where
 	];
 	const INTERACTIVE_SPAWNERS: &[(GetNormalizedName, InteractiveType)] = &[(
 		|| NormalizedName::from("SlideDoorSpawn"),
-		InteractiveType::Door(DoorType::SlideDoor),
+		InteractiveType::Door,
 	)];
 	const MESH_COLLIDER_PREFIX: &str = "Collider";
 	const NAV_MESH_PREFIX: &str = "NavMesh";


### PR DESCRIPTION
- removed interactive sub-type `DoorType`. We should add this back later, if needed. But currently this serves no point
- added `Container` to `InteractiveType`. This also serves no real point at the moment, but allows valid tests against enum variants. Also, we'll likely add container interactives in the future (looting dead enemies/drops, other containers)
