### PR TITLE
Carry anmimation seek time accross sessions

### DIFF
--- a/src/plugins/animations/src/components/animation_dispatch.rs
+++ b/src/plugins/animations/src/components/animation_dispatch.rs
@@ -124,7 +124,7 @@ impl<'a> Iterator for IterAllAnimations<'a> {
 
 #[derive(Debug, PartialEq, Default, Clone, Copy, Serialize, Deserialize)]
 pub(crate) struct AnimationState {
-	pub(crate) seek: f32,
+	pub(crate) seek: F32Finite,
 }
 
 #[derive(Component, Debug, PartialEq)]

--- a/src/plugins/animations/src/components/animation_dispatch.rs
+++ b/src/plugins/animations/src/components/animation_dispatch.rs
@@ -9,7 +9,7 @@ use bevy::{ecs::entity::EntityHashSet, prelude::*};
 use common::traits::handles_animations::{AnimationKey, AnimationPriority};
 use macros::SavableComponent;
 use serde::{Deserialize, Serialize};
-use std::{fmt::Debug, iter::Rev};
+use std::{collections::HashMap, fmt::Debug, iter::Rev};
 use zyheeda_core::prelude::*;
 
 #[derive(Component, SavableComponent, Debug, PartialEq, Clone, Serialize, Deserialize)]
@@ -21,6 +21,8 @@ pub struct AnimationDispatch {
 		OrderedSet<AnimationKey>,
 		OrderedSet<AnimationKey>,
 	),
+	#[serde(with = "as_vec")]
+	pub(crate) states: HashMap<AnimationKey, AnimationState>,
 }
 
 impl AnimationDispatch {
@@ -51,6 +53,7 @@ impl Default for AnimationDispatch {
 	fn default() -> Self {
 		Self {
 			priorities: default(),
+			states: default(),
 		}
 	}
 }
@@ -109,6 +112,11 @@ impl<'a> Iterator for IterAllAnimations<'a> {
 
 		None
 	}
+}
+
+#[derive(Debug, PartialEq, Default, Clone, Copy, Serialize, Deserialize)]
+pub(crate) struct AnimationState {
+	pub(crate) seek: f32,
 }
 
 #[derive(Component, Debug, PartialEq)]

--- a/src/plugins/animations/src/components/animation_dispatch.rs
+++ b/src/plugins/animations/src/components/animation_dispatch.rs
@@ -26,6 +26,14 @@ pub struct AnimationDispatch {
 }
 
 impl AnimationDispatch {
+	#[cfg(test)]
+	pub(crate) fn with_states<const N: usize>(states: [(AnimationKey, AnimationState); N]) -> Self {
+		Self {
+			states: HashMap::from(states),
+			..default()
+		}
+	}
+
 	pub(crate) fn slot_mut<TLayer>(&mut self, layer: TLayer) -> &mut OrderedSet<AnimationKey>
 	where
 		TLayer: Into<AnimationPriority>,

--- a/src/plugins/animations/src/components/animation_lookup.rs
+++ b/src/plugins/animations/src/components/animation_lookup.rs
@@ -16,6 +16,33 @@ pub(crate) struct AnimationLookup<TClips = AnimationClips<AnimationNodeIndex>> {
 	pub(crate) animation_mask_groups: HashMap<AnimationMaskBits, AffectedAnimationBones>,
 }
 
+#[cfg(test)]
+impl<TClips> AnimationLookup<TClips> {
+	pub(crate) fn with_clips<const N: usize, T>(clips: [(AnimationKey, T); N]) -> Self
+	where
+		T: Into<TClips>,
+	{
+		use common::traits::handles_animations::PlayMode;
+
+		Self {
+			animations: clips
+				.into_iter()
+				.map(|(key, clips)| {
+					(
+						key,
+						Animation {
+							clips: clips.into(),
+							play_mode: PlayMode::default(),
+							mask_groups: AnimationMaskBits::default(),
+						},
+					)
+				})
+				.collect(),
+			..default()
+		}
+	}
+}
+
 impl<TClips> Default for AnimationLookup<TClips> {
 	fn default() -> Self {
 		Self {

--- a/src/plugins/animations/src/lib.rs
+++ b/src/plugins/animations/src/lib.rs
@@ -70,6 +70,7 @@ where
 				UnlinkedGraph::link_to::<AnimationDispatch, AnimationGraphOf>,
 				AnimationDispatch::distribute_player_components,
 				AnimationDispatch::play_animation_clip::<&mut AnimationPlayer>,
+				AnimationDispatch::apply_seek_times,
 				AnimationDispatch::set_directional_animation_weights,
 				AnimationDispatch::set_pitch_animation_weights,
 			)

--- a/src/plugins/animations/src/lib.rs
+++ b/src/plugins/animations/src/lib.rs
@@ -53,6 +53,8 @@ where
 		type UnlinkedGraph = (Added<AnimationGraphHandle>, Without<AnimationGraphOf>);
 
 		TSavegame::register_savable_component::<AnimationDispatch>(app);
+		TSavegame::on_before_save(app, AnimationDispatch::write_animation_seek_state);
+
 		app.add_observer(SetupAnimations::insert_when::<SceneInstanceReady>);
 		app.add_systems(
 			Update,

--- a/src/plugins/animations/src/systems.rs
+++ b/src/plugins/animations/src/systems.rs
@@ -1,3 +1,4 @@
+pub(crate) mod apply_seek_times;
 pub(crate) mod dispatch_player_components;
 pub(crate) mod play_animation_clip;
 pub(crate) mod set_directional_animation_weights;

--- a/src/plugins/animations/src/systems.rs
+++ b/src/plugins/animations/src/systems.rs
@@ -3,3 +3,4 @@ pub(crate) mod play_animation_clip;
 pub(crate) mod set_directional_animation_weights;
 pub(crate) mod set_pitch_animation_weights;
 pub(crate) mod setup_animations;
+pub(crate) mod write_animation_seek_state;

--- a/src/plugins/animations/src/systems/apply_seek_times.rs
+++ b/src/plugins/animations/src/systems/apply_seek_times.rs
@@ -32,7 +32,7 @@ impl AnimationDispatch {
 				};
 
 				for id in data.clips.iterate() {
-					player.set_animation_seek_time(*id, state.seek);
+					player.set_animation_seek_time(*id, *state.seek);
 				}
 			}
 		}
@@ -63,6 +63,7 @@ mod tests {
 	use macros::NestedMocks;
 	use mockall::{automock, predicate::eq};
 	use testing::{NestedMocks, SingleThreadedApp};
+	use zyheeda_core::prelude::*;
 
 	#[derive(Component, NestedMocks)]
 	struct _AnimationPlayer {
@@ -95,7 +96,9 @@ mod tests {
 			.spawn((
 				AnimationDispatch::with_states([(
 					AnimationKey::Walk,
-					AnimationState { seek: 11. },
+					AnimationState {
+						seek: f32_finite!(11.),
+					},
 				)]),
 				AnimationLookup::<_Clips>::with_clips([(
 					AnimationKey::Walk,
@@ -125,7 +128,9 @@ mod tests {
 			.spawn((
 				AnimationDispatch::with_states([(
 					AnimationKey::Walk,
-					AnimationState { seek: 11. },
+					AnimationState {
+						seek: f32_finite!(11.),
+					},
 				)]),
 				AnimationLookup::<_Clips>::with_clips([(
 					AnimationKey::Walk,

--- a/src/plugins/animations/src/systems/apply_seek_times.rs
+++ b/src/plugins/animations/src/systems/apply_seek_times.rs
@@ -1,0 +1,151 @@
+use crate::components::{
+	animation_dispatch::{AnimationDispatch, AnimationPlayerOf},
+	animation_lookup::AnimationLookup,
+};
+use bevy::{ecs::component::Mutable, prelude::*};
+use common::traits::thread_safe::ThreadSafe;
+use zyheeda_core::collections::iterate::Iterate;
+
+impl AnimationDispatch {
+	pub(crate) fn apply_seek_times(
+		dispatchers: Query<(&AnimationDispatch, &AnimationLookup)>,
+		players: Query<(&mut AnimationPlayer, &AnimationPlayerOf), Added<AnimationPlayerOf>>,
+	) {
+		Self::apply_seek_times_internal(dispatchers, players);
+	}
+
+	fn apply_seek_times_internal<TClips, TPlayer>(
+		dispatchers: Query<(&AnimationDispatch, &AnimationLookup<TClips>)>,
+		players: Query<(&mut TPlayer, &AnimationPlayerOf), Added<AnimationPlayerOf>>,
+	) where
+		TClips: ThreadSafe + for<'a> Iterate<'a, TItem = &'a AnimationNodeIndex>,
+		TPlayer: Component<Mutability = Mutable> + SetAnimationSeekTime,
+	{
+		for (mut player, AnimationPlayerOf(dispatch)) in players {
+			let Ok((dispatch, lookup)) = dispatchers.get(*dispatch) else {
+				continue;
+			};
+
+			for (key, state) in &dispatch.states {
+				let Some(data) = lookup.animations.get(key) else {
+					continue;
+				};
+
+				for id in data.clips.iterate() {
+					player.set_animation_seek_time(*id, state.seek);
+				}
+			}
+		}
+	}
+}
+
+trait SetAnimationSeekTime {
+	fn set_animation_seek_time(&mut self, id: AnimationNodeIndex, seek_time: f32);
+}
+
+impl SetAnimationSeekTime for AnimationPlayer {
+	fn set_animation_seek_time(&mut self, id: AnimationNodeIndex, seek_time: f32) {
+		self.animation_mut(id).map(|a| a.set_seek_time(seek_time));
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::{
+		components::{
+			animation_dispatch::{AnimationPlayerOf, AnimationState},
+			animation_lookup::AnimationLookup,
+		},
+		systems::write_animation_seek_state::tests::_Clips,
+	};
+	use common::traits::handles_animations::AnimationKey;
+	use macros::NestedMocks;
+	use mockall::{automock, predicate::eq};
+	use testing::{NestedMocks, SingleThreadedApp};
+
+	#[derive(Component, NestedMocks)]
+	struct _AnimationPlayer {
+		mock: Mock_AnimationPlayer,
+	}
+
+	#[automock]
+	impl SetAnimationSeekTime for _AnimationPlayer {
+		fn set_animation_seek_time(&mut self, id: AnimationNodeIndex, seek_time: f32) {
+			self.mock.set_animation_seek_time(id, seek_time);
+		}
+	}
+
+	fn setup() -> App {
+		let mut app = App::new().single_threaded(Update);
+
+		app.add_systems(
+			Update,
+			AnimationDispatch::apply_seek_times_internal::<_Clips, _AnimationPlayer>,
+		);
+
+		app
+	}
+
+	#[test]
+	fn apply_seek_time() {
+		let mut app = setup();
+		let dispatch = app
+			.world_mut()
+			.spawn((
+				AnimationDispatch::with_states([(
+					AnimationKey::Walk,
+					AnimationState { seek: 11. },
+				)]),
+				AnimationLookup::<_Clips>::with_clips([(
+					AnimationKey::Walk,
+					vec![AnimationNodeIndex::new(42)],
+				)]),
+			))
+			.id();
+		app.world_mut().spawn((
+			AnimationPlayerOf(dispatch),
+			_AnimationPlayer::new().with_mock(assert_set_seek_time),
+		));
+
+		app.update();
+
+		fn assert_set_seek_time(mock: &mut Mock_AnimationPlayer) {
+			mock.expect_set_animation_seek_time()
+				.with(eq(AnimationNodeIndex::new(42)), eq(11.))
+				.return_const(());
+		}
+	}
+
+	#[test]
+	fn act_only_once() {
+		let mut app = setup();
+		let dispatch = app
+			.world_mut()
+			.spawn((
+				AnimationDispatch::with_states([(
+					AnimationKey::Walk,
+					AnimationState { seek: 11. },
+				)]),
+				AnimationLookup::<_Clips>::with_clips([(
+					AnimationKey::Walk,
+					vec![AnimationNodeIndex::new(42)],
+				)]),
+			))
+			.id();
+		app.world_mut().spawn((
+			AnimationPlayerOf(dispatch),
+			_AnimationPlayer::new().with_mock(assert_set_seek_time),
+		));
+
+		app.update();
+		app.update();
+
+		fn assert_set_seek_time(mock: &mut Mock_AnimationPlayer) {
+			mock.expect_set_animation_seek_time()
+				.with(eq(AnimationNodeIndex::new(42)), eq(11.))
+				.once()
+				.return_const(());
+		}
+	}
+}

--- a/src/plugins/animations/src/systems/write_animation_seek_state.rs
+++ b/src/plugins/animations/src/systems/write_animation_seek_state.rs
@@ -4,7 +4,7 @@ use crate::components::{
 };
 use bevy::prelude::*;
 use common::traits::thread_safe::ThreadSafe;
-use zyheeda_core::collections::iterate::Iterate;
+use zyheeda_core::prelude::*;
 
 impl AnimationDispatch {
 	pub(crate) fn write_animation_seek_state(
@@ -41,10 +41,9 @@ impl AnimationDispatch {
 						continue;
 					};
 
-					let seek = animation.seek_time();
-					if seek.is_nan() {
+					let Ok(seek) = F32Finite::try_from_f32(animation.seek_time()) else {
 						continue;
-					}
+					};
 
 					dispatch.states.insert(*key, AnimationState { seek });
 				}
@@ -85,7 +84,7 @@ pub(crate) mod tests {
 
 		for (clip, AnimationState { seek }) in clips {
 			let clip = player.play(clip);
-			clip.set_seek_time(seek);
+			clip.set_seek_time(*seek);
 		}
 
 		player
@@ -117,7 +116,12 @@ pub(crate) mod tests {
 			.id();
 		app.world_mut().spawn((
 			AnimationPlayerOf(entity),
-			player_with_clips([(AnimationNodeIndex::new(11), AnimationState { seek: 11. })]),
+			player_with_clips([(
+				AnimationNodeIndex::new(11),
+				AnimationState {
+					seek: f32_finite!(11.),
+				},
+			)]),
 		));
 
 		app.update();
@@ -125,7 +129,9 @@ pub(crate) mod tests {
 		assert_eq!(
 			Some(&AnimationDispatch::with_states([(
 				AnimationKey::Walk,
-				AnimationState { seek: 11. }
+				AnimationState {
+					seek: f32_finite!(11.)
+				}
 			)])),
 			app.world().entity(entity).get::<AnimationDispatch>(),
 		);
@@ -137,36 +143,12 @@ pub(crate) mod tests {
 		let entity = app
 			.world_mut()
 			.spawn((
-				AnimationDispatch::with_states([(AnimationKey::Run, AnimationState { seek: 44. })]),
-				AnimationLookup::<_Clips>::with_clips([(
-					AnimationKey::Walk,
-					vec![AnimationNodeIndex::new(11)],
+				AnimationDispatch::with_states([(
+					AnimationKey::Run,
+					AnimationState {
+						seek: f32_finite!(44.),
+					},
 				)]),
-			))
-			.id();
-		app.world_mut().spawn((
-			AnimationPlayerOf(entity),
-			player_with_clips([(AnimationNodeIndex::new(11), AnimationState { seek: 11. })]),
-		));
-
-		app.update();
-
-		assert_eq!(
-			Some(&AnimationDispatch::with_states([(
-				AnimationKey::Walk,
-				AnimationState { seek: 11. }
-			)])),
-			app.world().entity(entity).get::<AnimationDispatch>(),
-		);
-	}
-
-	#[test]
-	fn ignore_nan_values() {
-		let mut app = setup();
-		let entity = app
-			.world_mut()
-			.spawn((
-				AnimationDispatch::with_states([]),
 				AnimationLookup::<_Clips>::with_clips([(
 					AnimationKey::Walk,
 					vec![AnimationNodeIndex::new(11)],
@@ -177,14 +159,21 @@ pub(crate) mod tests {
 			AnimationPlayerOf(entity),
 			player_with_clips([(
 				AnimationNodeIndex::new(11),
-				AnimationState { seek: f32::NAN },
+				AnimationState {
+					seek: f32_finite!(11.),
+				},
 			)]),
 		));
 
 		app.update();
 
 		assert_eq!(
-			Some(&AnimationDispatch::with_states([])),
+			Some(&AnimationDispatch::with_states([(
+				AnimationKey::Walk,
+				AnimationState {
+					seek: f32_finite!(11.)
+				}
+			)])),
 			app.world().entity(entity).get::<AnimationDispatch>(),
 		);
 	}
@@ -205,8 +194,18 @@ pub(crate) mod tests {
 		app.world_mut().spawn((
 			AnimationPlayerOf(entity),
 			player_with_clips([
-				(AnimationNodeIndex::new(11), AnimationState { seek: 11. }),
-				(AnimationNodeIndex::new(22), AnimationState { seek: 22. }),
+				(
+					AnimationNodeIndex::new(11),
+					AnimationState {
+						seek: f32_finite!(11.),
+					},
+				),
+				(
+					AnimationNodeIndex::new(22),
+					AnimationState {
+						seek: f32_finite!(22.),
+					},
+				),
 			]),
 		));
 
@@ -215,7 +214,9 @@ pub(crate) mod tests {
 		assert_eq!(
 			Some(&AnimationDispatch::with_states([(
 				AnimationKey::Walk,
-				AnimationState { seek: 11. }
+				AnimationState {
+					seek: f32_finite!(11.)
+				}
 			)])),
 			app.world().entity(entity).get::<AnimationDispatch>(),
 		);

--- a/src/plugins/animations/src/systems/write_animation_seek_state.rs
+++ b/src/plugins/animations/src/systems/write_animation_seek_state.rs
@@ -54,18 +54,20 @@ impl AnimationDispatch {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
 	use super::*;
-	use crate::components::{
-		animation_dispatch::{AnimationPlayerOf, AnimationState},
-		animation_lookup::AnimationLookup,
-	};
-	use common::traits::handles_animations::{Animation, AnimationKey};
-	use std::collections::HashMap;
+	use crate::components::animation_dispatch::{AnimationPlayerOf, AnimationState};
+	use common::traits::handles_animations::AnimationKey;
 	use testing::SingleThreadedApp;
 
 	#[derive(Default)]
-	struct _Clips(Vec<AnimationNodeIndex>);
+	pub(crate) struct _Clips(Vec<AnimationNodeIndex>);
+
+	impl From<Vec<AnimationNodeIndex>> for _Clips {
+		fn from(clips: Vec<AnimationNodeIndex>) -> Self {
+			Self(clips)
+		}
+	}
 
 	impl<'a> Iterate<'a> for _Clips {
 		type TItem = &'a AnimationNodeIndex;
@@ -89,35 +91,6 @@ mod tests {
 		player
 	}
 
-	fn lookup_with_clips<const N: usize>(
-		clips: [(AnimationKey, Vec<AnimationNodeIndex>); N],
-	) -> AnimationLookup<_Clips> {
-		AnimationLookup {
-			animations: clips
-				.into_iter()
-				.map(|(key, clips)| {
-					(
-						key,
-						Animation {
-							clips: _Clips(clips),
-							..default()
-						},
-					)
-				})
-				.collect(),
-			..default()
-		}
-	}
-
-	fn dispatch_with_states<const N: usize>(
-		states: [(AnimationKey, AnimationState); N],
-	) -> AnimationDispatch {
-		let mut dispatch = AnimationDispatch::default();
-		dispatch.states = HashMap::from(states);
-
-		dispatch
-	}
-
 	fn setup() -> App {
 		let mut app = App::new().single_threaded(Update);
 
@@ -135,8 +108,11 @@ mod tests {
 		let entity = app
 			.world_mut()
 			.spawn((
-				dispatch_with_states([]),
-				lookup_with_clips([(AnimationKey::Walk, vec![AnimationNodeIndex::new(11)])]),
+				AnimationDispatch::with_states([]),
+				AnimationLookup::<_Clips>::with_clips([(
+					AnimationKey::Walk,
+					vec![AnimationNodeIndex::new(11)],
+				)]),
 			))
 			.id();
 		app.world_mut().spawn((
@@ -147,7 +123,7 @@ mod tests {
 		app.update();
 
 		assert_eq!(
-			Some(&dispatch_with_states([(
+			Some(&AnimationDispatch::with_states([(
 				AnimationKey::Walk,
 				AnimationState { seek: 11. }
 			)])),
@@ -161,8 +137,11 @@ mod tests {
 		let entity = app
 			.world_mut()
 			.spawn((
-				dispatch_with_states([(AnimationKey::Run, AnimationState { seek: 44. })]),
-				lookup_with_clips([(AnimationKey::Walk, vec![AnimationNodeIndex::new(11)])]),
+				AnimationDispatch::with_states([(AnimationKey::Run, AnimationState { seek: 44. })]),
+				AnimationLookup::<_Clips>::with_clips([(
+					AnimationKey::Walk,
+					vec![AnimationNodeIndex::new(11)],
+				)]),
 			))
 			.id();
 		app.world_mut().spawn((
@@ -173,7 +152,7 @@ mod tests {
 		app.update();
 
 		assert_eq!(
-			Some(&dispatch_with_states([(
+			Some(&AnimationDispatch::with_states([(
 				AnimationKey::Walk,
 				AnimationState { seek: 11. }
 			)])),
@@ -187,8 +166,11 @@ mod tests {
 		let entity = app
 			.world_mut()
 			.spawn((
-				dispatch_with_states([]),
-				lookup_with_clips([(AnimationKey::Walk, vec![AnimationNodeIndex::new(11)])]),
+				AnimationDispatch::with_states([]),
+				AnimationLookup::<_Clips>::with_clips([(
+					AnimationKey::Walk,
+					vec![AnimationNodeIndex::new(11)],
+				)]),
 			))
 			.id();
 		app.world_mut().spawn((
@@ -202,7 +184,7 @@ mod tests {
 		app.update();
 
 		assert_eq!(
-			Some(&dispatch_with_states([])),
+			Some(&AnimationDispatch::with_states([])),
 			app.world().entity(entity).get::<AnimationDispatch>(),
 		);
 	}
@@ -213,8 +195,8 @@ mod tests {
 		let entity = app
 			.world_mut()
 			.spawn((
-				dispatch_with_states([]),
-				lookup_with_clips([(
+				AnimationDispatch::with_states([]),
+				AnimationLookup::<_Clips>::with_clips([(
 					AnimationKey::Walk,
 					vec![AnimationNodeIndex::new(11), AnimationNodeIndex::new(22)],
 				)]),
@@ -231,7 +213,7 @@ mod tests {
 		app.update();
 
 		assert_eq!(
-			Some(&dispatch_with_states([(
+			Some(&AnimationDispatch::with_states([(
 				AnimationKey::Walk,
 				AnimationState { seek: 11. }
 			)])),

--- a/src/plugins/animations/src/systems/write_animation_seek_state.rs
+++ b/src/plugins/animations/src/systems/write_animation_seek_state.rs
@@ -1,0 +1,241 @@
+use crate::components::{
+	animation_dispatch::{AnimationDispatch, AnimationPlayers, AnimationState},
+	animation_lookup::AnimationLookup,
+};
+use bevy::prelude::*;
+use common::traits::thread_safe::ThreadSafe;
+use zyheeda_core::collections::iterate::Iterate;
+
+impl AnimationDispatch {
+	pub(crate) fn write_animation_seek_state(
+		dispatchers: Query<(&mut AnimationDispatch, &AnimationPlayers, &AnimationLookup)>,
+		players: Query<&AnimationPlayer>,
+	) {
+		Self::write_animation_seek_state_internal(dispatchers, players);
+	}
+
+	fn write_animation_seek_state_internal<TClips>(
+		dispatchers: Query<(
+			&mut AnimationDispatch,
+			&AnimationPlayers,
+			&AnimationLookup<TClips>,
+		)>,
+		players: Query<&AnimationPlayer>,
+	) where
+		TClips: ThreadSafe + for<'a> Iterate<'a, TItem = &'a AnimationNodeIndex>,
+	{
+		for (mut dispatch, pls, lookup) in dispatchers {
+			dispatch.states.clear();
+
+			for player in pls.iter() {
+				let Ok(player) = players.get(player) else {
+					continue;
+				};
+
+				for (key, animation) in lookup.animations.iter() {
+					let Some(id) = animation.clips.iterate().next() else {
+						continue;
+					};
+
+					let Some(animation) = player.animation(*id) else {
+						continue;
+					};
+
+					let seek = animation.seek_time();
+					if seek.is_nan() {
+						continue;
+					}
+
+					dispatch.states.insert(*key, AnimationState { seek });
+				}
+			}
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::components::{
+		animation_dispatch::{AnimationPlayerOf, AnimationState},
+		animation_lookup::AnimationLookup,
+	};
+	use common::traits::handles_animations::{Animation, AnimationKey};
+	use std::collections::HashMap;
+	use testing::SingleThreadedApp;
+
+	#[derive(Default)]
+	struct _Clips(Vec<AnimationNodeIndex>);
+
+	impl<'a> Iterate<'a> for _Clips {
+		type TItem = &'a AnimationNodeIndex;
+		type TIter = std::slice::Iter<'a, AnimationNodeIndex>;
+
+		fn iterate(&'a self) -> Self::TIter {
+			self.0.iter()
+		}
+	}
+
+	fn player_with_clips<const N: usize>(
+		clips: [(AnimationNodeIndex, AnimationState); N],
+	) -> AnimationPlayer {
+		let mut player = AnimationPlayer::default();
+
+		for (clip, AnimationState { seek }) in clips {
+			let clip = player.play(clip);
+			clip.set_seek_time(seek);
+		}
+
+		player
+	}
+
+	fn lookup_with_clips<const N: usize>(
+		clips: [(AnimationKey, Vec<AnimationNodeIndex>); N],
+	) -> AnimationLookup<_Clips> {
+		AnimationLookup {
+			animations: clips
+				.into_iter()
+				.map(|(key, clips)| {
+					(
+						key,
+						Animation {
+							clips: _Clips(clips),
+							..default()
+						},
+					)
+				})
+				.collect(),
+			..default()
+		}
+	}
+
+	fn dispatch_with_states<const N: usize>(
+		states: [(AnimationKey, AnimationState); N],
+	) -> AnimationDispatch {
+		let mut dispatch = AnimationDispatch::default();
+		dispatch.states = HashMap::from(states);
+
+		dispatch
+	}
+
+	fn setup() -> App {
+		let mut app = App::new().single_threaded(Update);
+
+		app.add_systems(
+			Update,
+			AnimationDispatch::write_animation_seek_state_internal::<_Clips>,
+		);
+
+		app
+	}
+
+	#[test]
+	fn write_active_animations_state() {
+		let mut app = setup();
+		let entity = app
+			.world_mut()
+			.spawn((
+				dispatch_with_states([]),
+				lookup_with_clips([(AnimationKey::Walk, vec![AnimationNodeIndex::new(11)])]),
+			))
+			.id();
+		app.world_mut().spawn((
+			AnimationPlayerOf(entity),
+			player_with_clips([(AnimationNodeIndex::new(11), AnimationState { seek: 11. })]),
+		));
+
+		app.update();
+
+		assert_eq!(
+			Some(&dispatch_with_states([(
+				AnimationKey::Walk,
+				AnimationState { seek: 11. }
+			)])),
+			app.world().entity(entity).get::<AnimationDispatch>(),
+		);
+	}
+
+	#[test]
+	fn overwrite_active_animations_state() {
+		let mut app = setup();
+		let entity = app
+			.world_mut()
+			.spawn((
+				dispatch_with_states([(AnimationKey::Run, AnimationState { seek: 44. })]),
+				lookup_with_clips([(AnimationKey::Walk, vec![AnimationNodeIndex::new(11)])]),
+			))
+			.id();
+		app.world_mut().spawn((
+			AnimationPlayerOf(entity),
+			player_with_clips([(AnimationNodeIndex::new(11), AnimationState { seek: 11. })]),
+		));
+
+		app.update();
+
+		assert_eq!(
+			Some(&dispatch_with_states([(
+				AnimationKey::Walk,
+				AnimationState { seek: 11. }
+			)])),
+			app.world().entity(entity).get::<AnimationDispatch>(),
+		);
+	}
+
+	#[test]
+	fn ignore_nan_values() {
+		let mut app = setup();
+		let entity = app
+			.world_mut()
+			.spawn((
+				dispatch_with_states([]),
+				lookup_with_clips([(AnimationKey::Walk, vec![AnimationNodeIndex::new(11)])]),
+			))
+			.id();
+		app.world_mut().spawn((
+			AnimationPlayerOf(entity),
+			player_with_clips([(
+				AnimationNodeIndex::new(11),
+				AnimationState { seek: f32::NAN },
+			)]),
+		));
+
+		app.update();
+
+		assert_eq!(
+			Some(&dispatch_with_states([])),
+			app.world().entity(entity).get::<AnimationDispatch>(),
+		);
+	}
+
+	#[test]
+	fn ignore_subsequent_clips() {
+		let mut app = setup();
+		let entity = app
+			.world_mut()
+			.spawn((
+				dispatch_with_states([]),
+				lookup_with_clips([(
+					AnimationKey::Walk,
+					vec![AnimationNodeIndex::new(11), AnimationNodeIndex::new(22)],
+				)]),
+			))
+			.id();
+		app.world_mut().spawn((
+			AnimationPlayerOf(entity),
+			player_with_clips([
+				(AnimationNodeIndex::new(11), AnimationState { seek: 11. }),
+				(AnimationNodeIndex::new(22), AnimationState { seek: 22. }),
+			]),
+		));
+
+		app.update();
+
+		assert_eq!(
+			Some(&dispatch_with_states([(
+				AnimationKey::Walk,
+				AnimationState { seek: 11. }
+			)])),
+			app.world().entity(entity).get::<AnimationDispatch>(),
+		);
+	}
+}


### PR DESCRIPTION
- on save: store seek times per `AnimationKey` in `AnimationDispatch` from a single active animation belonging to that animation 
  - disregarding animations with invalid seek time (invalid seek time fixed in bevy: https://github.com/bevyengine/bevy/pull/24996) 
- when adding `AnimationPlayer` to a `AnimationDispatch` apply store seek times to all active animation clips

Notes:
- the seek times in `AnimationDispatch` are not cleared to allow for delayed application of seek time (when related `AnimationPlayer` is added)
- seek times are stored per `AnimationKey` and not per animation clip, because all clips of a certain animation:
  -  start and stop at the same time 
  - replay/repeat settings apply to all clips on an animation the same way
  - if an animation has multiple clips, they need to be the same length for proper blending