### PR TITLE
Animation update optimizations

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -65,8 +65,7 @@ fn prepare_game(app: &mut App) -> Result<(), ZyheedaAppError> {
 	#[cfg(not(feature = "debug-utils"))]
 	let graphics = GraphicsPlugin::from_plugins(&loading, &savegame, &physics);
 
-	let loadout =
-		LoadoutPlugin::from_plugins(&savegame, &animations, &physics, &loading, &movement);
+	let loadout = LoadoutPlugin::from_plugins(&savegame, &physics, &loading, &movement);
 	let interactive =
 		InteractivePlugin::from_plugin(&loading, &physics, &map_generation, &animations);
 	let agents = AgentsPlugin::from_plugins(

--- a/src/plugins/animations/src/systems/play_animation_clip.rs
+++ b/src/plugins/animations/src/systems/play_animation_clip.rs
@@ -39,7 +39,7 @@ where
 				&AnimationLookup,
 				&AnimationGraphHandle,
 			),
-			Changed<AnimationDispatch>,
+			Or<(Changed<AnimationDispatch>, Changed<AnimationPlayers>)>,
 		>,
 		graphs: ResMut<Assets<AnimationGraph>>,
 	) where
@@ -61,7 +61,7 @@ fn play_animation_clip<TAnimationPlayer, TDispatch, TGraph, TClips>(
 			&AnimationLookup<TClips>,
 			&TGraph::TComponent,
 		),
-		Changed<TDispatch>,
+		Or<(Changed<TDispatch>, Changed<AnimationPlayers>)>,
 	>,
 	mut graphs: ResMut<Assets<TGraph>>,
 ) where
@@ -881,6 +881,57 @@ mod tests {
 		app.world_mut()
 			.entity_mut(agent)
 			.get_mut::<_AnimationDispatch>()
+			.unwrap()
+			.deref_mut();
+		app.update();
+
+		fn assert_repeat_twice(mock: &mut Mock_AnimationPlayer) {
+			mock.expect_is_playing().return_const(false);
+			mock.expect_update_animation()
+				.with(eq(AnimationNodeIndex::new(1)), eq(SetTo::Repeat))
+				.times(2)
+				.return_const(());
+		}
+	}
+
+	#[test]
+	fn play_animation_again_after_players_mutably_dereferenced() {
+		let handle = new_handle();
+		let lookup = AnimationLookup {
+			animations: HashMap::from([(
+				AnimationKey::Walk,
+				Animation {
+					clips: _Animations::from_indices([1]),
+					play_mode: PlayMode::Repeat,
+					..default()
+				},
+			)]),
+			..default()
+		};
+		let mut app = setup!(&lookup, &handle);
+		let agent = app
+			.world_mut()
+			.spawn((
+				_AnimationDispatch::new().with_mock(|mock: &mut Mock_AnimationDispatch| {
+					mock.expect_youngest_to_oldest_active_animations()
+						.with(eq(AnimationPriority::High))
+						.return_const(leak_iterator(vec![AnimationKey::Walk]));
+					mock.expect_youngest_to_oldest_active_animations::<AnimationPriority>()
+						.return_const(leak_iterator(vec![]));
+				}),
+				lookup,
+				_GraphComponent(handle),
+			))
+			.id();
+		app.world_mut().spawn((
+			_AnimationPlayer::new().with_mock(assert_repeat_twice),
+			AnimationPlayerOf(agent),
+		));
+
+		app.update();
+		app.world_mut()
+			.entity_mut(agent)
+			.get_mut::<AnimationPlayers>()
 			.unwrap()
 			.deref_mut();
 		app.update();

--- a/src/plugins/loadout/src/components/queue.rs
+++ b/src/plugins/loadout/src/components/queue.rs
@@ -32,6 +32,7 @@ pub struct Queue {
 	queue: VecDeque<QueuedSkill>,
 	active: Option<SkillElapsed<Duration>>,
 	state: State,
+	changed: bool,
 }
 
 impl Queue {
@@ -42,6 +43,22 @@ impl Queue {
 			State::Changed { len_before_change } => *len_before_change,
 		}
 	}
+
+	pub(crate) fn changed_this_frame(&self) -> bool {
+		self.changed
+	}
+
+	#[cfg(test)]
+	pub(crate) fn changed(mut self) -> Self {
+		self.changed = true;
+		self
+	}
+
+	#[cfg(test)]
+	pub(crate) fn with_skills<const N: usize>(mut self, skills: [QueuedSkill; N]) -> Self {
+		self.queue = VecDeque::from(skills);
+		self
+	}
 }
 
 impl Default for Queue {
@@ -50,20 +67,7 @@ impl Default for Queue {
 			queue: VecDeque::from([]),
 			active: None,
 			state: State::Flushed,
-		}
-	}
-}
-
-#[cfg(test)]
-impl<T> From<T> for Queue
-where
-	T: IntoIterator<Item = QueuedSkill>,
-{
-	fn from(skills: T) -> Self {
-		Self {
-			queue: VecDeque::from_iter(skills),
-			active: None,
-			state: State::Flushed,
+			changed: false,
 		}
 	}
 }
@@ -92,13 +96,17 @@ impl Enqueue<(Skill, SlotKey)> for Queue {
 
 impl Flush for Queue {
 	fn flush(&mut self) {
+		self.changed = match self.state {
+			State::Flushed => false,
+			State::Changed { .. } => true,
+		};
 		self.state = State::Flushed;
 
 		if self.active.is_some() {
 			return;
 		}
 
-		self.queue.pop_front();
+		self.changed |= self.queue.pop_front().is_some();
 	}
 }
 
@@ -208,7 +216,7 @@ mod test_queue_collection {
 
 	#[test]
 	fn enqueue_one_skill() {
-		let mut queue = Queue::from([]);
+		let mut queue = Queue::default();
 		queue.enqueue((
 			Skill {
 				token: Token::from("my skill"),
@@ -232,7 +240,7 @@ mod test_queue_collection {
 
 	#[test]
 	fn enqueue_two_skills() {
-		let mut queue = Queue::from([]);
+		let mut queue = Queue::default();
 		queue.enqueue((
 			Skill {
 				token: Token::from("skill a"),
@@ -272,8 +280,23 @@ mod test_queue_collection {
 	}
 
 	#[test]
+	fn flush_with_no_skill() {
+		let mut queue = Queue::default();
+
+		queue.flush();
+
+		assert_eq!(
+			Queue {
+				changed: false,
+				..default()
+			},
+			queue
+		);
+	}
+
+	#[test]
 	fn flush_with_one_skill() {
-		let mut queue = Queue::from([QueuedSkill {
+		let mut queue = Queue::default().with_skills([QueuedSkill {
 			key: SlotKey(11),
 			skill: Skill {
 				token: Token::from("my skill"),
@@ -284,12 +307,18 @@ mod test_queue_collection {
 
 		queue.flush();
 
-		assert_eq!(Queue::from([]), queue);
+		assert_eq!(
+			Queue {
+				changed: true,
+				..default()
+			},
+			queue
+		);
 	}
 
 	#[test]
 	fn flush_with_two_skill() {
-		let mut queue = Queue::from([
+		let mut queue = Queue::default().with_skills([
 			QueuedSkill {
 				key: SlotKey(42),
 				skill: Skill {
@@ -310,23 +339,19 @@ mod test_queue_collection {
 
 		queue.flush();
 
-		let queue_after_1_flush = Queue {
-			queue: queue.queue.clone(),
-			active: queue.active,
-			state: queue.state.clone(),
-		};
+		let queue_after_1_flush = queue.clone();
 
 		queue.flush();
 
-		let queue_after_2_flushes = Queue {
-			queue: queue.queue.clone(),
-			active: queue.active,
-			state: queue.state.clone(),
-		};
+		let queue_after_2_flushes = queue.clone();
 
 		assert_eq!(
 			(
-				Queue::from([QueuedSkill {
+				Queue {
+					changed: true,
+					..default()
+				}
+				.with_skills([QueuedSkill {
 					key: SlotKey(11),
 					skill: Skill {
 						token: Token::from("skill b"),
@@ -334,15 +359,83 @@ mod test_queue_collection {
 					},
 					..default()
 				}]),
-				Queue::from([])
+				Queue {
+					changed: true,
+					..default()
+				}
 			),
 			(queue_after_1_flush, queue_after_2_flushes)
 		);
 	}
 
 	#[test]
+	fn flush_with_added_to_active_skill() {
+		let mut queue = Queue {
+			active: Some(SkillElapsed::default()),
+			..default()
+		};
+
+		queue.enqueue((Skill::default(), SlotKey::default()));
+		queue.flush();
+
+		assert_eq!(
+			Queue {
+				active: Some(SkillElapsed::default()),
+				changed: true,
+				..default()
+			}
+			.with_skills([QueuedSkill {
+				skill: Skill::default(),
+				..default()
+			}]),
+			queue
+		);
+	}
+
+	#[test]
+	fn flush_empty_changed() {
+		// Only sound when loading an empty queue from a save state
+
+		let mut queue = Queue {
+			state: State::Changed {
+				len_before_change: 11,
+			},
+			..default()
+		};
+
+		queue.flush();
+
+		assert_eq!(
+			Queue {
+				changed: true,
+				..default()
+			},
+			queue
+		);
+	}
+
+	#[test]
+	fn flush_with_only_active_skill() {
+		let mut queue = Queue {
+			active: Some(SkillElapsed::default()),
+			..default()
+		};
+
+		queue.flush();
+
+		assert_eq!(
+			Queue {
+				active: Some(SkillElapsed::default()),
+				changed: false,
+				..default()
+			},
+			queue
+		);
+	}
+
+	#[test]
 	fn iter() {
-		let queue = Queue::from([
+		let queue = Queue::default().with_skills([
 			QueuedSkill {
 				key: SlotKey(42),
 				skill: Skill {
@@ -386,7 +479,7 @@ mod test_queue_collection {
 
 	#[test]
 	fn iter_recent_mut() {
-		let mut queue = Queue::from([]);
+		let mut queue = Queue::default();
 		queue.enqueue((
 			Skill {
 				token: Token::from("a"),
@@ -434,7 +527,7 @@ mod test_queue_collection {
 
 	#[test]
 	fn iter_recent_mut_only_new() {
-		let mut queue = Queue::from([QueuedSkill {
+		let mut queue = Queue::default().with_skills([QueuedSkill {
 			key: SlotKey(11),
 			skill: Skill {
 				token: Token::from("a"),
@@ -490,7 +583,7 @@ mod test_queue_collection {
 
 	#[test]
 	fn iter_recent_mut_empty_after_flush() {
-		let mut queue = Queue::from([QueuedSkill {
+		let mut queue = Queue::default().with_skills([QueuedSkill {
 			key: SlotKey(11),
 			skill: Skill {
 				token: Token::from("a"),
@@ -528,7 +621,7 @@ mod test_queue_collection {
 
 	#[test]
 	fn iter_recent_mut_empty_after_flush_with_active_duration() {
-		let mut queue = Queue::from([QueuedSkill {
+		let mut queue = Queue::default().with_skills([QueuedSkill {
 			key: SlotKey(11),
 			skill: Skill {
 				token: Token::from("a"),
@@ -585,7 +678,7 @@ mod test_queue_collection {
 				skill_mode: SkillMode::Release,
 			},
 		];
-		let mut queue = Queue::from(skills.clone());
+		let mut queue = Queue::default().with_skills(skills.clone());
 
 		assert_eq!(
 			vec![&skills[0]],

--- a/src/plugins/loadout/src/components/queue/dto.rs
+++ b/src/plugins/loadout/src/components/queue/dto.rs
@@ -26,6 +26,7 @@ impl From<Queue> for QueueDto {
 			queue,
 			active: elapsed,
 			state,
+			..
 		}: Queue,
 	) -> Self {
 		Self {
@@ -66,6 +67,7 @@ impl TryLoadFrom<QueueDto> for Queue {
 				released: released.map(Duration::from),
 			}),
 			state,
+			changed: true,
 		})
 	}
 }

--- a/src/plugins/loadout/src/lib.rs
+++ b/src/plugins/loadout/src/lib.rs
@@ -23,7 +23,7 @@ use crate::{
 		},
 		loadout_activity::{LoadoutActivityReader, LoadoutActivityWriter},
 	},
-	systems::enqueue::EnqueueSystem,
+	systems::{enqueue::EnqueueSystem, flush::FlushSystem},
 };
 use bevy::prelude::*;
 use common::{
@@ -55,7 +55,6 @@ use skills::{Skill, dto::SkillDto};
 use std::marker::PhantomData;
 use systems::{
 	combos::queue_update::ComboQueueUpdate,
-	flush::flush,
 	flush_skill_combos::flush_skill_combos,
 	schedule_active_skill::schedule_active_skill,
 };
@@ -116,7 +115,7 @@ where
 				flush_skill_combos::<Combos, CombosTimeOut, Virtual, Queue>,
 				schedule_active_skill::<Queue, TMovement::TFaceSystemParam, ActiveSkill, Virtual>,
 				ActiveSkill::<SkillBehaviorConfig>::execute::<TPhysics::TSkillSpawnerMut>,
-				flush::<Queue>,
+				Queue::flush_system,
 			)
 				.chain()
 				.after_plugin(TMovement::SYSTEMS)

--- a/src/plugins/loadout/src/lib.rs
+++ b/src/plugins/loadout/src/lib.rs
@@ -30,7 +30,6 @@ use common::{
 	states::game_state::{GameState, LoadingGame},
 	traits::{
 		after_plugin::AfterPlugin,
-		handles_animations::HandlesAnimations,
 		handles_custom_assets::{HandlesCustomAssets, HandlesCustomFolderAssets},
 		handles_load_tracking::HandlesLoadTracking,
 		handles_loadout::HandlesLoadout,
@@ -63,23 +62,16 @@ use systems::{
 
 pub struct LoadoutPlugin<TDependencies>(PhantomData<TDependencies>);
 
-impl<TSaveGame, TAnimations, TPhysics, TLoading, TMovement>
-	LoadoutPlugin<(TSaveGame, TAnimations, TPhysics, TLoading, TMovement)>
+impl<TSaveGame, TPhysics, TLoading, TMovement>
+	LoadoutPlugin<(TSaveGame, TPhysics, TLoading, TMovement)>
 where
 	TSaveGame: ThreadSafe + HandlesSaving,
-	TAnimations: ThreadSafe + HandlesAnimations,
 	TPhysics: ThreadSafe + HandlesAllPhysicalEffects + HandlesSkillPhysics + HandlesRaycast,
 	TLoading: ThreadSafe + HandlesCustomAssets + HandlesCustomFolderAssets + HandlesLoadTracking,
 	TMovement: ThreadSafe + HandlesOrientation + SystemSetDefinition,
 {
 	#[allow(clippy::too_many_arguments)]
-	pub fn from_plugins(
-		_: &TSaveGame,
-		_: &TAnimations,
-		_: &TPhysics,
-		_: &TLoading,
-		_: &TMovement,
-	) -> Self {
+	pub fn from_plugins(_: &TSaveGame, _: &TPhysics, _: &TLoading, _: &TMovement) -> Self {
 		Self(PhantomData)
 	}
 
@@ -133,12 +125,11 @@ where
 	}
 }
 
-impl<TSaveGame, TAnimations, TPhysics, TLoading, TMovement> Plugin
-	for LoadoutPlugin<(TSaveGame, TAnimations, TPhysics, TLoading, TMovement)>
+impl<TSaveGame, TPhysics, TLoading, TMovement> Plugin
+	for LoadoutPlugin<(TSaveGame, TPhysics, TLoading, TMovement)>
 where
 	TSaveGame: ThreadSafe + HandlesSaving,
 	TPhysics: ThreadSafe + HandlesAllPhysicalEffects + HandlesSkillPhysics + HandlesRaycast,
-	TAnimations: ThreadSafe + HandlesAnimations,
 	TLoading: ThreadSafe + HandlesCustomAssets + HandlesCustomFolderAssets + HandlesLoadTracking,
 	TMovement: ThreadSafe + HandlesOrientation + SystemSetDefinition,
 {

--- a/src/plugins/loadout/src/system_parameters/loadout/read/skills.rs
+++ b/src/plugins/loadout/src/system_parameters/loadout/read/skills.rs
@@ -281,7 +281,7 @@ mod tests {
 					Inventory::default(),
 					Slots::from([(SlotKey(11), Some(item_handle))]),
 					Combos::default(),
-					Queue::from([
+					Queue::default().with_skills([
 						QueuedSkill {
 							key: SlotKey(42),
 							skill: Skill { ..default() },
@@ -337,7 +337,7 @@ mod tests {
 					Inventory::default(),
 					Slots::from([(SlotKey(11), Some(item_handle))]),
 					Combos::default(),
-					Queue::from([QueuedSkill {
+					Queue::default().with_skills([QueuedSkill {
 						key: SlotKey(11),
 						skill: Skill {
 							token: Token::from("my active skill"),
@@ -386,7 +386,7 @@ mod tests {
 					Inventory::default(),
 					Slots::from([(SlotKey(11), Some(item_handle))]),
 					Combos::default(),
-					Queue::from([
+					Queue::default().with_skills([
 						QueuedSkill {
 							key: SlotKey(11),
 							skill: Skill {

--- a/src/plugins/loadout/src/system_parameters/loadout_activity.rs
+++ b/src/plugins/loadout/src/system_parameters/loadout_activity.rs
@@ -11,8 +11,7 @@ use zyheeda_core::prelude::*;
 
 #[derive(SystemParam)]
 pub struct LoadoutActivityReader<'w, 's> {
-	#[allow(clippy::type_complexity)]
-	loadout: Query<'w, 's, (Ref<'static, Queue>, Ref<'static, HeldSlots>)>,
+	loadout: Query<'w, 's, (&'static Queue, &'static HeldSlots)>,
 }
 
 impl TryGetContext<Skills> for LoadoutActivityReader<'static, 'static> {
@@ -29,13 +28,13 @@ impl TryGetContext<Skills> for LoadoutActivityReader<'static, 'static> {
 }
 
 pub struct LoadoutActivityReadContext<'a> {
-	queue: Ref<'a, Queue>,
-	held_slots: Ref<'a, HeldSlots>,
+	queue: &'a Queue,
+	held_slots: &'a HeldSlots,
 }
 
 impl ContextChanged for LoadoutActivityReadContext<'_> {
 	fn context_changed(&self) -> bool {
-		any!(is_changed(self.queue, self.held_slots))
+		any!(changed_this_frame(self.queue, self.held_slots))
 	}
 }
 
@@ -59,4 +58,79 @@ impl TryGetContextMut<Skills> for LoadoutActivityWriter<'static, 'static> {
 
 pub struct LoadoutActivityWriteContext<'a> {
 	held_slots: Mut<'a, HeldSlots>,
+}
+
+#[cfg(test)]
+mod tests {
+	#![allow(clippy::unwrap_used)]
+	use super::*;
+	use bevy::ecs::system::{RunSystemError, RunSystemOnce};
+	use common::tools::action_key::slot::SlotKey;
+	use testing::SingleThreadedApp;
+
+	fn setup() -> App {
+		App::new().single_threaded(Update)
+	}
+
+	#[test]
+	fn ctx_not_changed() -> Result<(), RunSystemError> {
+		let mut app = setup();
+		let entity = app
+			.world_mut()
+			.spawn((Queue::default(), HeldSlots::default()))
+			.id();
+
+		let changed = app
+			.world_mut()
+			.run_system_once(move |r: LoadoutActivityReader| {
+				let ctx = LoadoutActivityReader::try_get_context(&r, Skills { entity }).unwrap();
+				ctx.context_changed()
+			})?;
+
+		assert!(!changed);
+		Ok(())
+	}
+
+	#[test]
+	fn ctx_changed_when_queue_changed() -> Result<(), RunSystemError> {
+		let mut app = setup();
+		let entity = app
+			.world_mut()
+			.spawn((Queue::default().changed(), HeldSlots::default()))
+			.id();
+
+		let changed = app
+			.world_mut()
+			.run_system_once(move |r: LoadoutActivityReader| {
+				let ctx = LoadoutActivityReader::try_get_context(&r, Skills { entity }).unwrap();
+				ctx.context_changed()
+			})?;
+
+		assert!(changed);
+		Ok(())
+	}
+
+	#[test]
+	fn ctx_changed_when_held_slots_changed() -> Result<(), RunSystemError> {
+		let mut app = setup();
+		let entity = app
+			.world_mut()
+			.spawn((
+				Queue::default(),
+				HeldSlots::default()
+					.with_previous([SlotKey(11)])
+					.with_current([SlotKey(11), SlotKey(22)]),
+			))
+			.id();
+
+		let changed = app
+			.world_mut()
+			.run_system_once(move |r: LoadoutActivityReader| {
+				let ctx = LoadoutActivityReader::try_get_context(&r, Skills { entity }).unwrap();
+				ctx.context_changed()
+			})?;
+
+		assert!(changed);
+		Ok(())
+	}
 }

--- a/src/plugins/loadout/src/system_parameters/loadout_activity/read/active_skills.rs
+++ b/src/plugins/loadout/src/system_parameters/loadout_activity/read/active_skills.rs
@@ -12,7 +12,7 @@ impl ActiveSkills for LoadoutActivityReadContext<'_> {
 		Self: 'a;
 
 	fn active_skills(&self) -> Self::TIter<'_> {
-		let queue = Some(self.queue.as_ref().iterate());
+		let queue = Some(self.queue.iterate());
 
 		ActiveSkillsIter { queue }
 	}
@@ -68,10 +68,7 @@ mod tests {
 		let mut app = setup();
 		let entity = app
 			.world_mut()
-			.spawn(Queue::from([QueuedSkill::new(
-				Skill::default(),
-				SlotKey(42),
-			)]))
+			.spawn(Queue::default().with_skills([QueuedSkill::new(Skill::default(), SlotKey(42))]))
 			.id();
 
 		let active_skills = app
@@ -96,7 +93,7 @@ mod tests {
 		let mut app = setup();
 		let entity = app
 			.world_mut()
-			.spawn(Queue::from([
+			.spawn(Queue::default().with_skills([
 				QueuedSkill::new(Skill::default(), SlotKey(42)),
 				QueuedSkill::new(Skill::default(), SlotKey(11)),
 			]))
@@ -124,7 +121,7 @@ mod tests {
 		let mut app = setup();
 		let entity = app
 			.world_mut()
-			.spawn(Queue::from([QueuedSkill::new(
+			.spawn(Queue::default().with_skills([QueuedSkill::new(
 				Skill {
 					animation: Some(SkillAnimation::Aim),
 					..default()

--- a/src/plugins/loadout/src/system_parameters/loadout_activity/read/held_skills.rs
+++ b/src/plugins/loadout/src/system_parameters/loadout_activity/read/held_skills.rs
@@ -4,7 +4,7 @@ use std::collections::HashSet;
 
 impl HeldSkills for LoadoutActivityReadContext<'_> {
 	fn held_skills(&self) -> &HashSet<SlotKey> {
-		&self.held_slots
+		self.held_slots
 	}
 }
 

--- a/src/plugins/loadout/src/systems/enqueue/held_slots.rs
+++ b/src/plugins/loadout/src/systems/enqueue/held_slots.rs
@@ -25,6 +25,22 @@ impl HeldSlots {
 			current: self.current.iter(),
 		}
 	}
+
+	#[cfg(test)]
+	pub(crate) fn with_current<const N: usize>(mut self, slots: [SlotKey; N]) -> Self {
+		self.current = HashSet::from(slots);
+		self
+	}
+
+	#[cfg(test)]
+	pub(crate) fn with_previous<const N: usize>(mut self, slots: [SlotKey; N]) -> Self {
+		self.previous = HashSet::from(slots);
+		self
+	}
+
+	pub(crate) fn changed_this_frame(&self) -> bool {
+		self.iter_new().next().is_some()
+	}
 }
 
 impl<const N: usize> From<[SlotKey; N]> for HeldSlots {

--- a/src/plugins/loadout/src/systems/flush.rs
+++ b/src/plugins/loadout/src/systems/flush.rs
@@ -4,12 +4,13 @@ use bevy::{
 	prelude::Query,
 };
 
-pub(crate) fn flush<TFlush>(mut agents: Query<&mut TFlush>)
-where
-	TFlush: Flush + Component<Mutability = Mutable>,
-{
-	for mut queue in &mut agents {
-		queue.flush();
+impl<T> FlushSystem for T where T: Flush + Component<Mutability = Mutable> {}
+
+pub(crate) trait FlushSystem: Flush + Component<Mutability = Mutable> + Sized {
+	fn flush_system(mut agents: Query<&mut Self>) {
+		for mut queue in &mut agents {
+			queue.flush();
+		}
 	}
 }
 
@@ -35,7 +36,7 @@ mod tests {
 
 	fn setup() -> App {
 		let mut app = App::new().single_threaded(Update);
-		app.add_systems(Update, flush::<_Dequeue>);
+		app.add_systems(Update, _Dequeue::flush_system);
 
 		app
 	}

--- a/src/plugins/movement/src/system_param/movement_param.rs
+++ b/src/plugins/movement/src/system_param/movement_param.rs
@@ -5,14 +5,17 @@ mod stop_movement;
 mod toggle_speed;
 
 use crate::{
-	components::config::{Config, SpeedIndex},
+	components::{
+		config::{Config, SpeedIndex},
+		movement::Movement,
+	},
 	system_param::movement_param::context_changed::JustRemovedMovements,
 };
 use bevy::{ecs::system::SystemParam, prelude::*};
 use common::{
 	traits::{
 		accessors::get::{GetMut, TryGetContext, TryGetContextMut},
-		handles_movement::{ConfiguredMovement, Movement},
+		handles_movement::{ConfiguredMovement, Movement as MovementKey},
 	},
 	zyheeda_commands::{ZyheedaCommands, ZyheedaEntityCommands},
 };
@@ -27,7 +30,7 @@ where
 	just_removed_movements: Res<'w, JustRemovedMovements>,
 }
 
-impl<TMotion> TryGetContext<Movement> for MovementParam<'static, 'static, TMotion>
+impl<TMotion> TryGetContext<MovementKey> for MovementParam<'static, 'static, TMotion>
 where
 	TMotion: Component,
 {
@@ -35,7 +38,7 @@ where
 
 	fn try_get_context<'ctx>(
 		param: &'ctx MovementParam<TMotion>,
-		Movement { entity }: Movement,
+		MovementKey { entity }: MovementKey,
 	) -> Option<Self::TContext<'ctx>> {
 		let motion = match param.movements.get(entity) {
 			Ok(movement) => MotionState::Movement(movement),
@@ -62,6 +65,7 @@ where
 		's,
 		(
 			Option<&'static TMotion>,
+			Option<&'static Movement>,
 			&'static Config,
 			&'static mut SpeedIndex,
 		),
@@ -78,12 +82,13 @@ where
 		param: &'ctx mut MovementParamMut<TMotion>,
 		ConfiguredMovement { entity }: ConfiguredMovement,
 	) -> Option<Self::TContext<'ctx>> {
-		let (motion, config, current_speed) = param.motions.get_mut(entity).ok()?;
+		let (motion, movement, config, current_speed) = param.motions.get_mut(entity).ok()?;
 		let entity = param.commands.get_mut(&entity)?;
 
 		Some(MovementContextMut {
 			entity,
 			motion,
+			movement,
 			config,
 			current_speed,
 		})
@@ -113,6 +118,7 @@ where
 {
 	entity: ZyheedaEntityCommands<'ctx>,
 	motion: Option<&'ctx TMotion>,
+	movement: Option<&'ctx Movement>,
 	config: &'ctx Config,
 	current_speed: Mut<'ctx, SpeedIndex>,
 }

--- a/src/plugins/movement/src/system_param/movement_param/start_movement.rs
+++ b/src/plugins/movement/src/system_param/movement_param/start_movement.rs
@@ -2,6 +2,8 @@ use crate::{components::movement::Movement, system_param::movement_param::Moveme
 use bevy::ecs::component::Component;
 use common::traits::handles_movement::{MovementTarget, StartMovement};
 
+const ALLOWED_ANGLE: f32 = 1_f32.to_radians();
+
 impl<TMotion> StartMovement for MovementContextMut<'_, TMotion>
 where
 	TMotion: Component,
@@ -10,8 +12,22 @@ where
 	where
 		T: Into<MovementTarget>,
 	{
-		self.entity.try_insert(Movement::from(target));
+		let movement = Movement::from(target);
+
+		if directions_within_tolerance(self.movement, &movement) {
+			return;
+		}
+
+		self.entity.try_insert(movement);
 	}
+}
+
+fn directions_within_tolerance(l: Option<&Movement>, r: &Movement) -> bool {
+	let (Some(Movement::Direction(l)), Movement::Direction(r)) = (l, r) else {
+		return false;
+	};
+
+	l.angle_between(**r) <= ALLOWED_ANGLE
 }
 
 #[cfg(test)]
@@ -30,18 +46,22 @@ mod tests {
 		thread_safe::ThreadSafe,
 	};
 	use test_case::test_case;
-	use testing::SingleThreadedApp;
+	use testing::{IsChanged, SingleThreadedApp};
 
 	#[derive(Component)]
 	struct _Motion;
 
 	fn setup() -> App {
-		App::new().single_threaded(Update)
+		let mut app = App::new().single_threaded(Update);
+
+		app.add_systems(Update, IsChanged::<Movement>::detect);
+
+		app
 	}
 
-	#[test_case(Vec3::new(1.,2.,3.); "to point")]
+	#[test_case(Vec3::new(1., 2., 3.); "to point")]
 	#[test_case(Dir3::NEG_X; "towards direction")]
-	fn insert_path(
+	fn insert_movement(
 		target: impl Into<MovementTarget> + Copy + ThreadSafe,
 	) -> Result<(), RunSystemError> {
 		let mut app = setup();
@@ -57,6 +77,87 @@ mod tests {
 
 		assert_eq!(
 			Some(&Movement::from(target)),
+			app.world().entity(entity).get::<Movement>(),
+		);
+		Ok(())
+	}
+
+	#[test]
+	fn do_not_insert_movement_direction_if_already_present() -> Result<(), RunSystemError> {
+		let mut app = setup();
+		let entity = app
+			.world_mut()
+			.spawn((Config::default(), Movement::from(Dir3::NEG_X)))
+			.id();
+
+		app.update();
+		app.world_mut()
+			.run_system_once(move |mut p: MovementParamMut<_Motion>| {
+				let mut ctx =
+					MovementParamMut::try_get_context_mut(&mut p, ConfiguredMovement { entity })
+						.unwrap();
+				ctx.start(Dir3::NEG_X);
+			})?;
+		app.update();
+
+		assert_eq!(
+			Some(&IsChanged::FALSE),
+			app.world().entity(entity).get::<IsChanged<Movement>>(),
+		);
+		Ok(())
+	}
+
+	#[test]
+	fn do_not_insert_movement_direction_if_already_present_within_tolerance()
+	-> Result<(), RunSystemError> {
+		let mut app = setup();
+		let dir = Vec3::NEG_X.rotate_axis(Vec3::Y, ALLOWED_ANGLE);
+		let dir = Dir3::try_from(dir).unwrap();
+		let entity = app
+			.world_mut()
+			.spawn((Config::default(), Movement::from(dir)))
+			.id();
+
+		app.update();
+		app.world_mut()
+			.run_system_once(move |mut p: MovementParamMut<_Motion>| {
+				let mut ctx =
+					MovementParamMut::try_get_context_mut(&mut p, ConfiguredMovement { entity })
+						.unwrap();
+				ctx.start(Dir3::NEG_X);
+			})?;
+		app.update();
+
+		assert_eq!(
+			Some(&IsChanged::FALSE),
+			app.world().entity(entity).get::<IsChanged<Movement>>(),
+		);
+		Ok(())
+	}
+
+	#[test]
+	fn re_insert_movement_direction_if_already_present_but_outside_tolerance()
+	-> Result<(), RunSystemError> {
+		let mut app = setup();
+		let dir = Vec3::NEG_X.rotate_axis(Vec3::Y, ALLOWED_ANGLE * 1.1);
+		let dir = Dir3::try_from(dir).unwrap();
+		let entity = app
+			.world_mut()
+			.spawn((Config::default(), Movement::from(dir)))
+			.id();
+
+		app.update();
+		app.world_mut()
+			.run_system_once(move |mut p: MovementParamMut<_Motion>| {
+				let mut ctx =
+					MovementParamMut::try_get_context_mut(&mut p, ConfiguredMovement { entity })
+						.unwrap();
+				ctx.start(Dir3::NEG_X);
+			})?;
+		app.update();
+
+		assert_eq!(
+			Some(&Movement::from(Dir3::NEG_X)),
 			app.world().entity(entity).get::<Movement>(),
 		);
 		Ok(())

--- a/src/plugins/physics/src/components/target.rs
+++ b/src/plugins/physics/src/components/target.rs
@@ -1,10 +1,14 @@
 use bevy::prelude::*;
 use common::{
 	components::persistent_entity::PersistentEntity,
-	traits::handles_skill_physics::{Cursor, SkillTarget},
+	traits::{
+		handles_animations::DirForwardPitch,
+		handles_skill_physics::{Cursor, SkillTarget},
+	},
 };
 use macros::SavableComponent;
 use serde::{Deserialize, Serialize};
+use std::ops::Deref;
 
 #[derive(SavableComponent, Component, Debug, PartialEq, Default, Clone, Serialize, Deserialize)]
 #[savable_component(id = "skill target")]
@@ -19,5 +23,37 @@ impl From<PersistentEntity> for Target {
 impl From<Cursor> for Target {
 	fn from(cursor: Cursor) -> Self {
 		Self(Some(SkillTarget::Cursor(cursor)))
+	}
+}
+
+#[derive(Component, Debug, PartialEq, Default)]
+pub(crate) struct OldTargetPitch(pub(crate) Option<DirForwardPitch>);
+
+impl Deref for OldTargetPitch {
+	type Target = Option<DirForwardPitch>;
+
+	fn deref(&self) -> &Self::Target {
+		&self.0
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use testing::ApproxEqual;
+
+	impl ApproxEqual<f32> for OldTargetPitch {
+		fn approx_equal(&self, other: &Self, tolerance: &f32) -> bool {
+			match (self.0, other.0) {
+				(None, None) => true,
+				(Some(DirForwardPitch::Down(l)), Some(DirForwardPitch::Down(r))) => {
+					l.approx_equal(&r, tolerance)
+				}
+				(Some(DirForwardPitch::Up(l)), Some(DirForwardPitch::Up(r))) => {
+					l.approx_equal(&r, tolerance)
+				}
+				_ => false,
+			}
+		}
 	}
 }

--- a/src/plugins/physics/src/systems/update_target_pitch.rs
+++ b/src/plugins/physics/src/systems/update_target_pitch.rs
@@ -1,6 +1,6 @@
 use crate::components::{
 	offset::{AimOffset, CenterOffset, ComputeOffsetTranslation},
-	target::Target,
+	target::{OldTargetPitch, Target},
 };
 use bevy::{
 	ecs::system::{StaticSystemParam, SystemParam},
@@ -8,7 +8,7 @@ use bevy::{
 };
 use common::{
 	traits::{
-		accessors::get::{Get, TryGetContextMut},
+		accessors::get::{Get, TryApplyOn, TryGetContextMut},
 		handles_animations::{Animations, DirForwardPitch, ForwardPitch, GetForwardPitchMut},
 		handles_physics::{MouseHover, MouseHoversOver, Raycast},
 		handles_skill_physics::{Cursor, SkillTarget},
@@ -18,22 +18,25 @@ use common::{
 use std::f32::consts::FRAC_PI_2;
 
 impl Target {
+	#[allow(clippy::type_complexity)]
 	pub(crate) fn update_pitch<TRayCast, TAnimations>(
+		mut commands: ZyheedaCommands,
 		mut animations: StaticSystemParam<TAnimations>,
 		mut ray_caster: StaticSystemParam<TRayCast>,
-		targets: Query<(Entity, &Self, &GlobalTransform, Option<&AimOffset>)>,
 		transforms: Query<(&GlobalTransform, Option<&CenterOffset>)>,
-		commands: ZyheedaCommands,
+		targets: Query<(
+			Entity,
+			&Self,
+			&GlobalTransform,
+			Option<&AimOffset>,
+			Option<&OldTargetPitch>,
+		)>,
 	) where
 		for<'w, 's> TRayCast: SystemParam<Item<'w, 's>: Raycast<MouseHover>>,
 		for<'c> TAnimations:
 			SystemParam + TryGetContextMut<Animations, TContext<'c>: GetForwardPitchMut>,
 	{
-		for (entity, target, transform, offset) in targets {
-			let key = Animations { entity };
-			let Some(mut ctx) = TAnimations::try_get_context_mut(&mut animations, key) else {
-				continue;
-			};
+		for (entity, target, transform, offset, old_pitch) in targets {
 			let pitch = target.get_pitch(
 				entity,
 				transform,
@@ -43,7 +46,19 @@ impl Target {
 				&mut ray_caster,
 			);
 
+			if matches!(old_pitch, Some(old_pitch) if pitch == **old_pitch) {
+				continue;
+			}
+
+			let key = Animations { entity };
+			let Some(mut ctx) = TAnimations::try_get_context_mut(&mut animations, key) else {
+				continue;
+			};
+
 			*ctx.get_forward_pitch_mut() = pitch;
+			commands.try_apply_on(&entity, |mut e| {
+				e.try_insert(OldTargetPitch(pitch));
+			});
 		}
 	}
 
@@ -97,9 +112,11 @@ fn get_pitch(
 mod tests {
 	#![allow(clippy::unwrap_used)]
 	use super::*;
+	use crate::components::target::OldTargetPitch;
 	use common::{
 		CommonPlugin,
 		components::persistent_entity::PersistentEntity,
+		forward_pitch,
 		traits::{
 			handles_animations::{ForwardPitch, GetForwardPitch},
 			handles_skill_physics::{Cursor, SkillTarget},
@@ -588,5 +605,80 @@ mod tests {
 		}));
 
 		app.update();
+	}
+
+	#[test_case(0., None; "0 degrees")]
+	#[test_case(45., ForwardPitch::try_from(0.5).ok().map(DirForwardPitch::Up); "45 degrees up")]
+	#[test_case(-45., ForwardPitch::try_from(0.5).ok().map(DirForwardPitch::Down); "45 degrees down")]
+	#[test_case(90., DirForwardPitch::Up(ForwardPitch::MAX); "90 degrees up")]
+	#[test_case(-90., DirForwardPitch::Down(ForwardPitch::MAX); "90 degrees down")]
+	fn set_old_pitch(angle: f32, forward_pitch: impl Into<Option<DirForwardPitch>>) {
+		let mut app = setup();
+		let translation = Vec3::new(10., 2., 0.);
+		let offset = Quat::from_rotation_x(angle.to_radians()).mul_vec3(Vec3::new(0., 0., -30.));
+		let target_entity = PersistentEntity::default();
+		let entity = app
+			.world_mut()
+			.spawn((
+				Target(Some(SkillTarget::Entity(target_entity))),
+				GlobalTransform::from_translation(translation),
+				_Animations {
+					forward_pitch: None,
+				},
+			))
+			.id();
+
+		app.world_mut().spawn((
+			target_entity,
+			GlobalTransform::from_translation(translation + offset),
+		));
+
+		app.update();
+
+		assert_eq_approx!(
+			Some(&OldTargetPitch(forward_pitch.into())),
+			app.world().entity(entity).get::<OldTargetPitch>(),
+			1e-5,
+		);
+	}
+
+	#[test_case(0., None; "0 degrees")]
+	#[test_case(90., DirForwardPitch::Up(ForwardPitch::MAX); "90 degrees up")]
+	#[test_case(-90., DirForwardPitch::Down(ForwardPitch::MAX); "90 degrees down")]
+	fn do_nothing_if_old_pitch_is_current_pitch(
+		angle: f32,
+		forward_pitch: impl Into<Option<DirForwardPitch>>,
+	) {
+		let mut app = setup();
+		let forward_pitch = forward_pitch.into();
+		let translation = Vec3::new(10., 2., 0.);
+		let offset = Quat::from_rotation_x(angle.to_radians()).mul_vec3(Vec3::new(0., 0., -30.));
+		let target_entity = PersistentEntity::default();
+		let entity = app
+			.world_mut()
+			.spawn((
+				OldTargetPitch(forward_pitch),
+				Target(Some(SkillTarget::Entity(target_entity))),
+				GlobalTransform::from_translation(translation),
+				_Animations {
+					forward_pitch: Some(DirForwardPitch::Down(forward_pitch!(0.42))),
+				},
+			))
+			.id();
+
+		app.world_mut().spawn((
+			target_entity,
+			GlobalTransform::from_translation(translation + offset),
+		));
+
+		app.update();
+
+		assert_eq_approx!(
+			Some(&_Animations {
+				forward_pitch: Some(DirForwardPitch::Down(forward_pitch!(0.42))),
+			}),
+			app.world().entity(entity).get::<_Animations>(),
+			1e-5,
+		);
 	}
 }


### PR DESCRIPTION
Refine amount of times animations are dispatched:
- `Queue` and `HeldSlots` change detection improved so we only dispatch animations for actually new/ended skills
- restarting directional movement only when new direction differs by at least one degree with the old one
- dispatch animations again if animation players added

Other improvements:
- pitch update only happens when pitch actually changed
- removed animation dependency from loadout plugin