### PR TITLE
Interactive shapes can only be sub shapes

### DIFF
--- a/src/plugins/agents/src/systems/agent_config/apply_config_system.rs
+++ b/src/plugins/agents/src/systems/agent_config/apply_config_system.rs
@@ -26,7 +26,7 @@ use common::{
 			NoBodyConfigured,
 			NoDefaultAttributes,
 			TranslationOffsets,
-			physical_bodies::{Blocker, BodyConfig, PhysicsType, Shape, ShapeParameters},
+			physical_bodies::{Blocker, BodyConfig, Core, PhysicsType, Shape, ShapeParameters},
 		},
 		handles_skill_physics::{Initialize, NotInitializedAgent},
 		loadout::ItemName,
@@ -112,8 +112,10 @@ impl ApplyAgentConfig {
 				let aim = config.height_levels.aim - *config.required_clearance.vertical;
 				ctx.configure_body(
 					BodyConfig {
-						shape: Shape::Parameters(ShapeParameters::Capsule { half_y, radius }),
-						physics_type: PhysicsType::Agent(HashSet::from([Blocker::Character])),
+						core: Some(Core {
+							shape: Shape::Parameters(ShapeParameters::Capsule { half_y, radius }),
+							physics_type: PhysicsType::Agent(HashSet::from([Blocker::Character])),
+						}),
 						sub_frames: vec![config.interactive_detection_shape],
 					},
 					TranslationOffsets { center, aim },
@@ -763,11 +765,13 @@ mod tests {
 				AgentConfig { config_handle },
 				_Physics::new().with_mock(|mock| {
 					let expected_body = BodyConfig {
-						shape: Shape::Parameters(ShapeParameters::Capsule {
-							half_y: Units::from(1.5),
-							radius: Units::from(0.5),
+						core: Some(Core {
+							shape: Shape::Parameters(ShapeParameters::Capsule {
+								half_y: Units::from(1.5),
+								radius: Units::from(0.5),
+							}),
+							physics_type: PhysicsType::Agent(HashSet::from([Blocker::Character])),
 						}),
-						physics_type: PhysicsType::Agent(HashSet::from([Blocker::Character])),
 						sub_frames: vec![interactive_detection_shape],
 					};
 

--- a/src/plugins/common/src/traits/handles_physics/physical_bodies.rs
+++ b/src/plugins/common/src/traits/handles_physics/physical_bodies.rs
@@ -5,37 +5,10 @@ use crate::{
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone, Default, Serialize, Deserialize)]
 pub struct BodyConfig {
-	pub shape: Shape,
-	pub physics_type: PhysicsType,
+	pub core: Option<Core>,
 	pub sub_frames: Vec<InteractiveFrame>,
-}
-
-impl BodyConfig {
-	pub fn from_shape(shape: impl Into<Shape>) -> Self {
-		Self {
-			shape: shape.into(),
-			physics_type: PhysicsType::Terrain(HashSet::from([Blocker::Physical])),
-			sub_frames: vec![],
-		}
-	}
-
-	pub fn with_physics_type(mut self, physics_type: PhysicsType) -> Self {
-		self.physics_type = physics_type;
-		self
-	}
-
-	pub fn with_sub_frames(mut self, body_parts: impl Into<Vec<InteractiveFrame>>) -> Self {
-		self.sub_frames = body_parts.into();
-		self
-	}
-}
-
-impl From<Shape> for BodyConfig {
-	fn from(shape: Shape) -> Self {
-		Self::from_shape(shape)
-	}
 }
 
 #[derive(Debug, PartialEq, Default, Clone, Copy, Serialize, Deserialize)]
@@ -61,6 +34,21 @@ impl InteractiveFrame {
 impl From<ShapeParameters> for InteractiveFrame {
 	fn from(shape: ShapeParameters) -> Self {
 		Self::from_shape(shape)
+	}
+}
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+pub struct Core {
+	pub shape: Shape,
+	pub physics_type: PhysicsType,
+}
+
+impl Default for Core {
+	fn default() -> Self {
+		Self {
+			shape: Shape::StaticGltfMesh3d,
+			physics_type: PhysicsType::Terrain(HashSet::new()),
+		}
 	}
 }
 
@@ -122,7 +110,6 @@ impl Default for ShapeParameters {
 pub enum PhysicsType {
 	Agent(HashSet<Blocker>),
 	Terrain(HashSet<Blocker>),
-	InteractiveFrame,
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, Serialize, Deserialize)]

--- a/src/plugins/interactive/src/systems/apply_door_frame.rs
+++ b/src/plugins/interactive/src/systems/apply_door_frame.rs
@@ -10,7 +10,7 @@ use common::{
 			ConfigureBody,
 			NoBodyConfigured,
 			TranslationOffsets,
-			physical_bodies::{BodyConfig, PhysicsType},
+			physical_bodies::{BodyConfig, InteractiveFrame},
 		},
 	},
 	zyheeda_commands::ZyheedaCommands,
@@ -39,8 +39,13 @@ impl ApplyDoorFrame {
 				continue;
 			};
 
-			let body = BodyConfig::from_shape(meta.interactive_detection_shape)
-				.with_physics_type(PhysicsType::InteractiveFrame);
+			let body = BodyConfig {
+				sub_frames: vec![InteractiveFrame {
+					shape: meta.interactive_detection_shape,
+					..default()
+				}],
+				..default()
+			};
 
 			ctx.configure_body(body, TranslationOffsets::ZERO);
 		}
@@ -53,10 +58,7 @@ mod tests {
 	use crate::{assets::door_meta::DoorMeta, components::door_meta_handle::DoorMetaHandle};
 	use common::{
 		tools::Units,
-		traits::handles_physics::{
-			TranslationOffsets,
-			physical_bodies::{PhysicsType, Shape, ShapeParameters},
-		},
+		traits::handles_physics::{TranslationOffsets, physical_bodies::ShapeParameters},
 	};
 	use macros::NestedMocks;
 	use mockall::{automock, predicate::eq};
@@ -119,11 +121,13 @@ mod tests {
 				.once()
 				.with(
 					eq(BodyConfig {
-						physics_type: PhysicsType::InteractiveFrame,
-						shape: Shape::Parameters(ShapeParameters::Sphere {
-							radius: Units::from(42.),
-						}),
-						sub_frames: vec![],
+						core: None,
+						sub_frames: vec![InteractiveFrame {
+							shape: ShapeParameters::Sphere {
+								radius: Units::from(42.),
+							},
+							forward_offset: Units::ZERO,
+						}],
 					}),
 					eq(TranslationOffsets::ZERO),
 				)

--- a/src/plugins/map_generation/src/components/mesh_collider.rs
+++ b/src/plugins/map_generation/src/components/mesh_collider.rs
@@ -7,7 +7,7 @@ use common::{
 			ConfigureBody,
 			NoBodyConfigured,
 			TranslationOffsets,
-			physical_bodies::{Blocker, BodyConfig, PhysicsType, Shape},
+			physical_bodies::{Blocker, BodyConfig, Core, PhysicsType, Shape},
 		},
 		prefab::{Prefab, PrefabEntityCommands},
 	},
@@ -38,8 +38,13 @@ where
 		};
 
 		ctx.configure_body(
-			BodyConfig::from_shape(Shape::StaticGltfMesh3d)
-				.with_physics_type(PhysicsType::Terrain(HashSet::from([Blocker::Physical]))),
+			BodyConfig {
+				core: Some(Core {
+					shape: Shape::StaticGltfMesh3d,
+					physics_type: PhysicsType::Terrain(HashSet::from([Blocker::Physical])),
+				}),
+				..default()
+			},
 			TranslationOffsets::ZERO,
 		);
 

--- a/src/plugins/physics/src/components/body.rs
+++ b/src/plugins/physics/src/components/body.rs
@@ -1,6 +1,7 @@
 use crate::components::{
 	blocker_types::BlockerTypes,
 	collider::{
+		ChildColliderOf,
 		ColliderShape,
 		GENERIC_COLLISION_GROUP,
 		INTERACTIVE_GROUP,
@@ -51,10 +52,11 @@ impl Body {
 		)
 	}
 
-	fn interactive() -> impl Bundle {
+	fn interactive_of(entity: Entity) -> impl Bundle {
 		(
 			Interactive,
 			Sensor,
+			ChildColliderOf(entity),
 			CollidingEntities::default(),
 			ActiveEvents::COLLISION_EVENTS,
 			ActiveCollisionTypes::all(),
@@ -81,29 +83,24 @@ impl Prefab<()> for Body {
 		entity: &mut impl PrefabEntityCommands,
 		_: StaticSystemParam<()>,
 	) -> Result<(), Self::TError> {
-		let Self(BodyConfig {
-			physics_type,
-			shape,
-			sub_frames,
-		}) = self;
+		let Self(BodyConfig { core, sub_frames }) = self;
 
-		match physics_type {
-			PhysicsType::Agent(blockers) => {
-				entity.try_insert((Self::agent(), BlockerTypes(blockers.clone())));
-			}
-			PhysicsType::Terrain(blockers) => {
-				entity.try_insert((Self::terrain(), BlockerTypes(blockers.clone())));
-			}
-			PhysicsType::InteractiveFrame => {
-				entity.try_insert((Self::interactive(), RigidBody::Fixed));
-			}
-		};
+		if let Some(core) = core {
+			match core.physics_type {
+				PhysicsType::Agent(ref blockers) => {
+					entity.try_insert((Self::agent(), BlockerTypes(blockers.clone())));
+				}
+				PhysicsType::Terrain(ref blockers) => {
+					entity.try_insert((Self::terrain(), BlockerTypes(blockers.clone())));
+				}
+			};
 
-		entity.try_insert(ColliderShape::from(*shape));
+			entity.try_insert(ColliderShape::from(core.shape));
+		}
 
 		for sub_frame in sub_frames {
 			entity.with_child((
-				Self::interactive(),
+				Self::interactive_of(entity.entity_id()),
 				Transform::from_xyz(0., 0., -*sub_frame.forward_offset),
 				ColliderShape::from(sub_frame.shape),
 			));
@@ -139,9 +136,9 @@ mod tests {
 	}
 
 	mod body {
-		use crate::components::collision_domains::Physical;
-
 		use super::*;
+		use crate::components::collision_domains::Physical;
+		use common::traits::handles_physics::physical_bodies::Core;
 		use test_case::test_case;
 
 		#[test]
@@ -153,7 +150,10 @@ mod tests {
 
 			let entity = app
 				.world_mut()
-				.spawn(Body(BodyConfig::from_shape(shape)))
+				.spawn(Body(BodyConfig {
+					core: Some(Core { shape, ..default() }),
+					..default()
+				}))
 				.id();
 
 			assert_eq!(
@@ -164,7 +164,6 @@ mod tests {
 
 		#[test_case(PhysicsType::Terrain, |e| e.contains::<Physical>(); "terrain as physical")]
 		#[test_case(PhysicsType::Agent, |e| e.contains::<Physical>(); "agent as physical")]
-		#[test_case(|_| PhysicsType::InteractiveFrame, |e| e.contains::<Interactive>(); "interactive frame as interactive")]
 		fn mark(
 			physics_type: fn(HashSet<Blocker>) -> PhysicsType,
 			marker: fn(EntityWorldMut) -> bool,
@@ -174,16 +173,19 @@ mod tests {
 				radius: Units::from(42.),
 			});
 
-			let entity = app.world_mut().spawn(Body(
-				BodyConfig::from_shape(shape).with_physics_type(physics_type(HashSet::default())),
-			));
+			let entity = app.world_mut().spawn(Body(BodyConfig {
+				core: Some(Core {
+					shape,
+					physics_type: physics_type(HashSet::default()),
+				}),
+				..default()
+			}));
 
 			assert!(marker(entity));
 		}
 
 		#[test_case(PhysicsType::Terrain, RigidBody::Fixed, false, false, None, None; "terrain")]
 		#[test_case(PhysicsType::Agent, RigidBody::KinematicPositionBased, true, true, Some(&ActiveEvents::COLLISION_EVENTS), Some(&ActiveCollisionTypes::all()); "agent")]
-		#[test_case(|_| PhysicsType::InteractiveFrame, RigidBody::Fixed, false, true, Some(&ActiveEvents::COLLISION_EVENTS), Some(&ActiveCollisionTypes::all()); "interactive frame")]
 		fn insert_physics_constraints(
 			physics_type: fn(HashSet<Blocker>) -> PhysicsType,
 			rigid_body: RigidBody,
@@ -197,9 +199,13 @@ mod tests {
 				radius: Units::from(42.),
 			});
 
-			let entity = app.world_mut().spawn(Body(
-				BodyConfig::from_shape(shape).with_physics_type(physics_type(HashSet::default())),
-			));
+			let entity = app.world_mut().spawn(Body(BodyConfig {
+				core: Some(Core {
+					shape,
+					physics_type: physics_type(HashSet::new()),
+				}),
+				..default()
+			}));
 
 			assert_eq!(
 				(
@@ -221,7 +227,6 @@ mod tests {
 
 		#[test_case(PhysicsType::Terrain, Some; "terrain")]
 		#[test_case(PhysicsType::Agent, Some; "agent")]
-		#[test_case(|_| PhysicsType::InteractiveFrame, |_| None; "interactive frame")]
 		fn insert_blocker_types(
 			physics_type: fn(HashSet<Blocker>) -> PhysicsType,
 			blocks: fn(HashSet<Blocker>) -> Option<HashSet<Blocker>>,
@@ -231,11 +236,13 @@ mod tests {
 				radius: Units::from(42.),
 			});
 
-			let entity =
-				app.world_mut()
-					.spawn(Body(BodyConfig::from_shape(shape).with_physics_type(
-						physics_type(HashSet::from([Blocker::Force, Blocker::Physical])),
-					)));
+			let entity = app.world_mut().spawn(Body(BodyConfig {
+				core: Some(Core {
+					shape,
+					physics_type: physics_type(HashSet::from([Blocker::Force, Blocker::Physical])),
+				}),
+				..default()
+			}));
 
 			assert_eq!(
 				blocks(HashSet::from([Blocker::Force, Blocker::Physical])).map(BlockerTypes::from),
@@ -245,7 +252,6 @@ mod tests {
 
 		#[test_case(PhysicsType::Terrain, generic_and(TERRAIN_GROUP) , generic_and(RAY_GROUP); "terrain")]
 		#[test_case(PhysicsType::Agent, generic_and(MOUSE_HOVERABLE_GROUP), generic_and(RAY_GROUP); "agent")]
-		#[test_case(|_| PhysicsType::InteractiveFrame, INTERACTIVE_GROUP, INTERACTIVE_GROUP | RAY_GROUP; "interactive frame")]
 		fn insert_collision_groups(
 			physics_type: fn(HashSet<Blocker>) -> PhysicsType,
 			memberships: Group,
@@ -256,9 +262,13 @@ mod tests {
 				radius: Units::from(42.),
 			});
 
-			let entity = app.world_mut().spawn(Body(
-				BodyConfig::from_shape(shape).with_physics_type(physics_type(HashSet::default())),
-			));
+			let entity = app.world_mut().spawn(Body(BodyConfig {
+				core: Some(Core {
+					shape,
+					physics_type: physics_type(HashSet::new()),
+				}),
+				..default()
+			}));
 
 			assert_eq!(
 				Some(&CollisionGroups {
@@ -271,7 +281,6 @@ mod tests {
 
 		#[test_case(PhysicsType::Terrain, None; "terrain")]
 		#[test_case(PhysicsType::Agent, None; "agent")]
-		#[test_case(|_| PhysicsType::InteractiveFrame, Some(&Sensor); "interactive object")]
 		fn insert_sensor(
 			physics_type: fn(HashSet<Blocker>) -> PhysicsType,
 			sensor: Option<&Sensor>,
@@ -281,15 +290,21 @@ mod tests {
 				radius: Units::from(42.),
 			});
 
-			let entity = app.world_mut().spawn(Body(
-				BodyConfig::from_shape(shape).with_physics_type(physics_type(HashSet::default())),
-			));
+			let entity = app.world_mut().spawn(Body(BodyConfig {
+				core: Some(Core {
+					shape,
+					physics_type: physics_type(HashSet::new()),
+				}),
+				..default()
+			}));
 
 			assert_eq!(sensor, entity.get::<Sensor>());
 		}
 	}
 
 	mod sub_frames {
+		use crate::components::collider::ChildColliderOf;
+
 		use super::*;
 		use common::traits::handles_physics::physical_bodies::InteractiveFrame;
 		use testing::assert_children_count;
@@ -303,10 +318,10 @@ mod tests {
 
 			let entity = app
 				.world_mut()
-				.spawn(Body(
-					BodyConfig::from_shape(Shape::StaticGltfMesh3d)
-						.with_sub_frames([InteractiveFrame::from(shape)]),
-				))
+				.spawn(Body(BodyConfig {
+					sub_frames: vec![InteractiveFrame::from(shape)],
+					..default()
+				}))
 				.id();
 
 			let [child] = assert_children_count!(1, app, entity);
@@ -325,11 +340,12 @@ mod tests {
 
 			let entity = app
 				.world_mut()
-				.spawn(Body(
-					BodyConfig::from_shape(Shape::StaticGltfMesh3d).with_sub_frames([
+				.spawn(Body(BodyConfig {
+					sub_frames: vec![
 						InteractiveFrame::from(shape).with_forward_offset(Units::from(11.)),
-					]),
-				))
+					],
+					..default()
+				}))
 				.id();
 
 			let [child] = assert_children_count!(1, app, entity);
@@ -348,10 +364,10 @@ mod tests {
 
 			let entity = app
 				.world_mut()
-				.spawn(Body(
-					BodyConfig::from_shape(Shape::StaticGltfMesh3d)
-						.with_sub_frames([InteractiveFrame::from(shape)]),
-				))
+				.spawn(Body(BodyConfig {
+					sub_frames: vec![InteractiveFrame::from(shape)],
+					..default()
+				}))
 				.id();
 
 			let [child] = assert_children_count!(1, app, entity);
@@ -382,14 +398,35 @@ mod tests {
 
 			let entity = app
 				.world_mut()
-				.spawn(Body(
-					BodyConfig::from_shape(Shape::StaticGltfMesh3d)
-						.with_sub_frames([InteractiveFrame::from(shape)]),
-				))
+				.spawn(Body(BodyConfig {
+					sub_frames: vec![InteractiveFrame::from(shape)],
+					..default()
+				}))
 				.id();
 
 			let [child] = assert_children_count!(1, app, entity);
 			assert_eq!(Some(&Interactive), child.get::<Interactive>());
+		}
+
+		#[test]
+		fn insert_child_collider_of() {
+			let mut app = setup();
+			let shape = ShapeParameters::Sphere {
+				radius: Units::from(42.),
+			};
+			let entity = app
+				.world_mut()
+				.spawn(Body(BodyConfig {
+					sub_frames: vec![InteractiveFrame::from(shape)],
+					..default()
+				}))
+				.id();
+
+			let [child] = assert_children_count!(1, app, entity);
+			assert_eq!(
+				Some(&ChildColliderOf(entity)),
+				child.get::<ChildColliderOf>(),
+			);
 		}
 
 		#[test]
@@ -400,10 +437,10 @@ mod tests {
 			};
 			let entity = app
 				.world_mut()
-				.spawn(Body(
-					BodyConfig::from_shape(Shape::StaticGltfMesh3d)
-						.with_sub_frames([InteractiveFrame::from(shape)]),
-				))
+				.spawn(Body(BodyConfig {
+					sub_frames: vec![InteractiveFrame::from(shape)],
+					..default()
+				}))
 				.id();
 
 			let [child] = assert_children_count!(1, app, entity);
@@ -425,10 +462,10 @@ mod tests {
 
 			let entity = app
 				.world_mut()
-				.spawn(Body(
-					BodyConfig::from_shape(Shape::StaticGltfMesh3d)
-						.with_sub_frames([InteractiveFrame::from(shape)]),
-				))
+				.spawn(Body(BodyConfig {
+					sub_frames: vec![InteractiveFrame::from(shape)],
+					..default()
+				}))
 				.id();
 
 			let [child] = assert_children_count!(1, app, entity);

--- a/src/plugins/physics/src/system_params/config.rs
+++ b/src/plugins/physics/src/system_params/config.rs
@@ -60,10 +60,7 @@ pub struct ConfigContextMut<'ctx> {
 mod tests {
 	use super::*;
 	use bevy::ecs::system::{RunSystemError, RunSystemOnce};
-	use common::traits::handles_physics::{
-		PhysicalDefaultAttributes,
-		physical_bodies::{BodyConfig, Shape},
-	};
+	use common::traits::handles_physics::{PhysicalDefaultAttributes, physical_bodies::BodyConfig};
 	use testing::SingleThreadedApp;
 
 	fn setup() -> App {
@@ -134,10 +131,7 @@ mod tests {
 		#[test]
 		fn get_no_config_when_component_present() -> Result<(), RunSystemError> {
 			let mut app = setup();
-			let entity = app
-				.world_mut()
-				.spawn(Body(BodyConfig::from_shape(Shape::StaticGltfMesh3d)))
-				.id();
+			let entity = app.world_mut().spawn(Body(BodyConfig::default())).id();
 
 			let ctx_entity = app
 				.world_mut()

--- a/src/plugins/physics/src/system_params/config/body.rs
+++ b/src/plugins/physics/src/system_params/config/body.rs
@@ -33,9 +33,15 @@ mod tests {
 		ecs::system::{RunSystemError, RunSystemOnce},
 		prelude::*,
 	};
-	use common::traits::{
-		accessors::get::TryGetContextMut,
-		handles_physics::{NoBodyConfigured, physical_bodies::Shape},
+	use common::{
+		tools::Units,
+		traits::{
+			accessors::get::TryGetContextMut,
+			handles_physics::{
+				NoBodyConfigured,
+				physical_bodies::{Core, Shape, ShapeParameters},
+			},
+		},
 	};
 	use testing::SingleThreadedApp;
 
@@ -53,13 +59,29 @@ mod tests {
 				let key = NoBodyConfigured { entity };
 				let mut ctx = ConfigParamMut::try_get_context_mut(&mut p, key).unwrap();
 				ctx.configure_body(
-					BodyConfig::from_shape(Shape::StaticGltfMesh3d),
+					BodyConfig {
+						core: Some(Core {
+							shape: Shape::Parameters(ShapeParameters::Sphere {
+								radius: Units::from(11.),
+							}),
+							..default()
+						}),
+						..default()
+					},
 					TranslationOffsets::ZERO,
 				);
 			})?;
 
 		assert_eq!(
-			Some(&Body(BodyConfig::from_shape(Shape::StaticGltfMesh3d))),
+			Some(&Body(BodyConfig {
+				core: Some(Core {
+					shape: Shape::Parameters(ShapeParameters::Sphere {
+						radius: Units::from(11.),
+					}),
+					..default()
+				}),
+				..default()
+			})),
 			app.world().entity(entity).get::<Body>(),
 		);
 		Ok(())
@@ -75,7 +97,7 @@ mod tests {
 				let key = NoBodyConfigured { entity };
 				let mut ctx = ConfigParamMut::try_get_context_mut(&mut p, key).unwrap();
 				ctx.configure_body(
-					BodyConfig::from_shape(Shape::StaticGltfMesh3d),
+					BodyConfig::default(),
 					TranslationOffsets {
 						aim: 11.,
 						center: 12.,


### PR DESCRIPTION
Making the root of a hierarchy an interactive collider means we add rapier's `Sensor` component, preventing the whole hierarchy of "taking part" in the physical world. This is now fixed:
- `BodyConfig` now has an optional `core`
- `BodyConfig` can not have a `core` that is interactive
- `BodyConfig` can only have interactive sensor sub frames, whose collisions are then mapped back the core entity for interaction reporting

This way the interactive sensors are a child of the entity for which they detect interactions and the entity can again take part in the physical world.