### PR TITLE
Disable sources for despawned persistant map objects

### DIFF
--- a/src/plugins/map_generation/src/lib.rs
+++ b/src/plugins/map_generation/src/lib.rs
@@ -92,7 +92,7 @@ where
 		TSavegame::register_savable_component::<GridAgent>(app);
 		TSavegame::register_savable_component::<Level<0>>(app);
 
-		TSavegame::on_before_save(app, Map::apply_map_persistence);
+		TSavegame::on_before_save(app, Map::apply_map_objects_persistence);
 
 		#[cfg(debug_assertions)]
 		crate::mesh_grid_graph::debug::draw(app);
@@ -101,6 +101,7 @@ where
 			.init_resource::<PrefabRegister<InteractiveType>>()
 			.add_systems(OnEnter(GameState::NewGame), Level::<0>::spawn)
 			.add_prefab_observer::<MeshCollider, TPhysics::TConfigMut>()
+			.add_observer(Map::apply_despawned_map_objects_persistence)
 			.add_observer(NavMesh::identify_by_prefix(Self::NAV_MESH_PREFIX))
 			.add_observer(MeshCollider::identify_by_prefix(Self::MESH_COLLIDER_PREFIX))
 			.add_observer(Spawner::<AgentType>::identify(Self::AGENT_SPAWNERS))

--- a/src/plugins/map_generation/src/observers.rs
+++ b/src/plugins/map_generation/src/observers.rs
@@ -1,3 +1,4 @@
+pub(crate) mod apply_despawned_map_objects_persistence;
 pub(crate) mod identify_by_prefix;
 pub(crate) mod identify_spawners;
 pub(crate) mod inactivate_disabled_spawners;

--- a/src/plugins/map_generation/src/observers/apply_despawned_map_objects_persistence.rs
+++ b/src/plugins/map_generation/src/observers/apply_despawned_map_objects_persistence.rs
@@ -1,0 +1,108 @@
+use crate::components::{
+	map::{Map, objects::MapObjectOf},
+	spawned_from::SpawnedFrom,
+};
+use bevy::prelude::*;
+use common::components::persistent_entity::PersistentEntity;
+
+impl Map {
+	pub(crate) fn apply_despawned_map_objects_persistence(
+		on_despawn: On<Despawn, SpawnedFrom>,
+		mut maps: Query<&mut Self>,
+		spawned: Query<(&SpawnedFrom, &MapObjectOf), With<PersistentEntity>>,
+	) {
+		let Ok((SpawnedFrom(source), MapObjectOf(map))) = spawned.get(on_despawn.entity) else {
+			return;
+		};
+
+		let Ok(mut map) = maps.get_mut(*map) else {
+			return;
+		};
+
+		map.disabled_object_sources.insert(source.clone());
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::components::map::{MapObjectSource, objects::MapObjectOf};
+	use common::components::persistent_entity::PersistentEntity;
+	use std::collections::HashSet;
+	use testing::SingleThreadedApp;
+
+	fn setup() -> App {
+		let mut app = App::new().single_threaded(Update);
+
+		app.add_observer(Map::apply_despawned_map_objects_persistence);
+
+		app
+	}
+
+	#[test]
+	fn set_persistent_map_agent_types() {
+		let mut app = setup();
+		let entity = app.world_mut().spawn(Map::default()).id();
+		let entities = [
+			app.world_mut()
+				.spawn((
+					PersistentEntity::default(),
+					SpawnedFrom(MapObjectSource(String::from("a"))),
+					MapObjectOf(entity),
+				))
+				.id(),
+			app.world_mut()
+				.spawn((
+					PersistentEntity::default(),
+					SpawnedFrom(MapObjectSource(String::from("b"))),
+					MapObjectOf(entity),
+				))
+				.id(),
+		];
+
+		for entity in entities {
+			app.world_mut().despawn(entity);
+		}
+
+		assert_eq!(
+			Some(&Map {
+				disabled_object_sources: HashSet::from([
+					MapObjectSource(String::from("a")),
+					MapObjectSource(String::from("b")),
+				]),
+			}),
+			app.world().entity(entity).get::<Map>(),
+		);
+	}
+
+	#[test]
+	fn do_not_set_persistent_map_agent_types_when_not_persistent() {
+		let mut app = setup();
+		let entity = app.world_mut().spawn(Map::default()).id();
+		let entities = [
+			app.world_mut()
+				.spawn((
+					SpawnedFrom(MapObjectSource(String::from("a"))),
+					MapObjectOf(entity),
+				))
+				.id(),
+			app.world_mut()
+				.spawn((
+					SpawnedFrom(MapObjectSource(String::from("b"))),
+					MapObjectOf(entity),
+				))
+				.id(),
+		];
+
+		for entity in entities {
+			app.world_mut().despawn(entity);
+		}
+
+		assert_eq!(
+			Some(&Map {
+				disabled_object_sources: HashSet::from([]),
+			}),
+			app.world().entity(entity).get::<Map>(),
+		);
+	}
+}

--- a/src/plugins/map_generation/src/systems.rs
+++ b/src/plugins/map_generation/src/systems.rs
@@ -1,4 +1,4 @@
-pub(crate) mod apply_map_persistence;
+pub(crate) mod apply_map_objects_persistence;
 pub(crate) mod link_agent_to_grid;
 pub(crate) mod link_map_object_with_map;
 pub(crate) mod link_persistent_map_object_with_map;

--- a/src/plugins/map_generation/src/systems/apply_map_objects_persistence.rs
+++ b/src/plugins/map_generation/src/systems/apply_map_objects_persistence.rs
@@ -13,7 +13,7 @@ use common::{
 };
 
 impl Map {
-	pub(crate) fn apply_map_persistence(
+	pub(crate) fn apply_map_objects_persistence(
 		mut commands: ZyheedaCommands,
 		maps: Query<(&mut Map, &MapObjects, &PersistentEntity)>,
 		spawned: Query<&SpawnedFrom, (With<PersistentEntity>, Added<SpawnedFrom>)>,
@@ -54,7 +54,7 @@ mod tests {
 
 		app.add_systems(
 			Update,
-			(Map::apply_map_persistence, IsChanged::<Map>::detect).chain(),
+			(Map::apply_map_objects_persistence, IsChanged::<Map>::detect).chain(),
 		);
 
 		app


### PR DESCRIPTION
This PR allows sources of persistent map objects to be registered in maps when the object is despawned before the first save.