### PR TITLE
Enforce uniquness through specialized system paramter

### DIFF
--- a/src/plugins/common/src/lib.rs
+++ b/src/plugins/common/src/lib.rs
@@ -7,6 +7,7 @@ pub mod errors;
 pub mod observers;
 pub mod resources;
 pub mod states;
+pub mod system_params;
 pub mod systems;
 pub mod tools;
 pub mod traits;

--- a/src/plugins/common/src/system_params.rs
+++ b/src/plugins/common/src/system_params.rs
@@ -1,0 +1,52 @@
+use bevy::{
+	ecs::{component::ComponentId, system::SystemParam},
+	prelude::*,
+};
+use std::{any::type_name, marker::PhantomData};
+
+/// A system parameter that only tests for uniqueness.
+///
+/// Can be included in system parameter structs to enforce that it can only be used once
+/// within a single system.
+///
+/// `T` will be used for the displayed message.
+pub struct MarkUnique<T>(PhantomData<T>);
+
+unsafe impl<T> SystemParam for MarkUnique<T> {
+	type State = ComponentId;
+	type Item<'world, 'state> = MarkUnique<T>;
+
+	fn init_state(world: &mut World) -> Self::State {
+		ResMut::<'static, PreventMultiAccess>::init_state(world)
+	}
+
+	fn init_access(
+		state: &Self::State,
+		system_meta: &mut bevy::ecs::system::SystemMeta,
+		component_access_set: &mut bevy::ecs::query::FilteredAccessSet,
+		_: &mut World,
+	) {
+		// Conceptually copied from unique access implementation for resources.
+		let combined_access = component_access_set.combined_access();
+		if combined_access.has_resource_write(*state) {
+			panic!(
+				"{} in system {} can only be accessed once",
+				type_name::<T>(),
+				system_meta.name(),
+			);
+		}
+		component_access_set.add_unfiltered_resource_write(*state);
+	}
+
+	unsafe fn get_param<'world, 'state>(
+		_: &'state mut Self::State,
+		_: &bevy::ecs::system::SystemMeta,
+		_: bevy::ecs::world::unsafe_world_cell::UnsafeWorldCell<'world>,
+		_: bevy::ecs::change_detection::Tick,
+	) -> Self::Item<'world, 'state> {
+		MarkUnique(PhantomData)
+	}
+}
+
+#[derive(Resource)]
+struct PreventMultiAccess;

--- a/src/plugins/physics/src/system_params/ray_caster.rs
+++ b/src/plugins/physics/src/system_params/ray_caster.rs
@@ -4,18 +4,13 @@ mod set_world_camera;
 mod solid_objects;
 mod terrain;
 
-use std::any::type_name;
-
 use crate::components::{collider::ChildColliderOf, offset::AimOffset, world_camera::WorldCamera};
 use bevy::{
-	ecs::{
-		component::ComponentId,
-		system::{StaticSystemParam, SystemParam},
-	},
+	ecs::system::{StaticSystemParam, SystemParam},
 	prelude::*,
 };
 use bevy_rapier3d::prelude::*;
-use common::{self, zyheeda_commands::ZyheedaCommands};
+use common::{self, system_params::MarkUnique, zyheeda_commands::ZyheedaCommands};
 
 #[derive(SystemParam)]
 
@@ -29,84 +24,9 @@ where
 	world_cams: Query<'w, 's, &'static mut WorldCamera>,
 }
 
-pub struct RayCasterMut<'w, 's> {
-	inner: Inner<'w, 's>,
-}
-
-// Manual implementation of `SystemParam` for `RayCasterMut` to prevent multiple access
-// of the system parameter within a single system
-unsafe impl<'w, 's> SystemParam for RayCasterMut<'w, 's> {
-	type State = (<Inner<'w, 's> as SystemParam>::State, ComponentId);
-	type Item<'world, 'state> = RayCasterMut<'world, 'state>;
-
-	fn init_state(world: &mut World) -> Self::State {
-		(
-			Inner::<'w, 's>::init_state(world),
-			ResMut::<'w, PreventMultiAccess>::init_state(world),
-		)
-	}
-
-	fn init_access(
-		(state, id): &Self::State,
-		system_meta: &mut bevy::ecs::system::SystemMeta,
-		component_access_set: &mut bevy::ecs::query::FilteredAccessSet,
-		world: &mut World,
-	) {
-		// Conceptually copied from unique access implementation for resources.
-		let combined_access = component_access_set.combined_access();
-		if combined_access.has_resource_write(*id) {
-			panic!(
-				"{} in system {} can only be accessed once",
-				type_name::<RayCasterMut>(),
-				system_meta.name(),
-			);
-		}
-		component_access_set.add_unfiltered_resource_write(*id);
-
-		Inner::<'w, 's>::init_access(state, system_meta, component_access_set, world);
-	}
-
-	unsafe fn get_param<'world, 'state>(
-		(state, ..): &'state mut Self::State,
-		system_meta: &bevy::ecs::system::SystemMeta,
-		world: bevy::ecs::world::unsafe_world_cell::UnsafeWorldCell<'world>,
-		change_tick: bevy::ecs::change_detection::Tick,
-	) -> Self::Item<'world, 'state> {
-		let inner = unsafe { Inner::<'w, 's>::get_param(state, system_meta, world, change_tick) };
-
-		RayCasterMut { inner }
-	}
-
-	fn apply(
-		(state, ..): &mut Self::State,
-		system_meta: &bevy::ecs::system::SystemMeta,
-		world: &mut World,
-	) {
-		Inner::<'w, 's>::apply(state, system_meta, world);
-	}
-
-	fn queue(
-		(state, ..): &mut Self::State,
-		system_meta: &bevy::ecs::system::SystemMeta,
-		world: bevy::ecs::world::DeferredWorld,
-	) {
-		Inner::<'w, 's>::queue(state, system_meta, world);
-	}
-
-	unsafe fn validate_param(
-		(state, ..): &mut Self::State,
-		system_meta: &bevy::ecs::system::SystemMeta,
-		world: bevy::ecs::world::unsafe_world_cell::UnsafeWorldCell,
-	) -> std::prelude::v1::Result<(), bevy::ecs::system::SystemParamValidationError> {
-		unsafe { Inner::<'w, 's>::validate_param(state, system_meta, world) }
-	}
-}
-
 #[derive(SystemParam)]
-pub struct Inner<'w, 's> {
+pub struct RayCasterMut<'w, 's> {
 	commands: ZyheedaCommands<'w, 's>,
 	world_cameras: Query<'w, 's, (), With<WorldCamera>>,
+	_u: MarkUnique<RayCasterMut<'w, 's>>,
 }
-
-#[derive(Resource)]
-struct PreventMultiAccess;

--- a/src/plugins/physics/src/system_params/ray_caster/set_world_camera.rs
+++ b/src/plugins/physics/src/system_params/ray_caster/set_world_camera.rs
@@ -12,11 +12,11 @@ impl<'w, 's> NoWorldCameraSet for RayCasterMut<'w, 's> {
 	type TSetter = WorldCameraSetter<'w, 's>;
 
 	fn no_world_camera_set(self) -> Option<Self::TSetter> {
-		if !self.inner.world_cameras.is_empty() {
+		if !self.world_cameras.is_empty() {
 			return None;
 		}
 
-		Some(WorldCameraSetter(self.inner.commands))
+		Some(WorldCameraSetter(self.commands))
 	}
 }
 


### PR DESCRIPTION
- added `MarkUnique` in `common`
- it enforces uniqueness of the system parameter it is used in

There might be a "prettier" variant via custom `SystemParameter` derive macro. But this is a good enough version without the need to get into derive macro details.