### PR TITLE
Limit agents collisions

### DIFF
--- a/src/plugins/physics/src/components/body.rs
+++ b/src/plugins/physics/src/components/body.rs
@@ -43,7 +43,7 @@ impl Body {
 			},
 			CollisionGroups {
 				memberships: AGENTS_GROUP | MOUSE_HOVERABLE_GROUP,
-				filters: SKILLS_GROUP | TERRAIN_GROUP | RAY_GROUP,
+				filters: AGENTS_GROUP | SKILLS_GROUP | TERRAIN_GROUP | RAY_GROUP,
 			},
 		)
 	}
@@ -254,7 +254,7 @@ mod tests {
 		}
 
 		#[test_case(PhysicsType::Terrain, TERRAIN_GROUP, SKILLS_GROUP|AGENTS_GROUP|RAY_GROUP; "terrain")]
-		#[test_case(PhysicsType::Agent, AGENTS_GROUP|MOUSE_HOVERABLE_GROUP, SKILLS_GROUP|TERRAIN_GROUP|RAY_GROUP; "agent")]
+		#[test_case(PhysicsType::Agent, AGENTS_GROUP|MOUSE_HOVERABLE_GROUP, AGENTS_GROUP|SKILLS_GROUP|TERRAIN_GROUP|RAY_GROUP; "agent")]
 		fn insert_collision_groups(
 			physics_type: fn(HashSet<Blocker>) -> PhysicsType,
 			memberships: Group,

--- a/src/plugins/physics/src/components/body.rs
+++ b/src/plugins/physics/src/components/body.rs
@@ -1,12 +1,13 @@
 use crate::components::{
 	blocker_types::BlockerTypes,
 	collider::{
+		AGENTS_GROUP,
 		ChildColliderOf,
 		ColliderShape,
-		GENERIC_COLLISION_GROUP,
 		INTERACTIVE_GROUP,
 		MOUSE_HOVERABLE_GROUP,
 		RAY_GROUP,
+		SKILLS_GROUP,
 		TERRAIN_GROUP,
 	},
 	collision_domains::{Interactive, Physical},
@@ -33,10 +34,10 @@ impl Body {
 			CollidingEntities::default(),
 			ActiveEvents::COLLISION_EVENTS,
 			ActiveCollisionTypes::all(),
-			KinematicCharacterController::default(),
+			KinematicCharacterController { ..default() },
 			CollisionGroups {
-				memberships: generic_and(MOUSE_HOVERABLE_GROUP),
-				filters: generic_and(RAY_GROUP),
+				memberships: AGENTS_GROUP | MOUSE_HOVERABLE_GROUP,
+				filters: SKILLS_GROUP | TERRAIN_GROUP | RAY_GROUP,
 			},
 		)
 	}
@@ -46,8 +47,8 @@ impl Body {
 			Physical::Contact,
 			RigidBody::Fixed,
 			CollisionGroups {
-				memberships: generic_and(TERRAIN_GROUP),
-				filters: generic_and(RAY_GROUP),
+				memberships: TERRAIN_GROUP,
+				filters: RAY_GROUP,
 			},
 		)
 	}
@@ -108,10 +109,6 @@ impl Prefab<()> for Body {
 
 		Ok(())
 	}
-}
-
-fn generic_and(group: Group) -> Group {
-	GENERIC_COLLISION_GROUP | group
 }
 
 #[cfg(test)]
@@ -250,8 +247,8 @@ mod tests {
 			);
 		}
 
-		#[test_case(PhysicsType::Terrain, generic_and(TERRAIN_GROUP) , generic_and(RAY_GROUP); "terrain")]
-		#[test_case(PhysicsType::Agent, generic_and(MOUSE_HOVERABLE_GROUP), generic_and(RAY_GROUP); "agent")]
+		#[test_case(PhysicsType::Terrain, TERRAIN_GROUP, RAY_GROUP; "terrain")]
+		#[test_case(PhysicsType::Agent, AGENTS_GROUP|MOUSE_HOVERABLE_GROUP, SKILLS_GROUP|TERRAIN_GROUP|RAY_GROUP; "agent")]
 		fn insert_collision_groups(
 			physics_type: fn(HashSet<Blocker>) -> PhysicsType,
 			memberships: Group,

--- a/src/plugins/physics/src/components/body.rs
+++ b/src/plugins/physics/src/components/body.rs
@@ -34,7 +34,13 @@ impl Body {
 			CollidingEntities::default(),
 			ActiveEvents::COLLISION_EVENTS,
 			ActiveCollisionTypes::all(),
-			KinematicCharacterController { ..default() },
+			KinematicCharacterController {
+				filter_groups: Some(CollisionGroups {
+					memberships: AGENTS_GROUP,
+					filters: SKILLS_GROUP | TERRAIN_GROUP,
+				}),
+				..default()
+			},
 			CollisionGroups {
 				memberships: AGENTS_GROUP | MOUSE_HOVERABLE_GROUP,
 				filters: SKILLS_GROUP | TERRAIN_GROUP | RAY_GROUP,
@@ -48,7 +54,7 @@ impl Body {
 			RigidBody::Fixed,
 			CollisionGroups {
 				memberships: TERRAIN_GROUP,
-				filters: RAY_GROUP,
+				filters: SKILLS_GROUP | AGENTS_GROUP | RAY_GROUP,
 			},
 		)
 	}
@@ -247,7 +253,7 @@ mod tests {
 			);
 		}
 
-		#[test_case(PhysicsType::Terrain, TERRAIN_GROUP, RAY_GROUP; "terrain")]
+		#[test_case(PhysicsType::Terrain, TERRAIN_GROUP, SKILLS_GROUP|AGENTS_GROUP|RAY_GROUP; "terrain")]
 		#[test_case(PhysicsType::Agent, AGENTS_GROUP|MOUSE_HOVERABLE_GROUP, SKILLS_GROUP|TERRAIN_GROUP|RAY_GROUP; "agent")]
 		fn insert_collision_groups(
 			physics_type: fn(HashSet<Blocker>) -> PhysicsType,

--- a/src/plugins/physics/src/components/collider.rs
+++ b/src/plugins/physics/src/components/collider.rs
@@ -14,11 +14,12 @@ use common::{
 };
 use macros::asset_path;
 
-pub(crate) const GENERIC_COLLISION_GROUP: Group = Group::GROUP_1;
-pub(crate) const TERRAIN_GROUP: Group = Group::GROUP_2;
-pub(crate) const RAY_GROUP: Group = Group::GROUP_3;
-pub(crate) const MOUSE_HOVERABLE_GROUP: Group = Group::GROUP_4;
-pub(crate) const INTERACTIVE_GROUP: Group = Group::GROUP_5;
+pub(crate) const TERRAIN_GROUP: Group = Group::GROUP_1;
+pub(crate) const RAY_GROUP: Group = Group::GROUP_2;
+pub(crate) const MOUSE_HOVERABLE_GROUP: Group = Group::GROUP_3;
+pub(crate) const INTERACTIVE_GROUP: Group = Group::GROUP_4;
+pub(crate) const AGENTS_GROUP: Group = Group::GROUP_5;
+pub(crate) const SKILLS_GROUP: Group = Group::GROUP_6;
 
 #[derive(Component, Debug, PartialEq, Clone, Copy)]
 #[component(immutable)]

--- a/src/plugins/physics/src/observers/skill_prefab.rs
+++ b/src/plugins/physics/src/observers/skill_prefab.rs
@@ -1,6 +1,6 @@
 use crate::components::{
 	blockable::Blockable,
-	collider::{ColliderShape, GENERIC_COLLISION_GROUP, RAY_GROUP},
+	collider::{AGENTS_GROUP, ColliderShape, RAY_GROUP, SKILLS_GROUP},
 	collision_domains::Physical,
 	effects::Effects,
 	persistent_root::PersistentRoot,
@@ -40,8 +40,8 @@ pub(crate) trait SkillPrefab:
 		let (obj, cont_model, cont_collider, cont_effects) = skill.get_contact_prefab();
 		let (proj_model, proj_collider, proj_effects) = skill.get_projection_prefab();
 		let collision_group = CollisionGroups {
-			memberships: GENERIC_COLLISION_GROUP,
-			filters: GENERIC_COLLISION_GROUP | RAY_GROUP,
+			memberships: SKILLS_GROUP,
+			filters: SKILLS_GROUP | AGENTS_GROUP | RAY_GROUP,
 		};
 
 		entity.try_insert((
@@ -408,8 +408,8 @@ mod tests {
 					))),
 					Some(&Transform::from_xyz(1., 2., 3.)),
 					Some(&CollisionGroups {
-						memberships: GENERIC_COLLISION_GROUP,
-						filters: GENERIC_COLLISION_GROUP | RAY_GROUP,
+						memberships: SKILLS_GROUP,
+						filters: SKILLS_GROUP | AGENTS_GROUP | RAY_GROUP,
 					})
 				),
 				(
@@ -552,8 +552,8 @@ mod tests {
 					))),
 					Some(&Transform::from_xyz(1., 2., 3.)),
 					Some(&CollisionGroups {
-						memberships: GENERIC_COLLISION_GROUP,
-						filters: GENERIC_COLLISION_GROUP | RAY_GROUP,
+						memberships: SKILLS_GROUP,
+						filters: SKILLS_GROUP | AGENTS_GROUP | RAY_GROUP,
 					})
 				),
 				(

--- a/src/plugins/physics/src/systems/apply_pull.rs
+++ b/src/plugins/physics/src/systems/apply_pull.rs
@@ -1,4 +1,8 @@
-use crate::components::{affected::gravity_affected::GravityPull, immobilized::Immobilized};
+use crate::components::{
+	affected::gravity_affected::GravityPull,
+	collider::AGENTS_GROUP,
+	immobilized::Immobilized,
+};
 use bevy::{ecs::component::Mutable, prelude::*};
 use bevy_rapier3d::prelude::*;
 use common::{
@@ -27,11 +31,16 @@ pub(crate) trait ApplyPull:
 
 		for (entity, transform, mut gravity_affected, mut character) in agents {
 			if !gravity_affected.is_pulled() {
+				remove(&mut character, AGENTS_GROUP);
+
 				commands.try_apply_on(&entity, |mut e| {
 					e.try_remove::<Immobilized>();
 				});
+
 				continue;
 			}
+
+			add(&mut character, AGENTS_GROUP);
 
 			let get_pull_center = |pull: &GravityPull| {
 				let towards = commands.get(&pull.towards)?;
@@ -51,6 +60,22 @@ pub(crate) trait ApplyPull:
 			});
 		}
 	}
+}
+
+fn remove(character: &mut KinematicCharacterController, group: Group) {
+	let Some(filter) = &mut character.filter_groups else {
+		return;
+	};
+
+	filter.filters &= !group;
+}
+
+fn add(character: &mut KinematicCharacterController, group: Group) {
+	let Some(filter) = &mut character.filter_groups else {
+		return;
+	};
+
+	filter.filters |= group;
 }
 
 pub(crate) trait PullAbleByGravity {
@@ -93,6 +118,7 @@ fn predict(direction: Vec3, pull_strength: f32, delta_secs: f32) -> Predict {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate::components::collider::TERRAIN_GROUP;
 	use bevy::{
 		app::App,
 		ecs::system::{RunSystemError, RunSystemOnce},
@@ -269,6 +295,48 @@ mod tests {
 	}
 
 	#[test]
+	fn add_agents_filter() -> Result<(), RunSystemError> {
+		let mut app = setup();
+		let towards = PersistentEntity::default();
+		app.world_mut().spawn((
+			towards,
+			GlobalTransform::from(Transform::from_translation(Vec3::new(0., 0., 3.))),
+		));
+		let agent = app
+			.world_mut()
+			.spawn((
+				Transform::from_xyz(1., 0., 0.),
+				KinematicCharacterController {
+					filter_groups: Some(CollisionGroups {
+						memberships: AGENTS_GROUP,
+						filters: TERRAIN_GROUP,
+					}),
+					..default()
+				},
+				_GravityTarget::from([GravityPull {
+					strength: UnitsPerSecond::from(2.),
+					towards,
+				}]),
+			))
+			.id();
+
+		app.world_mut()
+			.run_system_once_with(_GravityTarget::apply_pull, Duration::from_millis(100))?;
+
+		let agent = app.world().entity(agent);
+		assert_eq!(
+			Some(CollisionGroups {
+				memberships: AGENTS_GROUP,
+				filters: TERRAIN_GROUP | AGENTS_GROUP,
+			}),
+			agent
+				.get::<KinematicCharacterController>()
+				.and_then(|c| c.filter_groups),
+		);
+		Ok(())
+	}
+
+	#[test]
 	fn do_not_add_forced_movement_if_pulls_array_empty() -> Result<(), RunSystemError> {
 		let mut app = setup();
 		let agent = app
@@ -356,6 +424,41 @@ mod tests {
 
 		let agent = app.world().entity(agent);
 		assert_eq!(None, agent.get::<Immobilized>());
+		Ok(())
+	}
+
+	#[test]
+	fn remove_agents_filter_if_pulls_empty() -> Result<(), RunSystemError> {
+		let mut app = setup();
+		let agent = app
+			.world_mut()
+			.spawn((
+				Transform::from_xyz(1., 0., 0.),
+				KinematicCharacterController {
+					filter_groups: Some(CollisionGroups {
+						memberships: AGENTS_GROUP,
+						filters: TERRAIN_GROUP | AGENTS_GROUP,
+					}),
+					..default()
+				},
+				Immobilized,
+				_GravityTarget::from([]),
+			))
+			.id();
+
+		app.world_mut()
+			.run_system_once_with(_GravityTarget::apply_pull, Duration::from_secs(1))?;
+
+		let agent = app.world().entity(agent);
+		assert_eq!(
+			Some(CollisionGroups {
+				memberships: AGENTS_GROUP,
+				filters: TERRAIN_GROUP,
+			}),
+			agent
+				.get::<KinematicCharacterController>()
+				.and_then(|c| c.filter_groups)
+		);
 		Ok(())
 	}
 

--- a/src/plugins/physics/src/systems/blockable/apply_beam_blocks.rs
+++ b/src/plugins/physics/src/systems/blockable/apply_beam_blocks.rs
@@ -4,7 +4,14 @@ use crate::{
 		RayFilter,
 		blockable::Blockable,
 		blocker_types::BlockerTypes,
-		collider::{ChildColliderOf, ColliderShape, GENERIC_COLLISION_GROUP, RAY_GROUP},
+		collider::{
+			AGENTS_GROUP,
+			ChildColliderOf,
+			ColliderShape,
+			RAY_GROUP,
+			SKILLS_GROUP,
+			TERRAIN_GROUP,
+		},
 		collision_domains::Physical,
 		skill_transform::SkillTransforms,
 	},
@@ -141,7 +148,7 @@ impl Blockable {
 			filter: RayFilter {
 				groups: Some(CollisionGroups {
 					memberships: RAY_GROUP,
-					filters: GENERIC_COLLISION_GROUP,
+					filters: TERRAIN_GROUP | AGENTS_GROUP | SKILLS_GROUP,
 				}),
 				..default()
 			},
@@ -303,7 +310,7 @@ mod tests {
 						filter: RayFilter {
 							groups: Some(CollisionGroups {
 								memberships: RAY_GROUP,
-								filters: GENERIC_COLLISION_GROUP,
+								filters: TERRAIN_GROUP | AGENTS_GROUP | SKILLS_GROUP,
 							}),
 							..default()
 						},

--- a/src/plugins/physics/src/systems/prevent_tunneling.rs
+++ b/src/plugins/physics/src/systems/prevent_tunneling.rs
@@ -2,7 +2,7 @@ use crate::{
 	components::{
 		RayCasterArgs,
 		RayFilter,
-		collider::{Colliders, GENERIC_COLLISION_GROUP, RAY_GROUP},
+		collider::{AGENTS_GROUP, Colliders, RAY_GROUP, TERRAIN_GROUP},
 		collision_domains::Physical,
 		prevent_tunneling::PreventTunneling,
 	},
@@ -95,7 +95,7 @@ where
 				exclude_rigid_body: Some(entity),
 				groups: Some(CollisionGroups {
 					memberships: RAY_GROUP,
-					filters: GENERIC_COLLISION_GROUP,
+					filters: TERRAIN_GROUP | AGENTS_GROUP,
 				}),
 				..default()
 			},
@@ -379,7 +379,7 @@ mod tests {
 									exclude_rigid_body: Some(entity),
 									groups: Some(CollisionGroups {
 										memberships: RAY_GROUP,
-										filters: GENERIC_COLLISION_GROUP,
+										filters: TERRAIN_GROUP | AGENTS_GROUP,
 									}),
 									..default()
 								},


### PR DESCRIPTION
- cleaner definition of collision groups
- exclude agents from `KinematicCharacterController` obstacle resolution
- in gravity wells characters collide with each other to prevent them from stacking up in one spot

This prevents agents pushing each other in weird ways in most scenarios.