### PR TITLE
Reduce movement artefacts

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -91,7 +91,8 @@ fn prepare_game(app: &mut App) -> Result<(), ZyheedaAppError> {
 		&loadout,
 	);
 	let bars = BarsPlugin::from_plugins(&agents, &physics, &graphics);
-	let camera_control = CameraControlPlugin::from_plugins(&input, &savegame, &agents, &graphics);
+	let camera_control =
+		CameraControlPlugin::from_plugins(&input, &physics, &savegame, &agents, &graphics);
 	let frame_limiter = FrameLimiterPlugin {
 		target_fps: TARGET_FPS,
 	};

--- a/src/plugins/bars/src/lib.rs
+++ b/src/plugins/bars/src/lib.rs
@@ -3,16 +3,18 @@ mod systems;
 mod traits;
 
 use bevy::{
-	app::{App, Plugin, Update},
+	app::{App, FixedUpdate, Plugin, Update},
 	ecs::{query::Without, schedule::IntoScheduleConfigs},
 };
 use common::{
 	attributes::health::Health,
 	traits::{
+		after_plugin::AfterPlugin,
 		handles_agents::HandlesAgents,
 		handles_graphics::HandlesCameras,
 		handles_physics::HandlesLife,
 		ownership_relation::OwnershipRelation,
+		system_set_definition::SystemSetDefinition,
 		thread_safe::ThreadSafe,
 	},
 };
@@ -25,7 +27,7 @@ pub struct BarsPlugin<TDependencies>(PhantomData<TDependencies>);
 impl<TAgents, TPhysics, TGraphics> BarsPlugin<(TAgents, TPhysics, TGraphics)>
 where
 	TAgents: ThreadSafe + HandlesAgents,
-	TPhysics: ThreadSafe + HandlesLife,
+	TPhysics: ThreadSafe + SystemSetDefinition + HandlesLife,
 	TGraphics: ThreadSafe + HandlesCameras,
 {
 	pub fn from_plugins(_: &TAgents, _: &TPhysics, _: &TGraphics) -> Self {
@@ -36,7 +38,7 @@ where
 impl<TAgents, TPhysics, TGraphics> Plugin for BarsPlugin<(TAgents, TPhysics, TGraphics)>
 where
 	TAgents: ThreadSafe + HandlesAgents,
-	TPhysics: ThreadSafe + HandlesLife,
+	TPhysics: ThreadSafe + SystemSetDefinition + HandlesLife,
 	TGraphics: ThreadSafe + HandlesCameras,
 {
 	fn build(&self, app: &mut App) {
@@ -45,13 +47,14 @@ where
 
 		app.manage_ownership::<Bar>(Update);
 		app.add_systems(
-			Update,
+			FixedUpdate,
 			(
 				Bar::add_to::<TAgents::TAgent<Without<Bar>>>,
 				update_life_bars,
 				render_life_bars,
 			)
-				.chain(),
+				.chain()
+				.after_plugin(TPhysics::SYSTEMS),
 		);
 	}
 }

--- a/src/plugins/camera_control/src/lib.rs
+++ b/src/plugins/camera_control/src/lib.rs
@@ -20,23 +20,31 @@ use std::marker::PhantomData;
 
 pub struct CameraControlPlugin<TDependencies>(PhantomData<TDependencies>);
 
-impl<TInput, TSavegame, TPlayers, TGraphics>
-	CameraControlPlugin<(TInput, TSavegame, TPlayers, TGraphics)>
+impl<TInput, TPhysics, TSavegame, TPlayers, TGraphics>
+	CameraControlPlugin<(TInput, TPhysics, TSavegame, TPlayers, TGraphics)>
 where
 	TInput: ThreadSafe + SystemSetDefinition + HandlesInput,
+	TPhysics: ThreadSafe + SystemSetDefinition,
 	TSavegame: ThreadSafe + HandlesSaving,
 	TPlayers: ThreadSafe + HandlesPlayer,
 	TGraphics: ThreadSafe + SystemSetDefinition + HandlesCameras,
 {
-	pub fn from_plugins(_: &TInput, _: &TSavegame, _: &TPlayers, _: &TGraphics) -> Self {
+	pub fn from_plugins(
+		_: &TInput,
+		_: &TPhysics,
+		_: &TSavegame,
+		_: &TPlayers,
+		_: &TGraphics,
+	) -> Self {
 		Self(PhantomData)
 	}
 }
 
-impl<TInput, TSavegame, TPlayers, TGraphics> Plugin
-	for CameraControlPlugin<(TInput, TSavegame, TPlayers, TGraphics)>
+impl<TInput, TPhysics, TSavegame, TPlayers, TGraphics> Plugin
+	for CameraControlPlugin<(TInput, TPhysics, TSavegame, TPlayers, TGraphics)>
 where
 	TInput: ThreadSafe + SystemSetDefinition + HandlesInput,
+	TPhysics: ThreadSafe + SystemSetDefinition,
 	TSavegame: ThreadSafe + HandlesSaving,
 	TPlayers: ThreadSafe + HandlesPlayer,
 	TGraphics: ThreadSafe + SystemSetDefinition + HandlesCameras,
@@ -49,11 +57,17 @@ where
 			(
 				CameraArm::init_for::<TPlayers::TPlayer>,
 				CameraArm::move_arms::<TInput::TInput>,
-				CameraArm::apply_direction::<TGraphics::TCameraMut>,
 			)
 				.chain()
 				.after_plugin(TInput::SYSTEMS)
 				.after_plugin(TGraphics::SYSTEMS)
+				.run_if(in_state(GameState::Play)),
+		);
+
+		app.add_systems(
+			FixedUpdate,
+			CameraArm::apply_direction::<TGraphics::TCameraMut>
+				.after_plugin(TPhysics::SYSTEMS)
 				.run_if(in_state(GameState::Play)),
 		);
 	}


### PR DESCRIPTION
Movement could appear bumpy at times because the camera movement update was not in sync with the players actual position. Now fixed by updating camera position in `FixedUpdate`. Also now updating bar positions in `FixedUpdate` so agent position and their life bars are in sync too.