### PR TITLE
Set world camera through system param

### DIFF
--- a/src/plugins/agents/src/components/player_camera.rs
+++ b/src/plugins/agents/src/components/player_camera.rs
@@ -1,6 +1,14 @@
-use bevy::prelude::*;
+use bevy::{
+	ecs::system::{StaticSystemParam, SystemParam},
+	prelude::*,
+};
+use common::{
+	errors::{ErrorData, Level},
+	traits::handles_physics::{NoWorldCameraSet, SetWorldCamera},
+};
 use macros::SavableComponent;
 use serde::{Deserialize, Serialize};
+use std::fmt::Display;
 
 #[derive(
 	Component,
@@ -17,3 +25,146 @@ use serde::{Deserialize, Serialize};
 )]
 #[savable_component(id = "player camera")]
 pub struct PlayerCamera;
+
+impl PlayerCamera {
+	pub(crate) fn set_as_world_camera<TPhysics>(
+		on_add: On<Add, Self>,
+		physics: StaticSystemParam<TPhysics>,
+	) -> Result<(), WorldCameraAlreadySet>
+	where
+		TPhysics: for<'w, 's> SystemParam<Item<'w, 's>: NoWorldCameraSet>,
+	{
+		let Some(setter) = physics.into_inner().no_world_camera_set() else {
+			return Err(WorldCameraAlreadySet);
+		};
+
+		setter.set_world_camera(on_add.entity);
+		Ok(())
+	}
+}
+
+#[derive(Debug, PartialEq)]
+pub(crate) struct WorldCameraAlreadySet;
+
+impl Display for WorldCameraAlreadySet {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		write!(f, "World camera is already set")
+	}
+}
+
+impl ErrorData for WorldCameraAlreadySet {
+	fn level(&self) -> common::errors::Level {
+		Level::Error
+	}
+
+	fn label() -> impl Display {
+		"World Camera Already Set Error"
+	}
+
+	fn into_details(self) -> impl Display {
+		self
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use macros::simple_mock;
+	use mockall::predicate::eq;
+	use testing::{Mock, SingleThreadedApp};
+
+	#[derive(Resource)]
+	enum _Setter {
+		NoCamSet(Mock_Setter),
+		CamAlreadySet,
+	}
+
+	#[derive(SystemParam)]
+	struct _Param<'w> {
+		setter: ResMut<'w, _Setter>,
+	}
+
+	impl<'w> NoWorldCameraSet for _Param<'w> {
+		type TSetter = Mock_Setter;
+
+		fn no_world_camera_set(mut self) -> Option<Self::TSetter> {
+			let mut return_setter = _Setter::CamAlreadySet;
+
+			std::mem::swap(&mut return_setter, &mut self.setter);
+
+			match return_setter {
+				_Setter::NoCamSet(mock_setter) => Some(mock_setter),
+				_Setter::CamAlreadySet => None,
+			}
+		}
+	}
+
+	simple_mock! {
+		_Setter {}
+		impl SetWorldCamera for _Setter {
+			fn set_world_camera(self, entity: Entity);
+		}
+	}
+
+	#[derive(Resource, Debug, PartialEq)]
+	struct _Result(Result<(), WorldCameraAlreadySet>);
+
+	fn setup() -> App {
+		let mut app = App::new().single_threaded(Update);
+
+		app.add_observer(PlayerCamera::set_as_world_camera::<_Param>.pipe(
+			|In(r), mut c: Commands| {
+				c.insert_resource(_Result(r));
+			},
+		));
+
+		app
+	}
+
+	#[test]
+	fn set_camera() {
+		let mut app = setup();
+		let entity = app.world_mut().spawn_empty().id();
+		app.insert_resource(_Setter::NoCamSet(Mock_Setter::new_mock(assert_set_to(
+			entity,
+		))));
+
+		app.world_mut().entity_mut(entity).insert(PlayerCamera);
+
+		fn assert_set_to(entity: Entity) -> impl FnMut(&mut Mock_Setter) {
+			move |mock| {
+				mock.expect_set_world_camera()
+					.times(1)
+					.with(eq(entity))
+					.return_const(());
+			}
+		}
+	}
+
+	#[test]
+	fn return_ok() {
+		let mut app = setup();
+		let entity = app.world_mut().spawn_empty().id();
+		app.insert_resource(_Setter::NoCamSet(Mock_Setter::new_mock(|mock| {
+			mock.expect_set_world_camera().return_const(());
+		})));
+
+		app.world_mut().entity_mut(entity).insert(PlayerCamera);
+
+		assert_eq!(&_Result(Ok(())), app.world().resource::<_Result>());
+	}
+
+	#[test]
+	fn return_already_set_error() {
+		let mut app = setup();
+		let entity = app.world_mut().spawn_empty().id();
+		app.insert_resource(_Setter::CamAlreadySet);
+
+		app.world_mut().entity_mut(entity).insert(PlayerCamera);
+
+		assert_eq!(
+			&_Result(Err(WorldCameraAlreadySet)),
+			app.world().resource::<_Result>(),
+		);
+	}
+}

--- a/src/plugins/agents/src/lib.rs
+++ b/src/plugins/agents/src/lib.rs
@@ -179,7 +179,9 @@ where
 		app.add_prefab_observer::<VoidSphere, ()>();
 
 		// # Behaviors
-		app.register_required_components::<PlayerCamera, TPhysics::TWorldCamera>();
+		app.add_observer(
+			PlayerCamera::set_as_world_camera::<TPhysics::TRayCastMut>.pipe(OnError::log),
+		);
 		app.add_systems(
 			Update,
 			(

--- a/src/plugins/common/src/traits/handles_physics.rs
+++ b/src/plugins/common/src/traits/handles_physics.rs
@@ -19,9 +19,7 @@ use std::{
 };
 
 pub trait HandlesRaycast {
-	/// Marks the world camera used in [`MouseHover`] raycasting. Only one instance may exist in
-	/// the world.
-	type TWorldCamera: Component + Default;
+	type TRayCastMut: for<'w, 's> SystemParam<Item<'w, 's>: NoWorldCameraSet>;
 
 	/// Raycast system parameter. [`MouseHover`] raycast requires that `Self::TWorldCamera` is being
 	/// attached to the actual camera.
@@ -30,6 +28,16 @@ pub trait HandlesRaycast {
 		+ for<'w, 's> SystemParam<Item<'w, 's>: Raycast<Terrain>>
 		+ for<'w, 's> SystemParam<Item<'w, 's>: Raycast<MouseTerrainHover>>
 		+ for<'w, 's> SystemParam<Item<'w, 's>: Raycast<MouseHover>>;
+}
+
+pub trait NoWorldCameraSet {
+	type TSetter: SetWorldCamera;
+
+	fn no_world_camera_set(self) -> Option<Self::TSetter>;
+}
+
+pub trait SetWorldCamera {
+	fn set_world_camera(self, entity: Entity);
 }
 
 pub trait Raycast<TArgs>

--- a/src/plugins/physics/src/components/world_camera.rs
+++ b/src/plugins/physics/src/components/world_camera.rs
@@ -3,7 +3,7 @@ use common::traits::handles_physics::{MouseHover, MouseHoversOver};
 use std::collections::HashMap;
 
 #[derive(Component, Debug, PartialEq, Default)]
-pub struct WorldCamera {
+pub(crate) struct WorldCamera {
 	pub(crate) mouse_hover: HashMap<MouseHover, MouseHoversOver>,
 	// Tracking camera ray in this component to prevent system param overlap when using `RayCaster`
 	pub(crate) ray: Option<Ray3d>,

--- a/src/plugins/physics/src/lib.rs
+++ b/src/plugins/physics/src/lib.rs
@@ -42,7 +42,7 @@ use crate::{
 	system_params::{
 		config::ConfigParamMut,
 		interactive::InteractiveParam,
-		ray_caster::RayCaster,
+		ray_caster::{RayCaster, RayCasterMut},
 		skill_agent::{SkillAgent, SkillAgentMut},
 		update_root_collisions::UpdateRootCollisions,
 	},
@@ -256,7 +256,7 @@ struct CollisionSystems;
 pub struct PhysicsSystems;
 
 impl<TDependencies> HandlesRaycast for PhysicsPlugin<TDependencies> {
-	type TWorldCamera = WorldCamera;
+	type TRayCastMut = RayCasterMut<'static, 'static>;
 	type TRaycast = RayCaster<'static, 'static>;
 }
 

--- a/src/plugins/physics/src/system_params/ray_caster.rs
+++ b/src/plugins/physics/src/system_params/ray_caster.rs
@@ -4,15 +4,21 @@ mod set_world_camera;
 mod solid_objects;
 mod terrain;
 
+use std::any::type_name;
+
 use crate::components::{collider::ChildColliderOf, offset::AimOffset, world_camera::WorldCamera};
 use bevy::{
-	ecs::system::{StaticSystemParam, SystemParam},
+	ecs::{
+		component::ComponentId,
+		system::{StaticSystemParam, SystemParam},
+	},
 	prelude::*,
 };
 use bevy_rapier3d::prelude::*;
 use common::{self, zyheeda_commands::ZyheedaCommands};
 
 #[derive(SystemParam)]
+
 pub struct RayCaster<'w, 's, T = ReadRapierContext<'static, 'static>>
 where
 	T: SystemParam + 'static,
@@ -23,8 +29,84 @@ where
 	world_cams: Query<'w, 's, &'static mut WorldCamera>,
 }
 
-#[derive(SystemParam)]
 pub struct RayCasterMut<'w, 's> {
+	inner: Inner<'w, 's>,
+}
+
+// Manual implementation of `SystemParam` for `RayCasterMut` to prevent multiple access
+// of the system parameter within a single system
+unsafe impl<'w, 's> SystemParam for RayCasterMut<'w, 's> {
+	type State = (<Inner<'w, 's> as SystemParam>::State, ComponentId);
+	type Item<'world, 'state> = RayCasterMut<'world, 'state>;
+
+	fn init_state(world: &mut World) -> Self::State {
+		(
+			Inner::<'w, 's>::init_state(world),
+			ResMut::<'w, PreventMultiAccess>::init_state(world),
+		)
+	}
+
+	fn init_access(
+		(state, id): &Self::State,
+		system_meta: &mut bevy::ecs::system::SystemMeta,
+		component_access_set: &mut bevy::ecs::query::FilteredAccessSet,
+		world: &mut World,
+	) {
+		// Conceptually copied from unique access implementation for resources.
+		let combined_access = component_access_set.combined_access();
+		if combined_access.has_resource_write(*id) {
+			panic!(
+				"{} in system {} can only be accessed once",
+				type_name::<RayCasterMut>(),
+				system_meta.name(),
+			);
+		}
+		component_access_set.add_unfiltered_resource_write(*id);
+
+		Inner::<'w, 's>::init_access(state, system_meta, component_access_set, world);
+	}
+
+	unsafe fn get_param<'world, 'state>(
+		(state, ..): &'state mut Self::State,
+		system_meta: &bevy::ecs::system::SystemMeta,
+		world: bevy::ecs::world::unsafe_world_cell::UnsafeWorldCell<'world>,
+		change_tick: bevy::ecs::change_detection::Tick,
+	) -> Self::Item<'world, 'state> {
+		let inner = unsafe { Inner::<'w, 's>::get_param(state, system_meta, world, change_tick) };
+
+		RayCasterMut { inner }
+	}
+
+	fn apply(
+		(state, ..): &mut Self::State,
+		system_meta: &bevy::ecs::system::SystemMeta,
+		world: &mut World,
+	) {
+		Inner::<'w, 's>::apply(state, system_meta, world);
+	}
+
+	fn queue(
+		(state, ..): &mut Self::State,
+		system_meta: &bevy::ecs::system::SystemMeta,
+		world: bevy::ecs::world::DeferredWorld,
+	) {
+		Inner::<'w, 's>::queue(state, system_meta, world);
+	}
+
+	unsafe fn validate_param(
+		(state, ..): &mut Self::State,
+		system_meta: &bevy::ecs::system::SystemMeta,
+		world: bevy::ecs::world::unsafe_world_cell::UnsafeWorldCell,
+	) -> std::prelude::v1::Result<(), bevy::ecs::system::SystemParamValidationError> {
+		unsafe { Inner::<'w, 's>::validate_param(state, system_meta, world) }
+	}
+}
+
+#[derive(SystemParam)]
+pub struct Inner<'w, 's> {
 	commands: ZyheedaCommands<'w, 's>,
 	world_cameras: Query<'w, 's, (), With<WorldCamera>>,
 }
+
+#[derive(Resource)]
+struct PreventMultiAccess;

--- a/src/plugins/physics/src/system_params/ray_caster.rs
+++ b/src/plugins/physics/src/system_params/ray_caster.rs
@@ -1,5 +1,6 @@
 mod mouse_hover;
 mod mouse_terrain_hover;
+mod set_world_camera;
 mod solid_objects;
 mod terrain;
 
@@ -9,6 +10,7 @@ use bevy::{
 	prelude::*,
 };
 use bevy_rapier3d::prelude::*;
+use common::{self, zyheeda_commands::ZyheedaCommands};
 
 #[derive(SystemParam)]
 pub struct RayCaster<'w, 's, T = ReadRapierContext<'static, 'static>>
@@ -19,4 +21,10 @@ where
 	child_colliders: Query<'w, 's, &'static ChildColliderOf>,
 	transforms: Query<'w, 's, (&'static GlobalTransform, Option<&'static AimOffset>)>,
 	world_cams: Query<'w, 's, &'static mut WorldCamera>,
+}
+
+#[derive(SystemParam)]
+pub struct RayCasterMut<'w, 's> {
+	commands: ZyheedaCommands<'w, 's>,
+	world_cameras: Query<'w, 's, (), With<WorldCamera>>,
 }

--- a/src/plugins/physics/src/system_params/ray_caster/set_world_camera.rs
+++ b/src/plugins/physics/src/system_params/ray_caster/set_world_camera.rs
@@ -1,0 +1,77 @@
+use crate::{components::world_camera::WorldCamera, system_params::ray_caster::RayCasterMut};
+use bevy::prelude::*;
+use common::{
+	traits::{
+		accessors::get::TryApplyOn,
+		handles_physics::{NoWorldCameraSet, SetWorldCamera},
+	},
+	zyheeda_commands::ZyheedaCommands,
+};
+
+impl<'w, 's> NoWorldCameraSet for RayCasterMut<'w, 's> {
+	type TSetter = WorldCameraSetter<'w, 's>;
+
+	fn no_world_camera_set(self) -> Option<Self::TSetter> {
+		if !self.world_cameras.is_empty() {
+			return None;
+		}
+
+		Some(WorldCameraSetter(self.commands))
+	}
+}
+
+pub struct WorldCameraSetter<'w, 's>(ZyheedaCommands<'w, 's>);
+
+impl SetWorldCamera for WorldCameraSetter<'_, '_> {
+	fn set_world_camera(mut self, entity: Entity) {
+		self.0.try_apply_on(&entity, |mut e| {
+			e.try_insert(WorldCamera::default());
+		});
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	#![allow(clippy::unwrap_used)]
+	use super::*;
+	use crate::{components::world_camera::WorldCamera, system_params::ray_caster::RayCasterMut};
+	use bevy::ecs::system::{RunSystemError, RunSystemOnce};
+	use testing::SingleThreadedApp;
+
+	fn setup() -> App {
+		App::new().single_threaded(Update)
+	}
+
+	#[test]
+	fn set_world_camera() -> Result<(), RunSystemError> {
+		let mut app = setup();
+		let entity = app.world_mut().spawn_empty().id();
+
+		app.world_mut().run_system_once(move |r: RayCasterMut| {
+			let Some(setter) = r.no_world_camera_set() else {
+				return;
+			};
+
+			setter.set_world_camera(entity);
+		})?;
+
+		assert_eq!(
+			Some(&WorldCamera::default()),
+			app.world().entity(entity).get::<WorldCamera>(),
+		);
+		Ok(())
+	}
+
+	#[test]
+	fn do_not_set_world_camera_when_already_set() -> Result<(), RunSystemError> {
+		let mut app = setup();
+		app.world_mut().spawn(WorldCamera::default());
+
+		let setter = app
+			.world_mut()
+			.run_system_once(move |r: RayCasterMut| r.no_world_camera_set().is_some())?;
+
+		assert!(!setter);
+		Ok(())
+	}
+}

--- a/src/plugins/physics/src/system_params/ray_caster/set_world_camera.rs
+++ b/src/plugins/physics/src/system_params/ray_caster/set_world_camera.rs
@@ -12,11 +12,11 @@ impl<'w, 's> NoWorldCameraSet for RayCasterMut<'w, 's> {
 	type TSetter = WorldCameraSetter<'w, 's>;
 
 	fn no_world_camera_set(self) -> Option<Self::TSetter> {
-		if !self.world_cameras.is_empty() {
+		if !self.inner.world_cameras.is_empty() {
 			return None;
 		}
 
-		Some(WorldCameraSetter(self.commands))
+		Some(WorldCameraSetter(self.inner.commands))
 	}
 }
 


### PR DESCRIPTION
- world camera is set through a consumed setter, that allows setting it once
- no setter is returned when already set
- world camera component is not exposed any more
- system parameter access to retrieve the setter is enforced to be unique within a system