### PR TITLE
Model render layers can have multiple main layers

### DIFF
--- a/src/plugins/graphics/src/components/model_render_layers.rs
+++ b/src/plugins/graphics/src/components/model_render_layers.rs
@@ -6,7 +6,7 @@ use std::collections::{
 
 #[derive(Component, Debug, PartialEq, Clone)]
 pub(crate) struct ModelRenderLayers {
-	main: Layer,
+	main: MainLayers,
 	additional: HashSet<Layer>,
 }
 
@@ -15,7 +15,9 @@ impl ModelRenderLayers {
 	where
 		T: IntoIterator<Item = Layer>,
 	{
-		let not_main_layer = layers.into_iter().filter(|layer| layer != &self.main);
+		let not_main_layer = layers
+			.into_iter()
+			.filter(|layer| !self.main.contains(layer));
 
 		self.additional.extend(not_main_layer);
 	}
@@ -32,7 +34,7 @@ impl ModelRenderLayers {
 	where
 		T: IntoIterator<Item = &'a Layer>,
 	{
-		let miss = |layer| &self.main != layer && !self.additional.contains(layer);
+		let miss = |layer| !self.main.contains(layer) && !self.additional.contains(layer);
 
 		!layers.into_iter().any(miss)
 	}
@@ -41,7 +43,16 @@ impl ModelRenderLayers {
 impl From<Layer> for ModelRenderLayers {
 	fn from(layer: Layer) -> Self {
 		Self {
-			main: layer,
+			main: MainLayers::Single(layer),
+			additional: HashSet::default(),
+		}
+	}
+}
+
+impl From<&'static [Layer]> for ModelRenderLayers {
+	fn from(layers: &'static [Layer]) -> Self {
+		Self {
+			main: MainLayers::Multiple(layers),
 			additional: HashSet::default(),
 		}
 	}
@@ -53,7 +64,7 @@ impl<'a> IntoIterator for &'a ModelRenderLayers {
 
 	fn into_iter(self) -> Self::IntoIter {
 		Iter {
-			main: Some(&self.main),
+			main: self.main.iter(),
 			additional: self.additional.iter(),
 		}
 	}
@@ -65,14 +76,48 @@ impl IntoIterator for ModelRenderLayers {
 
 	fn into_iter(self) -> Self::IntoIter {
 		IntoIter {
-			main: Some(self.main),
+			main: self.main.into_iter(),
 			additional: self.additional.into_iter(),
 		}
 	}
 }
 
+#[derive(Debug, PartialEq, Clone, Copy)]
+enum MainLayers {
+	Single(Layer),
+	Multiple(&'static [Layer]),
+}
+
+impl MainLayers {
+	fn contains(&self, layer: &Layer) -> bool {
+		match self {
+			MainLayers::Single(single) => single == layer,
+			MainLayers::Multiple(multiple) => multiple.contains(layer),
+		}
+	}
+
+	fn iter(&self) -> MainLayersIter<'_> {
+		match self {
+			MainLayers::Single(layer) => MainLayersIter::Single(Some(layer)),
+			MainLayers::Multiple(layers) => MainLayersIter::Multiple(layers.iter()),
+		}
+	}
+
+	fn into_iter(self) -> MainLayersIntoIter {
+		match self {
+			MainLayers::Single(layer) => MainLayersIntoIter::Single(Some(layer)),
+			MainLayers::Multiple(layers) => MainLayersIntoIter::Multiple(layers.iter()),
+		}
+	}
+}
+
+enum MainLayersIter<'a> {
+	Single(Option<&'a Layer>),
+	Multiple(std::slice::Iter<'a, Layer>),
+}
+
 pub(crate) struct Iter<'a> {
-	main: Option<&'a Layer>,
+	main: MainLayersIter<'a>,
 	additional: HashSetIter<'a, Layer>,
 }
 
@@ -80,15 +125,21 @@ impl<'a> Iterator for Iter<'a> {
 	type Item = &'a Layer;
 
 	fn next(&mut self) -> Option<Self::Item> {
-		match self.main.take() {
-			Some(layer) => Some(layer),
-			None => self.additional.next(),
+		match &mut self.main {
+			MainLayersIter::Single(None) => self.additional.next(),
+			MainLayersIter::Single(main) => main.take(),
+			MainLayersIter::Multiple(main) => main.next().or_else(|| self.additional.next()),
 		}
 	}
 }
 
+enum MainLayersIntoIter {
+	Single(Option<Layer>),
+	Multiple(std::slice::Iter<'static, Layer>),
+}
+
 pub(crate) struct IntoIter {
-	main: Option<Layer>,
+	main: MainLayersIntoIter,
 	additional: HashSetIntoIter<Layer>,
 }
 
@@ -96,9 +147,12 @@ impl Iterator for IntoIter {
 	type Item = Layer;
 
 	fn next(&mut self) -> Option<Self::Item> {
-		match self.main.take() {
-			Some(layer) => Some(layer),
-			None => self.additional.next(),
+		match &mut self.main {
+			MainLayersIntoIter::Single(None) => self.additional.next(),
+			MainLayersIntoIter::Single(main) => main.take(),
+			MainLayersIntoIter::Multiple(main) => {
+				main.next().copied().or_else(|| self.additional.next())
+			}
 		}
 	}
 }
@@ -132,12 +186,22 @@ mod tests {
 	}
 
 	#[test]
-	fn do_not_base_layer() {
+	fn do_not_repeat_base_layer() {
 		let mut pass_layer = ModelRenderLayers::from(42);
 
 		pass_layer.add_layers([42]);
 
 		assert_count!(1, pass_layer.iter());
+	}
+
+	#[test]
+	fn do_not_repeat_base_layers() {
+		const MAIN: &[Layer] = &[42, 333];
+		let mut pass_layer = ModelRenderLayers::from(MAIN);
+
+		pass_layer.add_layers([42, 333]);
+
+		assert_count!(2, pass_layer.iter());
 	}
 
 	#[test]
@@ -174,6 +238,34 @@ mod tests {
 		assert_eq!(
 			HashSet::from([42, 11, 22]),
 			(&pass_layer).into_iter().copied().collect::<HashSet<_>>(),
+		);
+	}
+
+	#[test]
+	fn into_iter_of_multiple_main_layers() {
+		const MAIN: &[Layer] = &[42, 333];
+		let mut pass_layer = ModelRenderLayers::from(MAIN);
+
+		pass_layer.add_layers([11]);
+		pass_layer.add_layers([22]);
+
+		assert_eq!(
+			HashSet::from([42, 333, 11, 22]),
+			pass_layer.into_iter().collect::<HashSet<_>>(),
+		);
+	}
+
+	#[test]
+	fn iter_of_multiple_main_layers() {
+		const MAIN: &[Layer] = &[42, 333];
+		let mut pass_layer = ModelRenderLayers::from(MAIN);
+
+		pass_layer.add_layers([11]);
+		pass_layer.add_layers([22]);
+
+		assert_eq!(
+			HashSet::from([&42, &333, &11, &22]),
+			pass_layer.iter().collect::<HashSet<_>>(),
 		);
 	}
 


### PR DESCRIPTION
In order to have meshes/lights be rendered by cameras on different render layers we add the possibility to have `ModelRenderLayers` main layer be multiple layers.