### PR TITLE
Entities can be querriesd for their type

### DIFF
--- a/src/plugins/common/src/traits.rs
+++ b/src/plugins/common/src/traits.rs
@@ -17,6 +17,7 @@ pub mod handles_custom_assets;
 pub mod handles_enemies;
 pub mod handles_graphics;
 pub mod handles_input;
+pub mod handles_interactive;
 pub mod handles_lights;
 pub mod handles_load_tracking;
 pub mod handles_loadout;

--- a/src/plugins/common/src/traits/handles_interactive.rs
+++ b/src/plugins/common/src/traits/handles_interactive.rs
@@ -1,0 +1,17 @@
+use crate::traits::{
+	accessors::get::{TryGetContext, View},
+	handles_map_generation::InteractiveType,
+	thread_safe::ThreadSafe,
+};
+use bevy::{ecs::system::SystemParam, prelude::*};
+use macros::EntityKey;
+
+pub trait HandlesInteractive: ThreadSafe {
+	type TInteractive: SystemParam
+		+ for<'c> TryGetContext<Interactive, TContext<'c>: View<InteractiveType>>;
+}
+
+#[derive(EntityKey)]
+pub struct Interactive {
+	entity: Entity,
+}

--- a/src/plugins/common/src/traits/handles_interactive.rs
+++ b/src/plugins/common/src/traits/handles_interactive.rs
@@ -1,17 +1,16 @@
 use crate::traits::{
 	accessors::get::{TryGetContext, View},
 	handles_map_generation::InteractiveType,
-	thread_safe::ThreadSafe,
 };
 use bevy::{ecs::system::SystemParam, prelude::*};
 use macros::EntityKey;
 
-pub trait HandlesInteractive: ThreadSafe {
+pub trait HandlesInteractive {
 	type TInteractive: SystemParam
 		+ for<'c> TryGetContext<Interactive, TContext<'c>: View<InteractiveType>>;
 }
 
 #[derive(EntityKey)]
 pub struct Interactive {
-	entity: Entity,
+	pub entity: Entity,
 }

--- a/src/plugins/common/src/traits/handles_map_generation.rs
+++ b/src/plugins/common/src/traits/handles_map_generation.rs
@@ -160,6 +160,10 @@ pub enum InteractiveType {
 	Container,
 }
 
+impl ViewField for InteractiveType {
+	type TValue<'a> = Self;
+}
+
 impl PrefabType for InteractiveType {
 	type TTranslation = Vec3;
 }

--- a/src/plugins/interactive/src/lib.rs
+++ b/src/plugins/interactive/src/lib.rs
@@ -1,5 +1,6 @@
 mod assets;
 mod components;
+mod system_params;
 mod systems;
 
 use crate::{
@@ -8,6 +9,7 @@ use crate::{
 		door::{ApplyDoorAnimations, ApplyDoorFrame, Door},
 		interactive::Interactive,
 	},
+	system_params::interactive_param::InteractiveParam,
 };
 use bevy::prelude::*;
 use common::{
@@ -17,6 +19,7 @@ use common::{
 		after_plugin::AfterPlugin,
 		handles_animations::HandlesAnimations,
 		handles_custom_assets::HandlesCustomFolderAssets,
+		handles_interactive::HandlesInteractive,
 		handles_map_generation::HandlesMapGeneration,
 		handles_physics::{HandlesInteractiveDetection, HandlesPhysicsConfig},
 		prefab::AddPrefabObserver,
@@ -70,4 +73,8 @@ where
 					.after_plugin(TPhysics::SYSTEMS),
 			);
 	}
+}
+
+impl<TDependencies> HandlesInteractive for InteractivePlugin<TDependencies> {
+	type TInteractive = InteractiveParam<'static, 'static>;
 }

--- a/src/plugins/interactive/src/system_params.rs
+++ b/src/plugins/interactive/src/system_params.rs
@@ -1,0 +1,1 @@
+pub(crate) mod interactive_param;

--- a/src/plugins/interactive/src/system_params/interactive_param.rs
+++ b/src/plugins/interactive/src/system_params/interactive_param.rs
@@ -1,0 +1,39 @@
+mod view_interactive_type;
+
+use crate::components::interactive::Interactive;
+use bevy::{
+	ecs::system::{SystemParam, SystemParamItem},
+	prelude::*,
+};
+use common::traits::{
+	accessors::get::{ContextChanged, TryGetContext},
+	handles_interactive::Interactive as InteractiveKey,
+};
+
+#[derive(SystemParam)]
+pub struct InteractiveParam<'w, 's> {
+	interactive_entities: Query<'w, 's, Ref<'static, Interactive>>,
+}
+
+impl TryGetContext<InteractiveKey> for InteractiveParam<'static, 'static> {
+	type TContext<'ctx> = InteractiveContext<'ctx>;
+
+	fn try_get_context<'ctx>(
+		param: &'ctx SystemParamItem<Self>,
+		InteractiveKey { entity }: InteractiveKey,
+	) -> Option<Self::TContext<'ctx>> {
+		Some(InteractiveContext {
+			interactive: param.interactive_entities.get(entity).ok()?,
+		})
+	}
+}
+
+pub struct InteractiveContext<'ctx> {
+	interactive: Ref<'ctx, Interactive>,
+}
+
+impl ContextChanged for InteractiveContext<'_> {
+	fn context_changed(&self) -> bool {
+		self.interactive.is_changed()
+	}
+}

--- a/src/plugins/interactive/src/system_params/interactive_param/view_interactive_type.rs
+++ b/src/plugins/interactive/src/system_params/interactive_param/view_interactive_type.rs
@@ -1,0 +1,47 @@
+use crate::system_params::interactive_param::InteractiveContext;
+use common::traits::{accessors::get::View, handles_map_generation::InteractiveType};
+
+impl View<InteractiveType> for InteractiveContext<'_> {
+	fn view(&self) -> InteractiveType {
+		self.interactive.interactive_type
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::{
+		components::interactive::Interactive,
+		system_params::interactive_param::InteractiveParam,
+	};
+	use bevy::{
+		ecs::system::{RunSystemError, RunSystemOnce},
+		prelude::*,
+	};
+	use common::traits::{
+		accessors::get::TryGetContext,
+		handles_interactive::Interactive as InteractiveKey,
+	};
+	use test_case::test_case;
+	use testing::SingleThreadedApp;
+
+	fn setup() -> App {
+		App::new().single_threaded(Update)
+	}
+
+	#[test_case(InteractiveType::Door;  "door")]
+	#[test_case(InteractiveType::Container;  "container")]
+	fn get_slide_door(interactive_type: InteractiveType) -> Result<(), RunSystemError> {
+		let mut app = setup();
+		let entity = app.world_mut().spawn(Interactive { interactive_type }).id();
+
+		let got = app
+			.world_mut()
+			.run_system_once(move |i: InteractiveParam| {
+				InteractiveParam::try_get_context(&i, InteractiveKey { entity }).map(|c| c.view())
+			})?;
+
+		assert_eq!(Some(interactive_type), got);
+		Ok(())
+	}
+}


### PR DESCRIPTION
- added `HandlesInteractive` trait
- implemented trait for `InteractivePluding`

This allows to check entities for their type. Will enable selective actions of agents when interacting with specific entities.