### PR TITLE
Remove generic lifetimes for prefab system param

### DIFF
--- a/src/plugins/agents/src/components/agent.rs
+++ b/src/plugins/agents/src/components/agent.rs
@@ -69,7 +69,7 @@ where
 	TGraphics: for<'c> TryGetContextMut<HasNoRole, TContext<'c>: SetRole>,
 {
 	type TError = RoleAlreadyConfigured;
-	type TSystemParam<'w, 's> = (Res<'w, AssetServer>, TGraphics);
+	type TSystemParam = (Res<'static, AssetServer>, TGraphics);
 
 	fn insert_prefab_components(
 		&self,

--- a/src/plugins/agents/src/components/enemy.rs
+++ b/src/plugins/agents/src/components/enemy.rs
@@ -34,12 +34,12 @@ where
 	TGraphics: for<'c> TryGetContextMut<HasNoRole, TContext<'c>: SetRole>,
 {
 	type TError = Unreachable;
-	type TSystemParam<'w, 's> = TGraphics;
+	type TSystemParam = TGraphics;
 
 	fn insert_prefab_components(
 		&self,
 		entity: &mut impl PrefabEntityCommands,
-		mut graphics: StaticSystemParam<Self::TSystemParam<'_, '_>>,
+		mut graphics: StaticSystemParam<Self::TSystemParam>,
 	) -> Result<(), Self::TError> {
 		let entity = entity.entity_id();
 		let no_role = HasNoRole { entity };

--- a/src/plugins/agents/src/components/enemy/void_sphere.rs
+++ b/src/plugins/agents/src/components/enemy/void_sphere.rs
@@ -129,7 +129,7 @@ impl From<VoidSphere> for AgentType {
 
 impl Prefab<()> for VoidSphere {
 	type TError = Unreachable;
-	type TSystemParam<'w, 's> = ();
+	type TSystemParam = ();
 
 	fn insert_prefab_components(
 		&self,

--- a/src/plugins/common/src/components/model.rs
+++ b/src/plugins/common/src/components/model.rs
@@ -39,7 +39,7 @@ where
 {
 	type TError = Unreachable;
 
-	type TSystemParam<'w, 's> = ResMut<'w, TAssetServer>;
+	type TSystemParam = ResMut<'static, TAssetServer>;
 
 	fn insert_prefab_components(
 		&self,

--- a/src/plugins/common/src/traits/prefab.rs
+++ b/src/plugins/common/src/traits/prefab.rs
@@ -13,14 +13,14 @@ use bevy::{
 
 pub trait Prefab<TDependency>: Component<Mutability = Immutable> {
 	type TError: ErrorData;
-	type TSystemParam<'w, 's>: SystemParam;
+	type TSystemParam: SystemParam;
 
 	const REAPPLY: Reapply = Reapply::Never;
 
 	fn insert_prefab_components(
 		&self,
 		entity: &mut impl PrefabEntityCommands,
-		system_param: StaticSystemParam<Self::TSystemParam<'_, '_>>,
+		system_param: StaticSystemParam<Self::TSystemParam>,
 	) -> Result<(), Self::TError>;
 }
 

--- a/src/plugins/common/src/traits/prefab/app.rs
+++ b/src/plugins/common/src/traits/prefab/app.rs
@@ -26,7 +26,7 @@ fn instantiate<TEvent, TPrefab, TDependencies>(
 	trigger: On<TEvent, TPrefab>,
 	components: Query<&TPrefab>,
 	mut commands: Commands,
-	system_param: StaticSystemParam<TPrefab::TSystemParam<'_, '_>>,
+	system_param: StaticSystemParam<TPrefab::TSystemParam>,
 ) -> Result<(), TPrefab::TError>
 where
 	TEvent: EntityEvent,
@@ -73,7 +73,7 @@ mod tests {
 
 	impl Prefab<_Dependency> for _Component {
 		type TError = _Error;
-		type TSystemParam<'w, 's> = ResMut<'w, _Counter>;
+		type TSystemParam = ResMut<'static, _Counter>;
 
 		fn insert_prefab_components(
 			&self,

--- a/src/plugins/graphics/src/components/camera_labels.rs
+++ b/src/plugins/graphics/src/components/camera_labels.rs
@@ -406,7 +406,7 @@ impl From<WorldLight> for RenderLayers {
 
 impl Prefab<()> for WorldLight {
 	type TError = Unreachable;
-	type TSystemParam<'w, 's> = ();
+	type TSystemParam = ();
 
 	fn insert_prefab_components(
 		&self,

--- a/src/plugins/graphics/src/components/roles.rs
+++ b/src/plugins/graphics/src/components/roles.rs
@@ -19,12 +19,12 @@ pub(crate) struct Player;
 
 impl Prefab<()> for Player {
 	type TError = Unreachable;
-	type TSystemParam<'w, 's> = ();
+	type TSystemParam = ();
 
 	fn insert_prefab_components(
 		&self,
 		entity: &mut impl PrefabEntityCommands,
-		_: StaticSystemParam<Self::TSystemParam<'_, '_>>,
+		_: StaticSystemParam<Self::TSystemParam>,
 	) -> Result<(), Self::TError> {
 		entity
 			.try_insert(ModelRenderLayers::from(AgentsPass))
@@ -49,12 +49,12 @@ pub(crate) struct Enemy;
 
 impl Prefab<()> for Enemy {
 	type TError = Unreachable;
-	type TSystemParam<'w, 's> = ();
+	type TSystemParam = ();
 
 	fn insert_prefab_components(
 		&self,
 		entity: &mut impl PrefabEntityCommands,
-		_: StaticSystemParam<Self::TSystemParam<'_, '_>>,
+		_: StaticSystemParam<Self::TSystemParam>,
 	) -> Result<(), Self::TError> {
 		entity.try_insert(ModelRenderLayers::from(AgentsPass));
 

--- a/src/plugins/interactive/src/components/door.rs
+++ b/src/plugins/interactive/src/components/door.rs
@@ -15,7 +15,7 @@ pub(crate) struct Door;
 
 impl Prefab<()> for Door {
 	type TError = Unreachable;
-	type TSystemParam<'w, 's> = Res<'w, AssetServer>;
+	type TSystemParam = Res<'static, AssetServer>;
 
 	fn insert_prefab_components(
 		&self,

--- a/src/plugins/map_generation/src/components/mesh_collider.rs
+++ b/src/plugins/map_generation/src/components/mesh_collider.rs
@@ -23,12 +23,12 @@ where
 	for<'c> TPhysics: TryGetContextMut<NoBodyConfigured, TContext<'c>: ConfigureBody>,
 {
 	type TError = HasAlreadyBody;
-	type TSystemParam<'w, 's> = TPhysics;
+	type TSystemParam = TPhysics;
 
 	fn insert_prefab_components(
 		&self,
 		entity: &mut impl PrefabEntityCommands,
-		mut physics: StaticSystemParam<Self::TSystemParam<'_, '_>>,
+		mut physics: StaticSystemParam<Self::TSystemParam>,
 	) -> Result<(), Self::TError> {
 		let entity = entity.entity_id();
 		let key = NoBodyConfigured { entity };

--- a/src/plugins/menu/src/components/start_menu_button.rs
+++ b/src/plugins/menu/src/components/start_menu_button.rs
@@ -57,7 +57,7 @@ impl TriggerState for StartMenuButton {
 
 impl Prefab<()> for StartMenuButton {
 	type TError = Unreachable;
-	type TSystemParam<'w, 's> = ();
+	type TSystemParam = ();
 
 	fn insert_prefab_components(
 		&self,

--- a/src/plugins/physics/src/components/body.rs
+++ b/src/plugins/physics/src/components/body.rs
@@ -74,7 +74,7 @@ impl From<BodyConfig> for Body {
 
 impl Prefab<()> for Body {
 	type TError = Unreachable;
-	type TSystemParam<'w, 's> = ();
+	type TSystemParam = ();
 
 	fn insert_prefab_components(
 		&self,

--- a/src/plugins/physics/src/components/collider.rs
+++ b/src/plugins/physics/src/components/collider.rs
@@ -84,7 +84,7 @@ where
 
 impl Prefab<()> for ColliderShape {
 	type TError = Unreachable;
-	type TSystemParam<'w, 's> = ();
+	type TSystemParam = ();
 
 	const REAPPLY: Reapply = Reapply::Always;
 


### PR DESCRIPTION
System parameters do not need generic lifetimes, they are valid with static lifetimes. Thus, we can safely remove lifetimes from `Prefab` system parameters so we need to define all needed system parameters as `'static` and don't sometimes mix generic and static lifetimes for no real reason.