### PR TITLE
Apply map object persistence before each save

### DIFF
--- a/src/plugins/common/src/traits/handles_saving.rs
+++ b/src/plugins/common/src/traits/handles_saving.rs
@@ -1,7 +1,7 @@
 mod external;
 
 use crate::{errors::Unreachable, traits::handles_custom_assets::TryLoadFrom};
-use bevy::prelude::*;
+use bevy::{ecs::system::ScheduleSystem, prelude::*};
 use serde::{Serialize, de::DeserializeOwned};
 use std::{hash::Hash, ops::Deref, sync::OnceLock};
 
@@ -17,6 +17,9 @@ pub trait HandlesSaving {
 	fn register_savable_component<TComponent>(app: &mut App)
 	where
 		TComponent: SavableComponent;
+
+	/// Register system to run just before saving
+	fn on_before_save<M>(app: &mut App, systems: impl IntoScheduleConfigs<ScheduleSystem, M>);
 }
 
 /// Marks components as being (de)serializable.

--- a/src/plugins/map_generation/src/lib.rs
+++ b/src/plugins/map_generation/src/lib.rs
@@ -92,6 +92,8 @@ where
 		TSavegame::register_savable_component::<GridAgent>(app);
 		TSavegame::register_savable_component::<Level<0>>(app);
 
+		TSavegame::on_before_save(app, Map::apply_map_persistence);
+
 		#[cfg(debug_assertions)]
 		crate::mesh_grid_graph::debug::draw(app);
 
@@ -114,7 +116,6 @@ where
 					PersistentMapObject::link_with_map.pipe(OnError::log),
 					Spawner::<AgentType>::execute,
 					Spawner::<InteractiveType>::execute,
-					Map::apply_map_persistence,
 					GridAgent::link_to_grid::<MeshGridGraph>.run_if(in_state(GameState::Play)),
 				)
 					.chain(),

--- a/src/plugins/savegame/src/lib.rs
+++ b/src/plugins/savegame/src/lib.rs
@@ -13,7 +13,7 @@ use crate::{
 		write_buffer::WriteBufferSystem,
 	},
 };
-use bevy::prelude::*;
+use bevy::{ecs::system::ScheduleSystem, prelude::*};
 use common::{
 	components::{
 		child_of_persistent::ChildOfPersistent,
@@ -45,6 +45,8 @@ use std::{
 	path::PathBuf,
 	sync::{Arc, Mutex},
 };
+
+const ON_ENTER_SAVE: OnEnter<GameState> = OnEnter(GameState::Save(SaveState::Save));
 
 pub struct SavegamePlugin<TDependencies> {
 	game_directory: PathBuf,
@@ -102,6 +104,11 @@ where
 		Self::register_savable_component::<ChildOfPersistent>(app);
 		Self::register_savable_component::<Lifetime>(app);
 
+		app.configure_sets(
+			ON_ENTER_SAVE,
+			(SaveSystems::OnBeforeSave, SaveSystems::ExecuteSave).chain(),
+		);
+
 		app.init_resource::<Register>()
 			.insert_resource(Inspector {
 				quick_save: quick_save.clone(),
@@ -120,11 +127,12 @@ where
 					.after_plugin(TInput::SYSTEMS),
 			)
 			.add_systems(
-				OnEnter(GameState::Save(SaveState::Save)),
+				ON_ENTER_SAVE,
 				(
 					SaveContext::write_buffer_system(quick_save.clone()).pipe(OnError::log),
 					SaveContext::write_file_system(quick_save.clone()).pipe(OnError::log),
 				)
+					.in_set(SaveSystems::ExecuteSave)
 					.chain(),
 			)
 			.add_systems(
@@ -188,6 +196,16 @@ impl<TDependencies> HandlesSaving for SavegamePlugin<TDependencies> {
 			}
 		}
 	}
+
+	fn on_before_save<M>(app: &mut App, systems: impl IntoScheduleConfigs<ScheduleSystem, M>) {
+		app.add_systems(ON_ENTER_SAVE, systems.in_set(SaveSystems::OnBeforeSave));
+	}
+}
+
+#[derive(SystemSet, Debug, PartialEq, Eq, Hash, Clone, Copy)]
+enum SaveSystems {
+	OnBeforeSave,
+	ExecuteSave,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- added method to register systems to run just before saving
- changed system that applies map object persistence (persistent map reference and disabling spawners of persistent map objects) to run just before saving 