### PR TITLE
Use error type rate limit for `Vec<Error>`

### DIFF
--- a/src/plugins/common/src/errors.rs
+++ b/src/plugins/common/src/errors.rs
@@ -189,6 +189,10 @@ impl<T> ErrorData for Vec<T>
 where
 	T: ErrorData,
 {
+	fn rate_limit() -> Option<Duration> {
+		T::rate_limit()
+	}
+
 	fn level(&self) -> Level {
 		if self.iter().any(|e| e.level() == Level::Error) {
 			return Level::Error;


### PR DESCRIPTION
Vectors of `ErrorData` used the default `None` rate limit. Now they will inherit the rate limit from the contained error type for more consistent behavior.