### PR TITLE
`PersistentEntity` as save/load driver

### DIFF
--- a/src/plugins/agents/src/lib.rs
+++ b/src/plugins/agents/src/lib.rs
@@ -176,7 +176,6 @@ where
 		TSaveGame::register_savable_component::<Agent>(app);
 		TSaveGame::register_savable_component::<Enemy>(app);
 		TSaveGame::register_savable_component::<EnemyAttackPhase>(app);
-		app.register_required_components::<Agent, TSaveGame::TSaveEntityMarker>();
 
 		// # Prefabs
 		app.add_prefab_observer::<Agent, TGraphics::TRolesMut>();

--- a/src/plugins/common/src/components/persistent_entity.rs
+++ b/src/plugins/common/src/components/persistent_entity.rs
@@ -4,9 +4,15 @@ use macros::SavableComponent;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-/// Used as an [`Entity`] reference through different game sessions
+/// Used as an [`Entity`] reference throughout different game sessions.
 ///
-/// Works in tandem with [`PersistentEntities`](crate::resources::persistent_entities::PersistentEntities).
+/// Plugins that implement saving should tread this component as the driver for what should be
+/// saved/loaded.
+///
+/// This component should only ever be present on the root entity of a hierarchy.
+///
+/// Works in tandem with [`PersistentEntities`](crate::resources::persistent_entities::PersistentEntities)
+/// and [`ZyheedaCommands`](crate::zyheeda_commands::ZyheedaCommands).
 /// Requires:
 /// - either [`CommonPlugin`](crate::CommonPlugin)
 /// - or [`RegisterPersistentEntities`](crate::traits::register_persistent_entities::RegisterPersistentEntities).

--- a/src/plugins/common/src/lib.rs
+++ b/src/plugins/common/src/lib.rs
@@ -20,6 +20,7 @@ use crate::{
 		gltf::GltfLookup,
 		lifetime::Lifetime,
 		load_scene::LoadScene,
+		persistent_entity::PersistentEntity,
 	},
 	error_logger::GlobalErrorLogger,
 	states::game_state::GameState,
@@ -64,6 +65,7 @@ fn game_state(app: &mut App) {
 fn persistent_entities(app: &mut App) {
 	app.register_persistent_entities();
 	app.add_observer(ChildOfPersistent::insert_child_of);
+	app.add_systems(Update, PersistentEntity::has_parent::<GlobalErrorLogger>);
 }
 
 fn life_cycles(app: &mut App) {

--- a/src/plugins/common/src/systems.rs
+++ b/src/plugins/common/src/systems.rs
@@ -4,5 +4,6 @@ pub mod register_animations;
 pub mod remove_components;
 
 pub(crate) mod lifetime;
+pub(crate) mod log_persistent_entity_has_parent;
 pub(crate) mod remove_not_owned;
 pub(crate) mod trigger_gltf_model_load;

--- a/src/plugins/common/src/systems/log_persistent_entity_has_parent.rs
+++ b/src/plugins/common/src/systems/log_persistent_entity_has_parent.rs
@@ -1,0 +1,151 @@
+use crate::{
+	components::persistent_entity::PersistentEntity,
+	error_logger::Log,
+	errors::{ErrorData, Level},
+};
+use bevy::{
+	ecs::system::{StaticSystemParam, SystemParam},
+	prelude::*,
+};
+use std::fmt::Display;
+
+impl PersistentEntity {
+	pub(crate) fn has_parent<TLogger>(
+		logger: StaticSystemParam<TLogger>,
+		entities: Query<(&PersistentEntity, &ChildOf), Changed<ChildOf>>,
+	) where
+		TLogger: for<'w, 's> SystemParam<Item<'w, 's>: Log>,
+	{
+		for (entity, ChildOf(parent)) in entities {
+			logger.log(PersistentEntityHasParent {
+				entity: *entity,
+				parent: *parent,
+			});
+		}
+	}
+}
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+struct PersistentEntityHasParent {
+	entity: PersistentEntity,
+	parent: Entity,
+}
+
+impl Display for PersistentEntityHasParent {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		write!(
+			f,
+			"{:?}: has a parent {:?}. This will result in undefined behavior when saving/loading",
+			self.entity, self.parent,
+		)
+	}
+}
+
+impl ErrorData for PersistentEntityHasParent {
+	fn level(&self) -> Level {
+		Level::Warning
+	}
+
+	fn label() -> impl Display {
+		"Persistent Entity Has Parent"
+	}
+
+	fn into_details(self) -> impl Display {
+		self
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	#![allow(clippy::unwrap_used)]
+	use super::*;
+	use std::{any::Any, sync::RwLock};
+	use testing::SingleThreadedApp;
+
+	#[derive(Resource)]
+	struct _Logger(RwLock<Vec<PersistentEntityHasParent>>);
+
+	impl Log for _Logger {
+		fn log<TError>(&self, error: TError)
+		where
+			TError: ErrorData,
+		{
+			let Ok(mut lock) = self.0.write() else {
+				return;
+			};
+
+			let error = (&error as &dyn Any)
+				.downcast_ref::<PersistentEntityHasParent>()
+				.unwrap();
+
+			lock.push(*error);
+		}
+	}
+
+	fn setup() -> App {
+		let mut app = App::new().single_threaded(Update);
+
+		app.insert_resource(_Logger(RwLock::new(vec![])));
+		app.add_systems(Update, PersistentEntity::has_parent::<Res<_Logger>>);
+
+		app
+	}
+
+	#[test]
+	fn log_parent() {
+		let mut app = setup();
+		let entity = PersistentEntity::default();
+		let parent = app.world_mut().spawn_empty().id();
+		app.world_mut().spawn((ChildOf(parent), entity));
+
+		app.update();
+
+		assert_eq!(
+			vec![PersistentEntityHasParent { entity, parent }],
+			*app.world().resource::<_Logger>().0.read().unwrap(),
+		);
+	}
+
+	#[test]
+	fn log_only_once() {
+		let mut app = setup();
+		let entity = PersistentEntity::default();
+		let parent = app.world_mut().spawn_empty().id();
+		app.world_mut().spawn((ChildOf(parent), entity));
+
+		app.update();
+		app.update();
+
+		assert_eq!(
+			vec![PersistentEntityHasParent { entity, parent }],
+			*app.world().resource::<_Logger>().0.read().unwrap(),
+		);
+	}
+
+	#[test]
+	fn log_again_if_parent_changed() {
+		let mut app = setup();
+		let entity = PersistentEntity::default();
+		let parent_a = app.world_mut().spawn_empty().id();
+		let parent_b = app.world_mut().spawn_empty().id();
+		let child = app.world_mut().spawn((ChildOf(parent_a), entity)).id();
+
+		app.update();
+		app.world_mut().entity_mut(child).insert(ChildOf(parent_b));
+		app.update();
+
+		assert_eq!(
+			vec![
+				PersistentEntityHasParent {
+					entity,
+					parent: parent_a
+				},
+				PersistentEntityHasParent {
+					entity,
+					parent: parent_b
+				},
+			],
+			*app.world().resource::<_Logger>().0.read().unwrap(),
+		);
+	}
+}

--- a/src/plugins/common/src/traits/handles_saving.rs
+++ b/src/plugins/common/src/traits/handles_saving.rs
@@ -6,8 +6,6 @@ use serde::{Serialize, de::DeserializeOwned};
 use std::{hash::Hash, ops::Deref, sync::OnceLock};
 
 pub trait HandlesSaving {
-	type TSaveEntityMarker: Component + Default;
-
 	/// Check whether quick loading is possible
 	///
 	/// Useful for button (dis|en)ables.

--- a/src/plugins/graphics/src/lib.rs
+++ b/src/plugins/graphics/src/lib.rs
@@ -134,7 +134,6 @@ where
 	}
 
 	fn cameras(&self, app: &mut App) {
-		app.register_required_components::<UiPass, TSavegame::TSaveEntityMarker>();
 		TSavegame::register_savable_component::<UiPass>(app);
 
 		app.insert_resource(GlobalAmbientLight::NONE)

--- a/src/plugins/map_generation/src/lib.rs
+++ b/src/plugins/map_generation/src/lib.rs
@@ -97,7 +97,6 @@ where
 
 		app.init_resource::<PrefabRegister<AgentType>>()
 			.init_resource::<PrefabRegister<InteractiveType>>()
-			.register_required_components::<Map, TSavegame::TSaveEntityMarker>()
 			.add_systems(OnEnter(GameState::NewGame), Level::<0>::spawn)
 			.add_prefab_observer::<MeshCollider, TPhysics::TConfigMut>()
 			.add_observer(NavMesh::identify_by_prefix(Self::NAV_MESH_PREFIX))

--- a/src/plugins/physics/src/components/collision_domains.rs
+++ b/src/plugins/physics/src/components/collision_domains.rs
@@ -1,9 +1,7 @@
 use bevy::prelude::*;
-use common::components::persistent_entity::PersistentEntity;
 
 #[derive(Component, PartialEq, Debug, Clone, Copy)]
 #[component(immutable)]
-#[require(PersistentEntity)]
 pub(crate) enum Physical {
 	Contact,
 	Projection,

--- a/src/plugins/physics/src/lib.rs
+++ b/src/plugins/physics/src/lib.rs
@@ -167,7 +167,6 @@ where
 					.in_set(PhysicsSystems::Resolve),
 			)
 			// Skills
-			.register_required_components::<Skill, TSaveGame::TSaveEntityMarker>()
 			.add_observer(Skill::prefab)
 			// Colliders/Bodies
 			.add_prefab_observer::<ColliderShape, ()>()

--- a/src/plugins/savegame/src/components.rs
+++ b/src/plugins/savegame/src/components.rs
@@ -1,1 +1,0 @@
-pub mod save;

--- a/src/plugins/savegame/src/components/save.rs
+++ b/src/plugins/savegame/src/components/save.rs
@@ -1,4 +1,0 @@
-use bevy::prelude::*;
-
-#[derive(Component, Debug, PartialEq, Default)]
-pub struct Save;

--- a/src/plugins/savegame/src/lib.rs
+++ b/src/plugins/savegame/src/lib.rs
@@ -1,5 +1,3 @@
-pub mod components;
-
 mod context;
 mod errors;
 mod file_io;
@@ -9,7 +7,11 @@ mod traits;
 
 use crate::{
 	resources::{inspector::Inspector, unique_ids::UniqueIds},
-	systems::{trigger_state::TriggerState, write_buffer::WriteBufferSystem},
+	systems::{
+		despawn_persistent_entities::DespawnAll,
+		trigger_state::TriggerState,
+		write_buffer::WriteBufferSystem,
+	},
 };
 use bevy::prelude::*;
 use common::{
@@ -34,7 +36,6 @@ use common::{
 		thread_safe::ThreadSafe,
 	},
 };
-use components::save::Save;
 use context::SaveContext;
 use file_io::FileIO;
 use resources::register::Register;
@@ -136,7 +137,7 @@ where
 			.add_systems(
 				OnEnter(GameState::Save(SaveState::Load)),
 				(
-					Save::despawn_all,
+					PersistentEntity::despawn_all,
 					SaveContext::read_file_system(quick_save.clone()).pipe(OnError::log),
 					SaveContext::read_buffer_system(quick_save).pipe(OnError::log),
 				)
@@ -146,8 +147,6 @@ where
 }
 
 impl<TDependencies> HandlesSaving for SavegamePlugin<TDependencies> {
-	type TSaveEntityMarker = Save;
-
 	fn can_quick_load() -> impl SystemCondition<()> {
 		IntoSystem::into_system(
 			Inspector::<FileIO>::quick_save_file_exists.pipe(OnError::log_and_return(|| false)),

--- a/src/plugins/savegame/src/systems.rs
+++ b/src/plugins/savegame/src/systems.rs
@@ -1,4 +1,4 @@
-pub(crate) mod despawn_savable_entities;
+pub(crate) mod despawn_persistent_entities;
 pub(crate) mod quick_save_file_exists;
 pub(crate) mod read_buffer;
 pub(crate) mod read_file;

--- a/src/plugins/savegame/src/systems/despawn_persistent_entities.rs
+++ b/src/plugins/savegame/src/systems/despawn_persistent_entities.rs
@@ -1,10 +1,11 @@
-use crate::components::save::Save;
 use bevy::prelude::*;
 use common::{traits::accessors::get::TryApplyOn, zyheeda_commands::ZyheedaCommands};
 
-impl Save {
-	pub(crate) fn despawn_all(mut commands: ZyheedaCommands, targets: Query<Entity, With<Self>>) {
-		for target in &targets {
+impl<T> DespawnAll for T where T: Component {}
+
+pub(crate) trait DespawnAll: Component + Sized {
+	fn despawn_all(mut commands: ZyheedaCommands, targets: Query<Entity, With<Self>>) {
+		for target in targets {
 			commands.try_apply_on(&target, |e| e.try_despawn());
 		}
 	}
@@ -15,22 +16,25 @@ mod tests {
 	use super::*;
 	use testing::SingleThreadedApp;
 
+	#[derive(Component)]
+	struct _Component;
+
 	fn setup() -> App {
 		let mut app = App::new().single_threaded(Update);
 
-		app.add_systems(Update, Save::despawn_all);
+		app.add_systems(Update, _Component::despawn_all);
 
 		app
 	}
 
 	#[test]
-	fn despawn_all_save_entities() {
+	fn despawn_all_entities() {
 		let mut app = setup();
 		let entities = [
-			app.world_mut().spawn(Save).id(),
-			app.world_mut().spawn(Save).id(),
-			app.world_mut().spawn(Save).id(),
-			app.world_mut().spawn(Save).id(),
+			app.world_mut().spawn(_Component).id(),
+			app.world_mut().spawn(_Component).id(),
+			app.world_mut().spawn(_Component).id(),
+			app.world_mut().spawn(_Component).id(),
 		];
 
 		app.update();
@@ -42,7 +46,7 @@ mod tests {
 	}
 
 	#[test]
-	fn do_not_despawn_entities_without_save_component() {
+	fn do_not_despawn_entities_without_component() {
 		let mut app = setup();
 		let entities = [
 			app.world_mut().spawn_empty().id(),

--- a/src/plugins/savegame/src/systems/write_buffer.rs
+++ b/src/plugins/savegame/src/systems/write_buffer.rs
@@ -1,9 +1,9 @@
 use crate::{
-	components::save::Save,
 	errors::{LockPoisonedError, SerializationErrors, SerializationOrLockError},
 	traits::write_buffer::WriteBuffer,
 };
 use bevy::prelude::*;
+use common::components::persistent_entity::PersistentEntity;
 use std::{
 	collections::HashMap,
 	sync::{Arc, Mutex},
@@ -23,7 +23,7 @@ pub(crate) trait WriteBufferSystem {
 				return Err(SerializationOrLockError::LockPoisoned(LockPoisonedError));
 			};
 
-			let mut save_entities = world.query_filtered::<EntityRef, With<Save>>();
+			let mut save_entities = world.query_filtered::<EntityRef, With<PersistentEntity>>();
 			let errors = save_entities
 				.iter(world)
 				.filter_map(|entity| match context.write_buffer(entity) {
@@ -64,7 +64,7 @@ mod test_save {
 	#[test]
 	fn buffer() -> Result<(), RunSystemError> {
 		let mut app = setup();
-		let entity = app.world_mut().spawn(Save).id();
+		let entity = app.world_mut().spawn(PersistentEntity::default()).id();
 		let context = Mock_SaveContext::new_mock(|mock| {
 			mock.expect_write_buffer()
 				.times(1)
@@ -80,7 +80,7 @@ mod test_save {
 	}
 
 	#[test]
-	fn ignore_entities_without_save() -> Result<(), RunSystemError> {
+	fn ignore_entities_without_persistent_entity() -> Result<(), RunSystemError> {
 		let mut app = setup();
 		let entity = app.world_mut().spawn_empty().id();
 		let context = Mock_SaveContext::new_mock(|mock| {
@@ -100,8 +100,8 @@ mod test_save {
 	#[test]
 	fn serialization_error() -> Result<(), RunSystemError> {
 		let mut app = setup();
-		let a = app.world_mut().spawn(Save).id();
-		let b = app.world_mut().spawn(Save).id();
+		let a = app.world_mut().spawn(PersistentEntity::default()).id();
+		let b = app.world_mut().spawn(PersistentEntity::default()).id();
 		let context = Mock_SaveContext::new_mock(|mock| {
 			mock.expect_write_buffer().returning(|_| {
 				Err(EntitySerializationErrors(vec![


### PR DESCRIPTION
- removed `Save` component and concept of marking entities to be saved
- now all entities with a `PersistentEntity` component will be saved
- non top level `PersistentEntity`s will produce warnings
- removed `PersistentEntity` from `Physical`, because it might not sit on the root entity of a given hierarchy