### PR TITLE
Make door persistent across sessions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -67,7 +67,7 @@ fn prepare_game(app: &mut App) -> Result<(), ZyheedaAppError> {
 
 	let loadout = LoadoutPlugin::from_plugins(&savegame, &physics, &loading, &movement);
 	let interactive =
-		InteractivePlugin::from_plugin(&loading, &physics, &map_generation, &animations);
+		InteractivePlugin::from_plugin(&loading, &savegame, &physics, &map_generation, &animations);
 	let agents = AgentsPlugin::from_plugins(
 		&loading,
 		&input,

--- a/src/plugins/interactive/src/components/container.rs
+++ b/src/plugins/interactive/src/components/container.rs
@@ -1,4 +1,7 @@
+use crate::components::interactive::Interactive;
 use bevy::prelude::*;
+use common::traits::handles_map_generation::InteractiveType;
 
 #[derive(Component, Debug, PartialEq)]
+#[require(Interactive { interactive_type: InteractiveType::Container })]
 pub(crate) struct Container;

--- a/src/plugins/interactive/src/components/door.rs
+++ b/src/plugins/interactive/src/components/door.rs
@@ -1,16 +1,34 @@
-use crate::{assets::door_meta::DoorMeta, components::door_meta_handle::DoorMetaHandle};
+use crate::{
+	assets::door_meta::DoorMeta,
+	components::{door_meta_handle::DoorMetaHandle, interactive::Interactive},
+};
 use bevy::{ecs::system::StaticSystemParam, prelude::*};
 use common::{
-	components::model::{Model, SceneId, UseGltfLookup},
+	components::{
+		model::{Model, SceneId, UseGltfLookup},
+		persistent_entity::PersistentEntity,
+	},
 	errors::Unreachable,
 	systems::register_animations::AnimationsMarker,
-	traits::prefab::{Prefab, PrefabEntityCommands},
+	traits::{
+		handles_map_generation::InteractiveType,
+		prefab::{Prefab, PrefabEntityCommands},
+	},
 };
-use macros::asset_path;
+use macros::{SavableComponent, asset_path};
+use serde::{Deserialize, Serialize};
 
-#[derive(Component, Debug, PartialEq)]
+#[derive(Component, SavableComponent, Debug, PartialEq, Clone, Copy, Serialize, Deserialize)]
+#[savable_component(id = "door")]
 #[component(immutable)]
-#[require(DoorMetaHandle, Transform, ApplyDoorAnimations, ApplyDoorFrame)]
+#[require(
+	PersistentEntity,
+	Interactive { interactive_type: InteractiveType::Door },
+	DoorMetaHandle,
+	Transform,
+	ApplyDoorAnimations,
+	ApplyDoorFrame
+)]
 pub(crate) struct Door;
 
 impl Prefab<()> for Door {

--- a/src/plugins/interactive/src/components/interactive.rs
+++ b/src/plugins/interactive/src/components/interactive.rs
@@ -26,10 +26,7 @@ impl Interactive {
 		translation: Vec3,
 		interactive_type: InteractiveType,
 	) {
-		entity.try_insert((
-			Transform::from_translation(translation),
-			Self { interactive_type },
-		));
+		entity.try_insert(Transform::from_translation(translation));
 
 		match interactive_type {
 			InteractiveType::Door => entity.try_insert(Door),

--- a/src/plugins/interactive/src/lib.rs
+++ b/src/plugins/interactive/src/lib.rs
@@ -24,6 +24,7 @@ use common::{
 		handles_interactive::HandlesInteractive,
 		handles_map_generation::HandlesMapGeneration,
 		handles_physics::{HandlesInteractiveDetection, HandlesPhysicsConfig},
+		handles_saving::HandlesSaving,
 		prefab::AddPrefabObserver,
 		system_set_definition::SystemSetDefinition,
 		thread_safe::ThreadSafe,
@@ -33,29 +34,39 @@ use std::marker::PhantomData;
 
 pub struct InteractivePlugin<TDependencies>(PhantomData<TDependencies>);
 
-impl<TLoading, TPhysics, TMaps, TAnimations>
-	InteractivePlugin<(TLoading, TPhysics, TMaps, TAnimations)>
+impl<TLoading, TSavegame, TPhysics, TMaps, TAnimations>
+	InteractivePlugin<(TLoading, TSavegame, TPhysics, TMaps, TAnimations)>
 where
 	TLoading: ThreadSafe + HandlesCustomFolderAssets,
+	TSavegame: ThreadSafe + HandlesSaving,
 	TPhysics: ThreadSafe + HandlesPhysicsConfig + HandlesInteractiveDetection + SystemSetDefinition,
 	TMaps: ThreadSafe + HandlesMapGeneration,
 	TAnimations: ThreadSafe + HandlesAnimations,
 {
-	pub fn from_plugin(_: &TLoading, _: &TPhysics, _: &TMaps, _: &TAnimations) -> Self {
+	pub fn from_plugin(
+		_: &TLoading,
+		_: &TSavegame,
+		_: &TPhysics,
+		_: &TMaps,
+		_: &TAnimations,
+	) -> Self {
 		Self(PhantomData)
 	}
 }
 
-impl<TLoading, TPhysics, TMaps, TAnimations> Plugin
-	for InteractivePlugin<(TLoading, TPhysics, TMaps, TAnimations)>
+impl<TLoading, TSavegame, TPhysics, TMaps, TAnimations> Plugin
+	for InteractivePlugin<(TLoading, TSavegame, TPhysics, TMaps, TAnimations)>
 where
 	TLoading: ThreadSafe + HandlesCustomFolderAssets,
+	TSavegame: ThreadSafe + HandlesSaving,
 	TPhysics: ThreadSafe + HandlesPhysicsConfig + HandlesInteractiveDetection + SystemSetDefinition,
 	TMaps: ThreadSafe + HandlesMapGeneration,
 	TAnimations: ThreadSafe + HandlesAnimations,
 {
 	fn build(&self, app: &mut App) {
 		TLoading::register_custom_folder_assets::<DoorMeta, DoorMeta, LoadingEssentialAssets>(app);
+
+		TSavegame::register_savable_component::<Door>(app);
 
 		app.init_asset::<DoorMeta>()
 			.add_prefab_observer::<Door, ()>()


### PR DESCRIPTION
- doors are now part of the save file
- `Interactive` is not derived directly from the concrete interactive driver component (`Door` or `Container` for now)

This is done, so we can apply active open/close animations of doors when saving while a door opens.