### PR TITLE
Rework render layers and camera targeting

### DIFF
--- a/src/plugins/bars/src/lib.rs
+++ b/src/plugins/bars/src/lib.rs
@@ -4,12 +4,11 @@ mod traits;
 
 use bevy::{
 	app::{App, Plugin, Update},
-	camera::{Camera, visibility::RenderLayers},
+	camera::Camera,
 	ecs::schedule::IntoScheduleConfigs,
 };
 use common::{
 	attributes::health::Health,
-	components::ui_node_for::UiNodeFor,
 	traits::{
 		handles_agents::HandlesAgents,
 		handles_graphics::UiCamera,
@@ -44,11 +43,9 @@ where
 	fn build(&self, app: &mut App) {
 		let update_life_bars =
 			bar::<TPhysics::TAffectedComponent, Health, Camera, TGraphics::TUiCamera>;
-		let render_life_bars = render_bar::<Health>;
-		let render_layer = UiNodeFor::<Bar>::render_layer::<TGraphics::TUiCamera>;
+		let render_life_bars = render_bar::<Health, TGraphics::TUiCamera>;
 
 		app.register_required_components::<TAgents::TAgent, Bar>();
-		app.register_required_components_with::<UiNodeFor<Bar>, RenderLayers>(render_layer);
 
 		app.manage_ownership::<Bar>(Update);
 		app.add_systems(Update, (update_life_bars, render_life_bars).chain());

--- a/src/plugins/bars/src/systems/render_bar.rs
+++ b/src/plugins/bars/src/systems/render_bar.rs
@@ -3,20 +3,25 @@ use crate::{
 	traits::UIBarColors,
 };
 use bevy::prelude::*;
-use common::components::ui_node_for::UiNodeFor;
+use common::{components::ui_node_for::UiNodeFor, traits::thread_safe::ThreadSafe};
 
 const BASE_DIMENSIONS: Vec2 = Vec2::new(100., 10.);
 
-pub(crate) fn render_bar<T: Send + Sync + 'static>(
+pub(crate) fn render_bar<T, TCamera>(
 	mut commands: Commands,
 	mut bars: Query<(Entity, &Bar, &mut BarValues<T>)>,
 	mut styles: Query<&mut Node>,
+	cameras: Query<Entity, With<TCamera>>,
 ) where
+	T: ThreadSafe,
 	BarValues<T>: UIBarColors,
+	TCamera: Component,
 {
+	let cam = cameras.single().ok();
+
 	for (bar_id, bar, bar_values) in &mut bars {
 		match (bar.position, bar_values.ui) {
-			(Some(position), None) => add_ui(&mut commands, bar_id, bar, bar_values, position),
+			(Some(position), None) => add_ui(&mut commands, bar_id, bar, bar_values, position, cam),
 			(Some(position), Some(ui)) => update_ui(&mut styles, ui, bar, bar_values, position),
 			_ => noop(),
 		}
@@ -29,24 +34,27 @@ fn add_ui<T: Send + Sync + 'static>(
 	bar: &Bar,
 	mut bar_values: Mut<BarValues<T>>,
 	position: Vec2,
+	camera: Option<Entity>,
 ) where
 	BarValues<T>: UIBarColors,
 {
 	let scaled_dimension = BASE_DIMENSIONS * bar.scale;
-	let background = commands
-		.spawn((
-			UiNodeFor::<Bar>::with(bar_id),
-			Node {
-				width: Val::Px(scaled_dimension.x),
-				height: Val::Px(scaled_dimension.y),
-				position_type: PositionType::Absolute,
-				left: Val::Px(position.x - scaled_dimension.x / 2.),
-				top: Val::Px(position.y - scaled_dimension.y / 2.),
-				..default()
-			},
-			BackgroundColor::from(BarValues::<T>::background_color()),
-		))
-		.id();
+	let mut background = commands.spawn((
+		UiNodeFor::<Bar>::with(bar_id),
+		Node {
+			width: Val::Px(scaled_dimension.x),
+			height: Val::Px(scaled_dimension.y),
+			position_type: PositionType::Absolute,
+			left: Val::Px(position.x - scaled_dimension.x / 2.),
+			top: Val::Px(position.y - scaled_dimension.y / 2.),
+			..default()
+		},
+		BackgroundColor::from(BarValues::<T>::background_color()),
+	));
+	if let Some(camera) = camera {
+		background.insert(UiTargetCamera(camera));
+	}
+	let background = background.id();
 	let foreground = commands
 		.spawn((
 			Node {
@@ -86,9 +94,11 @@ fn noop() {}
 #[cfg(test)]
 mod tests {
 	#![allow(clippy::unwrap_used)]
-	use testing::assert_count;
-
 	use super::*;
+	use testing::{SingleThreadedApp, assert_count};
+
+	#[derive(Component)]
+	struct _Camera;
 
 	struct _Display;
 
@@ -102,11 +112,17 @@ mod tests {
 		}
 	}
 
+	fn setup() -> App {
+		let mut app = App::new().single_threaded(Update);
+
+		app.add_systems(Update, render_bar::<_Display, _Camera>);
+
+		app
+	}
+
 	#[test]
 	fn add_node_bundle() {
-		let mut app = App::new();
-		app.add_systems(Update, render_bar::<_Display>);
-
+		let mut app = setup();
 		let bar = Bar {
 			position: Some(default()),
 			..default()
@@ -136,10 +152,28 @@ mod tests {
 	}
 
 	#[test]
-	fn add_ownership_on_top_node() {
-		let mut app = App::new();
-		app.add_systems(Update, render_bar::<_Display>);
+	fn add_camera_target() {
+		let mut app = setup();
+		let bar = Bar {
+			position: Some(default()),
+			..default()
+		};
+		let bar_values = BarValues::<_Display>::new(0., 0.);
+		let camera = app.world_mut().spawn(_Camera).id();
+		app.world_mut().spawn((bar, bar_values));
 
+		app.update();
+
+		let mut top = app
+			.world_mut()
+			.query_filtered::<&UiTargetCamera, (With<Node>, Without<ChildOf>)>();
+		let [UiTargetCamera(target_camera)] = assert_count!(1, top.iter(app.world()));
+		assert_eq!(&camera, target_camera);
+	}
+
+	#[test]
+	fn add_ownership_on_top_node() {
+		let mut app = setup();
 		let bar = Bar {
 			position: Some(default()),
 			..default()
@@ -158,9 +192,7 @@ mod tests {
 
 	#[test]
 	fn set_dimensions() {
-		let mut app = App::new();
-		app.add_systems(Update, render_bar::<_Display>);
-
+		let mut app = setup();
 		let bar = Bar {
 			scale: 1.,
 			position: Some(default()),
@@ -181,9 +213,7 @@ mod tests {
 
 	#[test]
 	fn set_dimensions_scaled() {
-		let mut app = App::new();
-		app.add_systems(Update, render_bar::<_Display>);
-
+		let mut app = setup();
 		let bar = Bar {
 			scale: 2.,
 			position: Some(default()),
@@ -207,9 +237,7 @@ mod tests {
 
 	#[test]
 	fn set_position() {
-		let mut app = App::new();
-		app.add_systems(Update, render_bar::<_Display>);
-
+		let mut app = setup();
 		let bar = Bar {
 			scale: 1.,
 			position: Some(Vec2::new(300., 400.)),
@@ -234,9 +262,7 @@ mod tests {
 
 	#[test]
 	fn set_position_scaled() {
-		let mut app = App::new();
-		app.add_systems(Update, render_bar::<_Display>);
-
+		let mut app = setup();
 		let bar = Bar {
 			scale: 2.,
 			position: Some(Vec2::new(300., 400.)),
@@ -261,9 +287,7 @@ mod tests {
 
 	#[test]
 	fn set_background_color() {
-		let mut app = App::new();
-		app.add_systems(Update, render_bar::<_Display>);
-
+		let mut app = setup();
 		let bar = Bar {
 			position: Some(default()),
 			..default()
@@ -282,9 +306,7 @@ mod tests {
 
 	#[test]
 	fn set_foreground_color() {
-		let mut app = App::new();
-		app.add_systems(Update, render_bar::<_Display>);
-
+		let mut app = setup();
 		let bar = Bar {
 			position: Some(default()),
 			..default()
@@ -303,9 +325,7 @@ mod tests {
 
 	#[test]
 	fn set_fill() {
-		let mut app = App::new();
-		app.add_systems(Update, render_bar::<_Display>);
-
+		let mut app = setup();
 		let bar = Bar {
 			position: Some(default()),
 			..default()
@@ -322,9 +342,7 @@ mod tests {
 
 	#[test]
 	fn update_position() {
-		let mut app = App::new();
-		app.add_systems(Update, render_bar::<_Display>);
-
+		let mut app = setup();
 		let bar = Bar {
 			scale: 1.,
 			position: Some(Vec2::new(300., 400.)),
@@ -354,9 +372,7 @@ mod tests {
 
 	#[test]
 	fn update_position_scaled() {
-		let mut app = App::new();
-		app.add_systems(Update, render_bar::<_Display>);
-
+		let mut app = setup();
 		let bar = Bar {
 			scale: 2.,
 			position: Some(Vec2::new(300., 400.)),
@@ -386,9 +402,7 @@ mod tests {
 
 	#[test]
 	fn update_fill() {
-		let mut app = App::new();
-		app.add_systems(Update, render_bar::<_Display>);
-
+		let mut app = setup();
 		let bar = Bar {
 			position: Some(default()),
 			..default()

--- a/src/plugins/common/src/components/ui_node_for.rs
+++ b/src/plugins/common/src/components/ui_node_for.rs
@@ -1,5 +1,4 @@
-use crate::traits::handles_graphics::StaticRenderLayers;
-use bevy::{camera::visibility::RenderLayers, prelude::*};
+use bevy::prelude::*;
 use std::marker::PhantomData;
 
 #[derive(Component, Debug, PartialEq)]
@@ -14,33 +13,5 @@ impl<T> UiNodeFor<T> {
 			owner,
 			owner_type: PhantomData,
 		}
-	}
-
-	pub fn render_layer<TUiCamera>() -> RenderLayers
-	where
-		TUiCamera: StaticRenderLayers,
-	{
-		TUiCamera::render_layers()
-	}
-}
-
-#[cfg(test)]
-mod tests {
-	use super::*;
-
-	#[test]
-	fn ui_node_set_render_layer() {
-		struct _T;
-
-		impl StaticRenderLayers for _T {
-			fn render_layers() -> RenderLayers {
-				RenderLayers::layer(42)
-			}
-		}
-
-		assert_eq!(
-			RenderLayers::layer(42),
-			UiNodeFor::<()>::render_layer::<_T>()
-		);
 	}
 }

--- a/src/plugins/common/src/traits/handles_graphics.rs
+++ b/src/plugins/common/src/traits/handles_graphics.rs
@@ -1,11 +1,7 @@
-use bevy::{camera::visibility::RenderLayers, prelude::Component};
-
-pub trait StaticRenderLayers {
-	fn render_layers() -> RenderLayers;
-}
+use bevy::prelude::*;
 
 pub trait UiCamera {
-	type TUiCamera: Component + StaticRenderLayers;
+	type TUiCamera: Component;
 }
 
 pub trait FirstPassCamera {

--- a/src/plugins/graphics/src/components.rs
+++ b/src/plugins/graphics/src/components.rs
@@ -1,5 +1,5 @@
 pub(crate) mod camera_labels;
-pub(crate) mod effect_material_config;
+pub(crate) mod effect_material_handle;
 pub(crate) mod material_override;
 
 #[cfg(not(feature = "debug-utils"))]

--- a/src/plugins/graphics/src/components.rs
+++ b/src/plugins/graphics/src/components.rs
@@ -1,6 +1,7 @@
 pub(crate) mod camera_labels;
 pub(crate) mod effect_material_handle;
 pub(crate) mod material_override;
+pub(crate) mod pass_layer;
 
 #[cfg(not(feature = "debug-utils"))]
 pub mod no_debug_cam;

--- a/src/plugins/graphics/src/components.rs
+++ b/src/plugins/graphics/src/components.rs
@@ -1,4 +1,5 @@
 pub(crate) mod camera_labels;
+pub(crate) mod child_meshes;
 pub(crate) mod effect_material_handle;
 pub(crate) mod material_override;
 pub(crate) mod pass_layer;

--- a/src/plugins/graphics/src/components/camera_labels.rs
+++ b/src/plugins/graphics/src/components/camera_labels.rs
@@ -1,4 +1,4 @@
-use crate::components::pass_layer::PassLayer;
+use crate::components::pass_layer::PassLayers;
 use bevy::{
 	camera::visibility::RenderLayers,
 	core_pipeline::tonemapping::Tonemapping,
@@ -53,9 +53,9 @@ impl From<FirstPass> for RenderLayers {
 	}
 }
 
-impl From<FirstPass> for PassLayer {
+impl From<FirstPass> for PassLayers {
 	fn from(_: FirstPass) -> Self {
-		PassLayer { layer: FIRST_PASS }
+		PassLayers::from(FIRST_PASS)
 	}
 }
 
@@ -104,9 +104,9 @@ impl From<SecondPass> for RenderLayers {
 	}
 }
 
-impl From<SecondPass> for PassLayer {
+impl From<SecondPass> for PassLayers {
 	fn from(_: SecondPass) -> Self {
-		PassLayer { layer: SECOND_PASS }
+		PassLayers::from(SECOND_PASS)
 	}
 }
 

--- a/src/plugins/graphics/src/components/camera_labels.rs
+++ b/src/plugins/graphics/src/components/camera_labels.rs
@@ -6,7 +6,6 @@ use bevy::{
 	prelude::*,
 	render::view::Hdr,
 };
-use common::traits::handles_graphics::StaticRenderLayers;
 use macros::SavableComponent;
 use serde::{Deserialize, Serialize};
 
@@ -152,11 +151,5 @@ impl From<Ui> for Tonemapping {
 impl From<Ui> for RenderLayers {
 	fn from(_: Ui) -> Self {
 		RenderLayers::layer(UI_PASS)
-	}
-}
-
-impl StaticRenderLayers for Ui {
-	fn render_layers() -> RenderLayers {
-		RenderLayers::from(Ui)
 	}
 }

--- a/src/plugins/graphics/src/components/camera_labels.rs
+++ b/src/plugins/graphics/src/components/camera_labels.rs
@@ -1,3 +1,4 @@
+use crate::components::pass_layer::PassLayer;
 use bevy::{
 	camera::visibility::RenderLayers,
 	core_pipeline::tonemapping::Tonemapping,
@@ -8,6 +9,10 @@ use bevy::{
 use common::traits::handles_graphics::StaticRenderLayers;
 use macros::SavableComponent;
 use serde::{Deserialize, Serialize};
+
+const FIRST_PASS: usize = 0;
+const SECOND_PASS: usize = 1;
+const UI_PASS: usize = 2;
 
 #[derive(Component, Debug, PartialEq, Eq, Hash, Default, Clone, Copy)]
 #[require(Camera3d)]
@@ -27,12 +32,30 @@ pub struct WorldCamera;
 	Deserialize,
 )]
 #[savable_component(id = "1st pass camera")]
-#[require(WorldCamera, Hdr, Tonemapping = Self, Bloom)]
+#[require(
+	WorldCamera,
+	Tonemapping = Self,
+	RenderLayers = Self,
+	Hdr,
+	Bloom
+)]
 pub struct FirstPass;
 
 impl From<FirstPass> for Tonemapping {
 	fn from(_: FirstPass) -> Self {
 		Tonemapping::None
+	}
+}
+
+impl From<FirstPass> for RenderLayers {
+	fn from(_: FirstPass) -> Self {
+		Self::layer(FIRST_PASS)
+	}
+}
+
+impl From<FirstPass> for PassLayer {
+	fn from(_: FirstPass) -> Self {
+		PassLayer { layer: FIRST_PASS }
 	}
 }
 
@@ -52,26 +75,18 @@ impl From<FirstPass> for Tonemapping {
 #[savable_component(id = "2nd pass camera")]
 #[require(
 	WorldCamera,
-	Hdr,
 	Camera = Self,
 	Tonemapping = Self,
+	RenderLayers = Self,
+	Hdr,
 	Bloom,
-	RenderLayers = Self::with_default_layer(),
 )]
 pub struct SecondPass;
-
-impl SecondPass {
-	const ORDER: usize = 1;
-
-	fn with_default_layer() -> RenderLayers {
-		RenderLayers::from_layers(&[0, Self::ORDER])
-	}
-}
 
 impl From<SecondPass> for Camera {
 	fn from(_: SecondPass) -> Self {
 		Camera {
-			order: SecondPass::ORDER as isize,
+			order: SECOND_PASS as isize,
 			..default()
 		}
 	}
@@ -79,13 +94,19 @@ impl From<SecondPass> for Camera {
 
 impl From<SecondPass> for Tonemapping {
 	fn from(_: SecondPass) -> Self {
-		const { Tonemapping::TonyMcMapface }
+		Tonemapping::TonyMcMapface
 	}
 }
 
 impl From<SecondPass> for RenderLayers {
 	fn from(_: SecondPass) -> Self {
-		const { RenderLayers::layer(SecondPass::ORDER) }
+		RenderLayers::from_layers(&[FIRST_PASS, SECOND_PASS])
+	}
+}
+
+impl From<SecondPass> for PassLayer {
+	fn from(_: SecondPass) -> Self {
+		PassLayer { layer: SECOND_PASS }
 	}
 }
 
@@ -105,21 +126,17 @@ impl From<SecondPass> for RenderLayers {
 #[savable_component(id = "ui camera")]
 #[require(
 	WorldCamera,
-	Hdr,
 	Camera = Self,
 	Tonemapping = Self,
 	RenderLayers = Self,
+	Hdr,
 )]
 pub struct Ui;
-
-impl Ui {
-	const ORDER: usize = 2;
-}
 
 impl From<Ui> for Camera {
 	fn from(_: Ui) -> Self {
 		Camera {
-			order: Ui::ORDER as isize,
+			order: UI_PASS as isize,
 			clear_color: ClearColorConfig::None,
 			..default()
 		}
@@ -134,7 +151,7 @@ impl From<Ui> for Tonemapping {
 
 impl From<Ui> for RenderLayers {
 	fn from(_: Ui) -> Self {
-		const { RenderLayers::layer(Ui::ORDER) }
+		RenderLayers::layer(UI_PASS)
 	}
 }
 

--- a/src/plugins/graphics/src/components/child_meshes.rs
+++ b/src/plugins/graphics/src/components/child_meshes.rs
@@ -1,0 +1,9 @@
+use bevy::{ecs::entity::EntityHashSet, prelude::*};
+
+#[derive(Component, Default)]
+#[relationship_target(relationship = ChildMeshOf)]
+pub(crate) struct ChildMeshes(EntityHashSet);
+
+#[derive(Component)]
+#[relationship(relationship_target = ChildMeshes)]
+pub(crate) struct ChildMeshOf(pub(crate) Entity);

--- a/src/plugins/graphics/src/components/effect_material_handle.rs
+++ b/src/plugins/graphics/src/components/effect_material_handle.rs
@@ -2,18 +2,10 @@ use crate::{
 	components::{camera_labels::SecondPass, pass_layer::PassLayer},
 	materials::effect_material::EffectMaterial,
 };
-use bevy::{ecs::entity::EntityHashSet, prelude::*};
+use bevy::prelude::*;
 
 #[derive(Component, Default)]
 #[require(Visibility::Hidden, PassLayer::from(SecondPass))]
 pub struct EffectMaterialHandle {
 	pub(crate) material: Handle<EffectMaterial>,
 }
-
-#[derive(Component, Default)]
-#[relationship_target(relationship = EffectMeshOf)]
-pub(crate) struct EffectMeshes(EntityHashSet);
-
-#[derive(Component)]
-#[relationship(relationship_target = EffectMeshes)]
-pub(crate) struct EffectMeshOf(pub(crate) Entity);

--- a/src/plugins/graphics/src/components/effect_material_handle.rs
+++ b/src/plugins/graphics/src/components/effect_material_handle.rs
@@ -3,14 +3,14 @@ use bevy::{ecs::entity::EntityHashSet, prelude::*};
 
 #[derive(Component, Default)]
 #[require(Visibility = Visibility::Hidden)]
-pub struct EffectShader {
+pub struct EffectMaterialHandle {
 	pub(crate) material: Handle<EffectMaterial>,
 }
 
 #[derive(Component, Default)]
-#[relationship_target(relationship = EffectShaderMeshOf)]
-pub(crate) struct EffectShaderMeshes(EntityHashSet);
+#[relationship_target(relationship = EffectMeshOf)]
+pub(crate) struct EffectMeshes(EntityHashSet);
 
 #[derive(Component)]
-#[relationship(relationship_target = EffectShaderMeshes)]
-pub(crate) struct EffectShaderMeshOf(pub(crate) Entity);
+#[relationship(relationship_target = EffectMeshes)]
+pub(crate) struct EffectMeshOf(pub(crate) Entity);

--- a/src/plugins/graphics/src/components/effect_material_handle.rs
+++ b/src/plugins/graphics/src/components/effect_material_handle.rs
@@ -1,8 +1,11 @@
-use crate::materials::effect_material::EffectMaterial;
+use crate::{
+	components::{camera_labels::SecondPass, pass_layer::PassLayer},
+	materials::effect_material::EffectMaterial,
+};
 use bevy::{ecs::entity::EntityHashSet, prelude::*};
 
 #[derive(Component, Default)]
-#[require(Visibility = Visibility::Hidden)]
+#[require(Visibility::Hidden, PassLayer::from(SecondPass))]
 pub struct EffectMaterialHandle {
 	pub(crate) material: Handle<EffectMaterial>,
 }

--- a/src/plugins/graphics/src/components/effect_material_handle.rs
+++ b/src/plugins/graphics/src/components/effect_material_handle.rs
@@ -1,11 +1,11 @@
 use crate::{
-	components::{camera_labels::SecondPass, pass_layer::PassLayer},
+	components::{camera_labels::SecondPass, pass_layer::PassLayers},
 	materials::effect_material::EffectMaterial,
 };
 use bevy::prelude::*;
 
 #[derive(Component, Default)]
-#[require(Visibility::Hidden, PassLayer::from(SecondPass))]
+#[require(Visibility::Hidden, PassLayers::from(SecondPass))]
 pub struct EffectMaterialHandle {
 	pub(crate) material: Handle<EffectMaterial>,
 }

--- a/src/plugins/graphics/src/components/pass_layer.rs
+++ b/src/plugins/graphics/src/components/pass_layer.rs
@@ -1,6 +1,21 @@
-use bevy::{camera::visibility::Layer, prelude::*};
+use bevy::{
+	camera::visibility::{Layer, RenderLayers},
+	prelude::*,
+};
 
 #[derive(Component, Debug, PartialEq)]
-pub(crate) struct PassLayer {
-	pub(crate) layer: Layer,
+pub(crate) struct PassLayers {
+	layer: Layer,
+}
+
+impl From<Layer> for PassLayers {
+	fn from(layer: Layer) -> Self {
+		Self { layer }
+	}
+}
+
+impl From<&PassLayers> for RenderLayers {
+	fn from(PassLayers { layer }: &PassLayers) -> Self {
+		RenderLayers::layer(*layer)
+	}
 }

--- a/src/plugins/graphics/src/components/pass_layer.rs
+++ b/src/plugins/graphics/src/components/pass_layer.rs
@@ -4,7 +4,7 @@ use bevy::{
 };
 
 #[derive(Component, Debug, PartialEq)]
-pub(crate) struct PassLayers {
+pub struct PassLayers {
 	layer: Layer,
 }
 

--- a/src/plugins/graphics/src/components/pass_layer.rs
+++ b/src/plugins/graphics/src/components/pass_layer.rs
@@ -1,0 +1,6 @@
+use bevy::{camera::visibility::Layer, prelude::*};
+
+#[derive(Component, Debug, PartialEq)]
+pub(crate) struct PassLayer {
+	pub(crate) layer: Layer,
+}

--- a/src/plugins/graphics/src/lib.rs
+++ b/src/plugins/graphics/src/lib.rs
@@ -6,7 +6,7 @@ mod systems;
 mod traits;
 
 use crate::{
-	components::effect_material_config::EffectShaderMeshOf,
+	components::effect_material_handle::EffectMeshOf,
 	materials::effect_material::EffectMaterial,
 };
 use bevy::{
@@ -32,7 +32,7 @@ use common::{
 };
 use components::{
 	camera_labels::{FirstPass, SecondPass, Ui, WorldCamera},
-	effect_material_config::EffectShader,
+	effect_material_handle::EffectMaterialHandle,
 	material_override::MaterialOverride,
 };
 use materials::essence_material::EssenceMaterial;
@@ -85,19 +85,19 @@ where
 	}
 
 	fn effect_shading(app: &mut App) {
-		type UnlinkedEffectShader = (Added<Mesh3d>, Without<EffectShaderMeshOf>);
+		type UnlinkedEffectMeshes = (Added<Mesh3d>, Without<EffectMeshOf>);
 
 		app.add_plugins(MaterialPlugin::<EffectMaterial>::default())
-			.add_observer(EffectShader::add_to::<TPhysics::TSkillContact>)
-			.add_observer(EffectShader::add_to::<TPhysics::TSkillProjection>)
+			.add_observer(EffectMaterialHandle::add_to::<TPhysics::TSkillContact>)
+			.add_observer(EffectMaterialHandle::add_to::<TPhysics::TSkillProjection>)
 			.add_systems(
 				Update,
 				(
-					UnlinkedEffectShader::link_to::<EffectShader, EffectShaderMeshOf>,
-					EffectShader::modify_material::<TPhysics, Force>,
-					EffectShader::modify_material::<TPhysics, Gravity>,
-					EffectShader::modify_material::<TPhysics, HealthDamage>,
-					EffectShader::propagate(SecondPass),
+					UnlinkedEffectMeshes::link_to::<EffectMaterialHandle, EffectMeshOf>,
+					EffectMaterialHandle::modify_material::<TPhysics, Force>,
+					EffectMaterialHandle::modify_material::<TPhysics, Gravity>,
+					EffectMaterialHandle::modify_material::<TPhysics, HealthDamage>,
+					EffectMaterialHandle::propagate(SecondPass),
 				)
 					.chain()
 					.after_plugin(TPhysics::SYSTEMS),

--- a/src/plugins/graphics/src/lib.rs
+++ b/src/plugins/graphics/src/lib.rs
@@ -6,7 +6,7 @@ mod systems;
 mod traits;
 
 use crate::{
-	components::{child_meshes::ChildMeshOf, pass_layer::PassLayer},
+	components::{child_meshes::ChildMeshOf, pass_layer::PassLayers},
 	materials::effect_material::EffectMaterial,
 };
 use bevy::{
@@ -96,11 +96,12 @@ where
 			.add_systems(
 				Update,
 				(
-					UnlinkedMeshes::link_to::<PassLayer, ChildMeshOf>,
+					UnlinkedMeshes::link_to::<PassLayers, ChildMeshOf>,
 					EffectMaterialHandle::modify_material::<TPhysics, Force>,
 					EffectMaterialHandle::modify_material::<TPhysics, Gravity>,
 					EffectMaterialHandle::modify_material::<TPhysics, HealthDamage>,
 					EffectMaterialHandle::propagate_material,
+					PassLayers::propagate_layer,
 				)
 					.chain()
 					.after_plugin(TPhysics::SYSTEMS),

--- a/src/plugins/graphics/src/lib.rs
+++ b/src/plugins/graphics/src/lib.rs
@@ -6,7 +6,7 @@ mod systems;
 mod traits;
 
 use crate::{
-	components::effect_material_handle::EffectMeshOf,
+	components::{child_meshes::ChildMeshOf, pass_layer::PassLayer},
 	materials::effect_material::EffectMaterial,
 };
 use bevy::{
@@ -84,30 +84,27 @@ where
 			.in_sub_app(app, RenderApp, ExtractSchedule, no_waiting_pipelines);
 	}
 
-	fn effect_shading(app: &mut App) {
-		type UnlinkedEffectMeshes = (Added<Mesh3d>, Without<EffectMeshOf>);
+	fn shading(app: &mut App) {
+		type UnlinkedMeshes = (Added<Mesh3d>, Without<ChildMeshOf>);
 
 		app.add_plugins(MaterialPlugin::<EffectMaterial>::default())
+			.register_derived_component::<Essence, MaterialOverride>()
+			.register_shader::<EssenceMaterial>()
+			.add_observer(MaterialOverride::update_essence_shader)
 			.add_observer(EffectMaterialHandle::add_to::<TPhysics::TSkillContact>)
 			.add_observer(EffectMaterialHandle::add_to::<TPhysics::TSkillProjection>)
 			.add_systems(
 				Update,
 				(
-					UnlinkedEffectMeshes::link_to::<EffectMaterialHandle, EffectMeshOf>,
+					UnlinkedMeshes::link_to::<PassLayer, ChildMeshOf>,
 					EffectMaterialHandle::modify_material::<TPhysics, Force>,
 					EffectMaterialHandle::modify_material::<TPhysics, Gravity>,
 					EffectMaterialHandle::modify_material::<TPhysics, HealthDamage>,
-					EffectMaterialHandle::propagate(SecondPass),
+					EffectMaterialHandle::propagate_material,
 				)
 					.chain()
 					.after_plugin(TPhysics::SYSTEMS),
 			);
-	}
-
-	fn essence_material(app: &mut App) {
-		app.register_derived_component::<Essence, MaterialOverride>()
-			.register_shader::<EssenceMaterial>()
-			.add_observer(MaterialOverride::update_essence_shader);
 	}
 
 	fn cameras(&self, app: &mut App) {
@@ -138,8 +135,7 @@ where
 {
 	fn build(&self, app: &mut App) {
 		Self::track_render_pipeline_ready(app);
-		Self::effect_shading(app);
-		Self::essence_material(app);
+		Self::shading(app);
 		self.cameras(app);
 	}
 }

--- a/src/plugins/graphics/src/observers/add_effect_shader.rs
+++ b/src/plugins/graphics/src/observers/add_effect_shader.rs
@@ -1,12 +1,12 @@
 use crate::{
-	components::effect_material_config::EffectShader,
+	components::effect_material_handle::EffectMaterialHandle,
 	materials::effect_material::EffectMaterial,
 	resources::first_pass_image::FirstPassImage,
 };
 use bevy::prelude::*;
 use common::{traits::accessors::get::GetMut, zyheeda_commands::ZyheedaCommands};
 
-impl EffectShader {
+impl EffectMaterialHandle {
 	pub(crate) fn add_to<TComponent>(
 		on_add: On<Add, TComponent>,
 		mut materials: ResMut<Assets<EffectMaterial>>,
@@ -20,11 +20,11 @@ impl EffectShader {
 		};
 
 		let material = EffectMaterial::from_first_pass(first_pass_image.handle.clone());
-		let shader = EffectShader {
+		let material = EffectMaterialHandle {
 			material: materials.add(material),
 		};
 
-		entity.try_insert((shader, Visibility::Hidden));
+		entity.try_insert((material, Visibility::Hidden));
 	}
 }
 
@@ -41,25 +41,25 @@ mod tests {
 
 		app.insert_resource(FirstPassImage { handle: first_pass });
 		app.init_resource::<Assets<EffectMaterial>>();
-		app.add_observer(EffectShader::add_to::<_Component>);
+		app.add_observer(EffectMaterialHandle::add_to::<_Component>);
 
 		app
 	}
 
 	#[test]
-	fn insert_shader() {
+	fn insert_material() {
 		let mut app = setup(new_handle());
 
 		let entity = app.world_mut().spawn(_Component);
 
-		assert!(entity.contains::<EffectShader>());
+		assert!(entity.contains::<EffectMaterialHandle>());
 	}
 
 	macro_rules! get_material {
 		($app:expr, $entity:expr) => {
 			$app.world()
 				.entity($entity)
-				.get::<EffectShader>()
+				.get::<EffectMaterialHandle>()
 				.and_then(|shader| {
 					$app.world()
 						.resource::<Assets<EffectMaterial>>()
@@ -69,7 +69,7 @@ mod tests {
 	}
 
 	#[test]
-	fn inserted_shader_has_first_pass_image() {
+	fn inserted_material_has_first_pass_image() {
 		let first_pass = new_handle();
 		let mut app = setup(first_pass.clone());
 
@@ -102,9 +102,9 @@ mod tests {
 		let mut app = setup(new_handle());
 
 		let mut entity = app.world_mut().spawn(_Component);
-		entity.remove::<EffectShader>();
+		entity.remove::<EffectMaterialHandle>();
 		entity.insert(_Component);
 
-		assert!(!entity.contains::<EffectShader>());
+		assert!(!entity.contains::<EffectMaterialHandle>());
 	}
 }

--- a/src/plugins/graphics/src/systems.rs
+++ b/src/plugins/graphics/src/systems.rs
@@ -1,4 +1,5 @@
 pub(crate) mod modify_material;
 pub(crate) mod no_waiting_pipelines;
 pub(crate) mod propagate_effect_material;
+pub(crate) mod propagate_pass_layer;
 pub(crate) mod spawn_cameras;

--- a/src/plugins/graphics/src/systems.rs
+++ b/src/plugins/graphics/src/systems.rs
@@ -1,4 +1,4 @@
 pub(crate) mod modify_material;
 pub(crate) mod no_waiting_pipelines;
-pub(crate) mod propagate;
+pub(crate) mod propagate_effect_material;
 pub(crate) mod spawn_cameras;

--- a/src/plugins/graphics/src/systems/modify_material.rs
+++ b/src/plugins/graphics/src/systems/modify_material.rs
@@ -1,12 +1,12 @@
 use crate::{
-	components::effect_material_config::EffectShader,
+	components::effect_material_handle::EffectMaterialHandle,
 	materials::effect_material::EffectMaterial,
 	traits::modify_material::ModifyMaterial,
 };
 use bevy::prelude::*;
 use common::traits::handles_physics::{Effect, HandlesPhysicalEffect};
 
-impl EffectShader {
+impl EffectMaterialHandle {
 	pub(crate) fn modify_material<TPhysics, TEffect>(
 		shaders: Query<&Self, Added<TPhysics::TEffectComponent>>,
 		materials: ResMut<Assets<EffectMaterial>>,
@@ -24,7 +24,7 @@ impl EffectShader {
 		TEffectComponent: Component,
 		TEffect: ModifyMaterial + 'static,
 	{
-		for EffectShader { material } in shaders {
+		for EffectMaterialHandle { material } in shaders {
 			let Some(material) = materials.get_mut(material) else {
 				continue;
 			};
@@ -64,7 +64,7 @@ mod tests {
 		app.insert_resource(material_assets);
 		app.add_systems(
 			Update,
-			EffectShader::modify_material_internal::<_Component, _Effect>,
+			EffectMaterialHandle::modify_material_internal::<_Component, _Effect>,
 		);
 
 		app
@@ -77,7 +77,7 @@ mod tests {
 		let material = EffectMaterial::from_first_pass(first_pass.clone());
 		let mut app = setup([(&handle, material)]);
 		app.world_mut().spawn((
-			EffectShader {
+			EffectMaterialHandle {
 				material: handle.clone(),
 			},
 			_Component,
@@ -101,7 +101,7 @@ mod tests {
 		let handle = new_handle();
 		let material = EffectMaterial::from_first_pass(first_pass.clone());
 		let mut app = setup([(&handle, material)]);
-		app.world_mut().spawn(EffectShader {
+		app.world_mut().spawn(EffectMaterialHandle {
 			material: handle.clone(),
 		});
 
@@ -122,7 +122,7 @@ mod tests {
 		let material = EffectMaterial::from_first_pass(first_pass.clone());
 		let mut app = setup([(&handle, material)]);
 		app.world_mut().spawn((
-			EffectShader {
+			EffectMaterialHandle {
 				material: handle.clone(),
 			},
 			_Component,

--- a/src/plugins/graphics/src/systems/propagate.rs
+++ b/src/plugins/graphics/src/systems/propagate.rs
@@ -1,27 +1,28 @@
-use crate::components::effect_material_config::{EffectShader, EffectShaderMeshes};
+use crate::components::effect_material_handle::{EffectMaterialHandle, EffectMeshes};
 use bevy::{camera::visibility::RenderLayers, prelude::*};
 use common::{traits::accessors::get::TryApplyOn, zyheeda_commands::ZyheedaCommands};
 
-impl EffectShader {
+impl EffectMaterialHandle {
 	pub(crate) fn propagate(layers: impl Into<RenderLayers>) -> impl IntoSystem<(), (), ()> {
 		let layers = layers.into();
-		IntoSystem::into_system(
-			move |mut commands: ZyheedaCommands,
-			      shaders: Query<
-				(&Self, &mut Visibility, &EffectShaderMeshes),
-				Changed<EffectShaderMeshes>,
-			>| {
-				for (Self { material }, mut visibility, shader_meshes) in shaders {
-					for entity in shader_meshes.iter() {
-						commands.try_apply_on(&entity, |mut e| {
-							e.try_remove::<MeshMaterial3d<StandardMaterial>>();
-							e.try_insert((layers.clone(), MeshMaterial3d(material.clone())));
-						});
-					}
-					*visibility = Visibility::Visible;
+
+		#[rustfmt::skip]
+		let system = move |
+			mut commands: ZyheedaCommands,
+			meshes: Query<(&Self, &mut Visibility, &EffectMeshes), Changed<EffectMeshes>>
+		| {
+			for (Self { material }, mut visibility, shader_meshes) in meshes {
+				for entity in shader_meshes.iter() {
+					commands.try_apply_on(&entity, |mut e| {
+						e.try_remove::<MeshMaterial3d<StandardMaterial>>();
+						e.try_insert((layers.clone(), MeshMaterial3d(material.clone())));
+					});
 				}
-			},
-		)
+				*visibility = Visibility::Visible;
+			}
+		};
+
+		IntoSystem::into_system(system)
 	}
 }
 
@@ -29,7 +30,7 @@ impl EffectShader {
 mod tests {
 	use super::*;
 	use crate::{
-		components::effect_material_config::EffectShaderMeshOf,
+		components::effect_material_handle::EffectMeshOf,
 		materials::effect_material::EffectMaterial,
 	};
 	use testing::{SingleThreadedApp, new_handle};
@@ -37,7 +38,7 @@ mod tests {
 	fn setup(layers: impl Into<RenderLayers>) -> App {
 		let mut app = App::new().single_threaded(Update);
 
-		app.add_systems(Update, EffectShader::propagate(layers));
+		app.add_systems(Update, EffectMaterialHandle::propagate(layers));
 
 		app
 	}
@@ -48,11 +49,11 @@ mod tests {
 		let mut app = setup(RenderLayers::default());
 		let entity = app
 			.world_mut()
-			.spawn(EffectShader {
+			.spawn(EffectMaterialHandle {
 				material: material.clone(),
 			})
 			.id();
-		let child = app.world_mut().spawn(EffectShaderMeshOf(entity)).id();
+		let child = app.world_mut().spawn(EffectMeshOf(entity)).id();
 
 		app.update();
 
@@ -67,8 +68,8 @@ mod tests {
 	#[test]
 	fn propagate_render_layer() {
 		let mut app = setup(RenderLayers::layer(3));
-		let entity = app.world_mut().spawn(EffectShader::default()).id();
-		let child = app.world_mut().spawn(EffectShaderMeshOf(entity)).id();
+		let entity = app.world_mut().spawn(EffectMaterialHandle::default()).id();
+		let child = app.world_mut().spawn(EffectMeshOf(entity)).id();
 
 		app.update();
 
@@ -81,11 +82,11 @@ mod tests {
 	#[test]
 	fn remove_standard_material() {
 		let mut app = setup(RenderLayers::default());
-		let entity = app.world_mut().spawn(EffectShader::default()).id();
+		let entity = app.world_mut().spawn(EffectMaterialHandle::default()).id();
 		let child = app
 			.world_mut()
 			.spawn((
-				EffectShaderMeshOf(entity),
+				EffectMeshOf(entity),
 				MeshMaterial3d(new_handle::<StandardMaterial>()),
 			))
 			.id();
@@ -103,9 +104,9 @@ mod tests {
 	#[test]
 	fn set_visibility_to_visible() {
 		let mut app = setup(RenderLayers::default());
-		let entity = app.world_mut().spawn(EffectShader::default()).id();
+		let entity = app.world_mut().spawn(EffectMaterialHandle::default()).id();
 		app.world_mut().spawn((
-			EffectShaderMeshOf(entity),
+			EffectMeshOf(entity),
 			MeshMaterial3d(new_handle::<StandardMaterial>()),
 		));
 
@@ -120,8 +121,8 @@ mod tests {
 	#[test]
 	fn act_only_once() {
 		let mut app = setup(RenderLayers::default());
-		let entity = app.world_mut().spawn(EffectShader::default()).id();
-		let child = app.world_mut().spawn(EffectShaderMeshOf(entity)).id();
+		let entity = app.world_mut().spawn(EffectMaterialHandle::default()).id();
+		let child = app.world_mut().spawn(EffectMeshOf(entity)).id();
 
 		app.update();
 		app.world_mut()
@@ -143,11 +144,11 @@ mod tests {
 		let mut app = setup(RenderLayers::default());
 		let entity = app
 			.world_mut()
-			.spawn(EffectShader {
+			.spawn(EffectMaterialHandle {
 				material: material.clone(),
 			})
 			.id();
-		let child = app.world_mut().spawn(EffectShaderMeshOf(entity)).id();
+		let child = app.world_mut().spawn(EffectMeshOf(entity)).id();
 
 		app.update();
 		app.world_mut()
@@ -155,7 +156,7 @@ mod tests {
 			.remove::<MeshMaterial3d<EffectMaterial>>();
 		app.world_mut()
 			.entity_mut(entity)
-			.get_mut::<EffectShaderMeshes>()
+			.get_mut::<EffectMeshes>()
 			.as_deref_mut();
 		app.update();
 

--- a/src/plugins/graphics/src/systems/propagate_effect_material.rs
+++ b/src/plugins/graphics/src/systems/propagate_effect_material.rs
@@ -1,28 +1,21 @@
-use crate::components::effect_material_handle::{EffectMaterialHandle, EffectMeshes};
-use bevy::{camera::visibility::RenderLayers, prelude::*};
+use crate::components::{child_meshes::ChildMeshes, effect_material_handle::EffectMaterialHandle};
+use bevy::prelude::*;
 use common::{traits::accessors::get::TryApplyOn, zyheeda_commands::ZyheedaCommands};
 
 impl EffectMaterialHandle {
-	pub(crate) fn propagate(layers: impl Into<RenderLayers>) -> impl IntoSystem<(), (), ()> {
-		let layers = layers.into();
-
-		#[rustfmt::skip]
-		let system = move |
-			mut commands: ZyheedaCommands,
-			meshes: Query<(&Self, &mut Visibility, &EffectMeshes), Changed<EffectMeshes>>
-		| {
-			for (Self { material }, mut visibility, shader_meshes) in meshes {
-				for entity in shader_meshes.iter() {
-					commands.try_apply_on(&entity, |mut e| {
-						e.try_remove::<MeshMaterial3d<StandardMaterial>>();
-						e.try_insert((layers.clone(), MeshMaterial3d(material.clone())));
-					});
-				}
-				*visibility = Visibility::Visible;
+	pub(crate) fn propagate_material(
+		mut commands: ZyheedaCommands,
+		meshes: Query<(&Self, &mut Visibility, &ChildMeshes), Changed<ChildMeshes>>,
+	) {
+		for (Self { material }, mut visibility, child_meshes) in meshes {
+			for entity in child_meshes.iter() {
+				commands.try_apply_on(&entity, |mut e| {
+					e.try_remove::<MeshMaterial3d<StandardMaterial>>();
+					e.try_insert(MeshMaterial3d(material.clone()));
+				});
 			}
-		};
-
-		IntoSystem::into_system(system)
+			*visibility = Visibility::Visible;
+		}
 	}
 }
 
@@ -30,15 +23,15 @@ impl EffectMaterialHandle {
 mod tests {
 	use super::*;
 	use crate::{
-		components::effect_material_handle::EffectMeshOf,
+		components::child_meshes::ChildMeshOf,
 		materials::effect_material::EffectMaterial,
 	};
 	use testing::{SingleThreadedApp, new_handle};
 
-	fn setup(layers: impl Into<RenderLayers>) -> App {
+	fn setup() -> App {
 		let mut app = App::new().single_threaded(Update);
 
-		app.add_systems(Update, EffectMaterialHandle::propagate(layers));
+		app.add_systems(Update, EffectMaterialHandle::propagate_material);
 
 		app
 	}
@@ -46,14 +39,14 @@ mod tests {
 	#[test]
 	fn propagate_material() {
 		let material = new_handle();
-		let mut app = setup(RenderLayers::default());
+		let mut app = setup();
 		let entity = app
 			.world_mut()
 			.spawn(EffectMaterialHandle {
 				material: material.clone(),
 			})
 			.id();
-		let child = app.world_mut().spawn(EffectMeshOf(entity)).id();
+		let child = app.world_mut().spawn(ChildMeshOf(entity)).id();
 
 		app.update();
 
@@ -66,27 +59,13 @@ mod tests {
 	}
 
 	#[test]
-	fn propagate_render_layer() {
-		let mut app = setup(RenderLayers::layer(3));
-		let entity = app.world_mut().spawn(EffectMaterialHandle::default()).id();
-		let child = app.world_mut().spawn(EffectMeshOf(entity)).id();
-
-		app.update();
-
-		assert_eq!(
-			Some(&RenderLayers::layer(3)),
-			app.world().entity(child).get::<RenderLayers>(),
-		);
-	}
-
-	#[test]
 	fn remove_standard_material() {
-		let mut app = setup(RenderLayers::default());
+		let mut app = setup();
 		let entity = app.world_mut().spawn(EffectMaterialHandle::default()).id();
 		let child = app
 			.world_mut()
 			.spawn((
-				EffectMeshOf(entity),
+				ChildMeshOf(entity),
 				MeshMaterial3d(new_handle::<StandardMaterial>()),
 			))
 			.id();
@@ -103,10 +82,10 @@ mod tests {
 
 	#[test]
 	fn set_visibility_to_visible() {
-		let mut app = setup(RenderLayers::default());
+		let mut app = setup();
 		let entity = app.world_mut().spawn(EffectMaterialHandle::default()).id();
 		app.world_mut().spawn((
-			EffectMeshOf(entity),
+			ChildMeshOf(entity),
 			MeshMaterial3d(new_handle::<StandardMaterial>()),
 		));
 
@@ -120,9 +99,9 @@ mod tests {
 
 	#[test]
 	fn act_only_once() {
-		let mut app = setup(RenderLayers::default());
+		let mut app = setup();
 		let entity = app.world_mut().spawn(EffectMaterialHandle::default()).id();
-		let child = app.world_mut().spawn(EffectMeshOf(entity)).id();
+		let child = app.world_mut().spawn(ChildMeshOf(entity)).id();
 
 		app.update();
 		app.world_mut()
@@ -141,14 +120,14 @@ mod tests {
 	#[test]
 	fn act_only_once_again_if_children_changed() {
 		let material = new_handle();
-		let mut app = setup(RenderLayers::default());
+		let mut app = setup();
 		let entity = app
 			.world_mut()
 			.spawn(EffectMaterialHandle {
 				material: material.clone(),
 			})
 			.id();
-		let child = app.world_mut().spawn(EffectMeshOf(entity)).id();
+		let child = app.world_mut().spawn(ChildMeshOf(entity)).id();
 
 		app.update();
 		app.world_mut()
@@ -156,7 +135,7 @@ mod tests {
 			.remove::<MeshMaterial3d<EffectMaterial>>();
 		app.world_mut()
 			.entity_mut(entity)
-			.get_mut::<EffectMeshes>()
+			.get_mut::<ChildMeshes>()
 			.as_deref_mut();
 		app.update();
 

--- a/src/plugins/graphics/src/systems/propagate_pass_layer.rs
+++ b/src/plugins/graphics/src/systems/propagate_pass_layer.rs
@@ -1,0 +1,135 @@
+use crate::components::{child_meshes::ChildMeshes, pass_layer::PassLayers};
+use bevy::{camera::visibility::RenderLayers, prelude::*};
+use common::{traits::accessors::get::TryApplyOn, zyheeda_commands::ZyheedaCommands};
+
+type PassLayerOrChildMeshesChanged = Or<(Changed<PassLayers>, Changed<ChildMeshes>)>;
+
+impl PassLayers {
+	pub(crate) fn propagate_layer(
+		mut commands: ZyheedaCommands,
+		layers: Query<(Entity, &PassLayers, Option<&ChildMeshes>), PassLayerOrChildMeshesChanged>,
+	) {
+		for (root, pass_layers, children) in layers {
+			for entity in iter(root, children) {
+				commands.try_apply_on(&entity, |mut e| {
+					e.try_insert(RenderLayers::from(pass_layers));
+				});
+			}
+		}
+	}
+}
+
+fn iter(root: Entity, children: Option<&ChildMeshes>) -> impl Iterator<Item = Entity> {
+	std::iter::once(root).chain(children.into_iter().flat_map(ChildMeshes::iter))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::components::child_meshes::ChildMeshOf;
+	use bevy::camera::visibility::RenderLayers;
+	use testing::SingleThreadedApp;
+
+	fn setup() -> App {
+		let mut app = App::new().single_threaded(Update);
+
+		app.add_systems(Update, PassLayers::propagate_layer);
+
+		app
+	}
+
+	#[test]
+	fn set_layer_on_root() {
+		let mut app = setup();
+		let entity = app.world_mut().spawn(PassLayers::from(2)).id();
+
+		app.update();
+
+		assert_eq!(
+			Some(&RenderLayers::layer(2)),
+			app.world().entity(entity).get::<RenderLayers>(),
+		);
+	}
+
+	#[test]
+	fn set_layer_on_child() {
+		let mut app = setup();
+		let parent = app.world_mut().spawn(PassLayers::from(2)).id();
+		let child = app.world_mut().spawn(ChildMeshOf(parent)).id();
+
+		app.update();
+
+		assert_eq!(
+			Some(&RenderLayers::layer(2)),
+			app.world().entity(child).get::<RenderLayers>(),
+		);
+	}
+
+	#[test]
+	fn act_only_once() {
+		let mut app = setup();
+		let parent = app.world_mut().spawn(PassLayers::from(2)).id();
+		let child = app.world_mut().spawn(ChildMeshOf(parent)).id();
+
+		app.update();
+		app.world_mut().entity_mut(parent).remove::<RenderLayers>();
+		app.world_mut().entity_mut(child).remove::<RenderLayers>();
+		app.update();
+
+		assert_eq!(
+			(None, None),
+			(
+				app.world().entity(parent).get::<RenderLayers>(),
+				app.world().entity(child).get::<RenderLayers>(),
+			)
+		);
+	}
+
+	#[test]
+	fn act_again_if_pass_layer_changed() {
+		let mut app = setup();
+		let parent = app.world_mut().spawn(PassLayers::from(2)).id();
+		let child = app.world_mut().spawn(ChildMeshOf(parent)).id();
+
+		app.update();
+		app.world_mut()
+			.entity_mut(parent)
+			.remove::<RenderLayers>()
+			.get_mut::<PassLayers>()
+			.as_deref_mut();
+		app.world_mut().entity_mut(child).remove::<RenderLayers>();
+		app.update();
+
+		assert_eq!(
+			(Some(&RenderLayers::layer(2)), Some(&RenderLayers::layer(2))),
+			(
+				app.world().entity(parent).get::<RenderLayers>(),
+				app.world().entity(child).get::<RenderLayers>(),
+			)
+		);
+	}
+
+	#[test]
+	fn act_again_if_children_changed() {
+		let mut app = setup();
+		let parent = app.world_mut().spawn(PassLayers::from(2)).id();
+		let child = app.world_mut().spawn(ChildMeshOf(parent)).id();
+
+		app.update();
+		app.world_mut()
+			.entity_mut(parent)
+			.remove::<RenderLayers>()
+			.get_mut::<ChildMeshes>()
+			.as_deref_mut();
+		app.world_mut().entity_mut(child).remove::<RenderLayers>();
+		app.update();
+
+		assert_eq!(
+			(Some(&RenderLayers::layer(2)), Some(&RenderLayers::layer(2))),
+			(
+				app.world().entity(parent).get::<RenderLayers>(),
+				app.world().entity(child).get::<RenderLayers>(),
+			)
+		);
+	}
+}

--- a/src/plugins/menu/src/debug.rs
+++ b/src/plugins/menu/src/debug.rs
@@ -14,12 +14,7 @@ use bevy::{ecs::relationship::RelatedSpawnerCommands, prelude::*};
 use common::{
 	states::game_state::GameState,
 	tools::Index,
-	traits::{
-		handles_graphics::StaticRenderLayers,
-		handles_localization::Localize,
-		iteration::IterFinite,
-		thread_safe::ThreadSafe,
-	},
+	traits::{handles_localization::Localize, iteration::IterFinite, thread_safe::ThreadSafe},
 };
 use std::{fmt::Debug, marker::PhantomData, time::Duration};
 
@@ -94,7 +89,7 @@ fn update_state_time<TState>(
 pub fn setup_run_time_display<TLocalization, TGraphics>(app: &mut App)
 where
 	TLocalization: Localize + Resource,
-	TGraphics: StaticRenderLayers + 'static,
+	TGraphics: Component,
 {
 	for state in GameState::iterator() {
 		app.add_ui::<StateTime<GameState>, TLocalization, TGraphics>(state);

--- a/src/plugins/menu/src/systems/spawn.rs
+++ b/src/plugins/menu/src/systems/spawn.rs
@@ -1,23 +1,30 @@
 use crate::traits::LoadUi;
 use bevy::prelude::*;
-use common::traits::{handles_graphics::StaticRenderLayers, load_asset::LoadAsset};
+use common::{traits::load_asset::LoadAsset, zyheeda_commands::ZyheedaCommands};
 
-pub fn spawn<TComponent, TServer, TGraphics>(mut commands: Commands, mut images: ResMut<TServer>)
-where
+pub fn spawn<TComponent, TServer, TCameras>(
+	mut commands: ZyheedaCommands,
+	mut images: ResMut<TServer>,
+	cameras: Query<Entity, With<TCameras>>,
+) where
 	TComponent: LoadUi<TServer> + Component,
 	TServer: Resource + LoadAsset,
-	TGraphics: StaticRenderLayers,
+	TCameras: Component,
 {
 	let component = TComponent::load_ui(images.as_mut());
 
-	commands.spawn((component, TGraphics::render_layers()));
+	let mut entity = commands.spawn(component);
+
+	if let Ok(camera) = cameras.single() {
+		entity.insert(UiTargetCamera(camera));
+	}
 }
 
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use bevy::{asset::AssetPath, camera::visibility::RenderLayers};
-	use testing::assert_count;
+	use bevy::asset::AssetPath;
+	use testing::{SingleThreadedApp, assert_count};
 
 	#[derive(Component, Resource, Default)]
 	struct _Server;
@@ -41,20 +48,22 @@ mod tests {
 		}
 	}
 
-	struct _Graphics;
+	#[derive(Component)]
+	struct _Camera;
 
-	impl StaticRenderLayers for _Graphics {
-		fn render_layers() -> RenderLayers {
-			RenderLayers::layer(11)
-		}
+	fn setup() -> App {
+		let mut app = App::new().single_threaded(Update);
+
+		app.init_resource::<_Server>();
+		app.add_systems(Update, spawn::<_Component, _Server, _Camera>);
+
+		app
 	}
 
 	#[test]
 	fn spawn_component() {
-		let mut app = App::new();
+		let mut app = setup();
 
-		app.init_resource::<_Server>();
-		app.add_systems(Update, spawn::<_Component, _Server, _Graphics>);
 		app.update();
 
 		let mut components = app.world_mut().query_filtered::<(), With<_Component>>();
@@ -62,19 +71,16 @@ mod tests {
 	}
 
 	#[test]
-	fn spawn_render_layer() {
-		let mut app = App::new();
+	fn set_ui_target_camera() {
+		let mut app = setup();
+		let camera = app.world_mut().spawn(_Camera).id();
 
-		app.init_resource::<_Server>();
-		app.add_systems(Update, spawn::<_Component, _Server, _Graphics>);
 		app.update();
 
-		let mut render_layers = app.world_mut().query::<&RenderLayers>();
-		assert_count!(
-			1,
-			render_layers
-				.iter(app.world())
-				.filter(|r| r == &&RenderLayers::layer(11))
-		);
+		let mut components = app
+			.world_mut()
+			.query_filtered::<&UiTargetCamera, With<_Component>>();
+		let [UiTargetCamera(target_camera)] = assert_count!(1, components.iter(app.world()));
+		assert_eq!(&camera, target_camera);
 	}
 }

--- a/src/plugins/menu/src/traits/add_ui.rs
+++ b/src/plugins/menu/src/traits/add_ui.rs
@@ -1,29 +1,29 @@
 use super::{LoadUi, insert_ui_content::InsertUiContent};
 use crate::systems::{despawn::despawn, spawn::spawn, update_children::update_children};
 use bevy::prelude::*;
-use common::traits::{handles_graphics::StaticRenderLayers, handles_localization::Localize};
+use common::traits::handles_localization::Localize;
 
 pub(crate) trait AddUI<TState> {
-	fn add_ui<TComponent, TLocalizationServer, TGraphics>(&mut self, on_state: TState) -> &mut Self
+	fn add_ui<TComponent, TLocalizationServer, TUICamera>(&mut self, on_state: TState) -> &mut Self
 	where
 		TComponent: Component + LoadUi<AssetServer> + InsertUiContent,
 		TLocalizationServer: Resource + Localize,
-		TGraphics: StaticRenderLayers + 'static;
+		TUICamera: Component;
 }
 
 impl<TState> AddUI<TState> for App
 where
 	TState: States + Copy,
 {
-	fn add_ui<TComponent, TLocalizationServer, TGraphics>(&mut self, on_state: TState) -> &mut Self
+	fn add_ui<TComponent, TLocalizationServer, TUICamera>(&mut self, on_state: TState) -> &mut Self
 	where
 		TComponent: Component + LoadUi<AssetServer> + InsertUiContent,
 		TLocalizationServer: Resource + Localize,
-		TGraphics: StaticRenderLayers + 'static,
+		TUICamera: Component,
 	{
 		self.add_systems(
 			OnEnter(on_state),
-			spawn::<TComponent, AssetServer, TGraphics>,
+			spawn::<TComponent, AssetServer, TUICamera>,
 		)
 		.add_systems(OnExit(on_state), despawn::<TComponent>)
 		.add_systems(Update, update_children::<TComponent, TLocalizationServer>)


### PR DESCRIPTION
- switched to proper camera targeting for UI: the previous approach via render layers somehow worked by accident
- render layers are controlled by a `LayerPass` component: it will propagate `RenderLayers` to itself and children
- effect shader to root mapping replaced with a more generic child mesh mapping 
- separated render layer propagation and effect material propagation

This should lay the basis for dynamic render layer changes, to be able to temporarily target additional/other cameras when needed (for instance for drawing to textures as basis for post processing shaders, which will come in the near future)