### PR TITLE
Update to rust `1.96.0`

### DIFF
--- a/src/plugins/savegame/src/systems/write_buffer.rs
+++ b/src/plugins/savegame/src/systems/write_buffer.rs
@@ -11,7 +11,7 @@ use std::{
 
 impl<T> WriteBufferSystem for T {}
 
-pub trait WriteBufferSystem {
+pub(crate) trait WriteBufferSystem {
 	fn write_buffer_system(
 		context: Arc<Mutex<Self>>,
 	) -> impl Fn(&mut World) -> Result<(), SerializationOrLockError>


### PR DESCRIPTION
Made `WriteBufferSystem` crate private, because rustc version `1.96.0` can't leak crate private type `SerializationOrLockError` via a public trait.