### PR TITLE
Selective lighting around player

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -73,6 +73,7 @@
 		"Hasher",
 		"hoverable",
 		"Icosphere",
+		"ifdef",
 		"impls",
 		"ingame",
 		"interruptable",

--- a/assets/shaders/lit_shader.wgsl
+++ b/assets/shaders/lit_shader.wgsl
@@ -15,12 +15,9 @@
 }
 #endif
 
-struct LitMaterial {
-    player_position: vec3<f32>,
-}
-
-@group(#{MATERIAL_BIND_GROUP}) @binding(100)
-var<uniform> lit_material: LitMaterial;
+@group(#{MATERIAL_BIND_GROUP}) @binding(100) var<uniform> player_position: vec3<f32>;
+@group(#{MATERIAL_BIND_GROUP}) @binding(101) var<uniform> falloff: f32;
+@group(#{MATERIAL_BIND_GROUP}) @binding(102) var<uniform> min_light: f32;
 
 @fragment
 fn fragment(
@@ -37,6 +34,12 @@ fn fragment(
     var out: FragmentOutput;
     out.color = apply_pbr_lighting(pbr_input);
     out.color = main_pass_post_lighting_processing(pbr_input, out.color);
+
+    let distance = length(player_position - in.world_position.xyz);
+    out.color = vec4(
+        out.color.rgb * max(1. - distance * falloff, min_light),
+        out.color.a,
+    );
 #endif
 
     return out;

--- a/assets/shaders/lit_shader.wgsl
+++ b/assets/shaders/lit_shader.wgsl
@@ -1,0 +1,43 @@
+#import bevy_pbr::{
+    pbr_fragment::pbr_input_from_standard_material,
+    pbr_functions::alpha_discard,
+}
+
+#ifdef PREPASS_PIPELINE
+#import bevy_pbr::{
+    prepass_io::{VertexOutput, FragmentOutput},
+    pbr_deferred_functions::deferred_output,
+}
+#else
+#import bevy_pbr::{
+    forward_io::{VertexOutput, FragmentOutput},
+    pbr_functions::{apply_pbr_lighting, main_pass_post_lighting_processing},
+}
+#endif
+
+struct LitMaterial {
+    player_position: vec3<f32>,
+}
+
+@group(#{MATERIAL_BIND_GROUP}) @binding(100)
+var<uniform> lit_material: LitMaterial;
+
+@fragment
+fn fragment(
+    in: VertexOutput,
+    @builtin(front_facing) is_front: bool,
+) -> FragmentOutput {
+    var pbr_input = pbr_input_from_standard_material(in, is_front);
+
+    pbr_input.material.base_color = alpha_discard(pbr_input.material, pbr_input.material.base_color);
+
+#ifdef PREPASS_PIPELINE
+    let out = deferred_output(in, pbr_input);
+#else
+    var out: FragmentOutput;
+    out.color = apply_pbr_lighting(pbr_input);
+    out.color = main_pass_post_lighting_processing(pbr_input, out.color);
+#endif
+
+    return out;
+}

--- a/src/plugins/graphics/src/lib.rs
+++ b/src/plugins/graphics/src/lib.rs
@@ -14,7 +14,7 @@ use crate::{
 		post_process_camera::PostProcessCamera,
 		roles::{Enemy, Player},
 	},
-	materials::effect_material::EffectMaterial,
+	materials::{effect_material::EffectMaterial, lit_material::StandardLitMaterial},
 	resources::{
 		camera_parameters::CameraParameters,
 		depth_texture::{CopyDepthTexture, DepthTexture},
@@ -113,6 +113,7 @@ where
 
 	fn shading(app: &mut App) {
 		app.add_plugins(MaterialPlugin::<EffectMaterial>::default())
+			.add_plugins(MaterialPlugin::<StandardLitMaterial>::default())
 			.register_derived_component::<Essence, MaterialOverride>()
 			.register_shader::<EssenceMaterial>()
 			.add_observer(MaterialOverride::update_essence_shader)

--- a/src/plugins/graphics/src/lib.rs
+++ b/src/plugins/graphics/src/lib.rs
@@ -14,7 +14,10 @@ use crate::{
 		post_process_camera::PostProcessCamera,
 		roles::{Enemy, Player},
 	},
-	materials::{effect_material::EffectMaterial, lit_material::StandardLitMaterial},
+	materials::{
+		effect_material::EffectMaterial,
+		lit_material::{LitMaterial, StandardLitMaterial},
+	},
 	resources::{
 		camera_parameters::CameraParameters,
 		depth_texture::{CopyDepthTexture, DepthTexture},
@@ -132,6 +135,7 @@ where
 					EffectMaterialHandle::modify_material::<TPhysics, HealthDamage>,
 					EffectMaterialHandle::propagate_material,
 					StandardMaterials::replace_with_lit_material,
+					LitMaterial::set_player_position,
 				)
 					.chain()
 					.in_set(GraphicSystems)

--- a/src/plugins/graphics/src/lib.rs
+++ b/src/plugins/graphics/src/lib.rs
@@ -131,6 +131,7 @@ where
 					EffectMaterialHandle::modify_material::<TPhysics, Gravity>,
 					EffectMaterialHandle::modify_material::<TPhysics, HealthDamage>,
 					EffectMaterialHandle::propagate_material,
+					StandardMaterials::replace_with_lit_material,
 				)
 					.chain()
 					.in_set(GraphicSystems)

--- a/src/plugins/graphics/src/lib.rs
+++ b/src/plugins/graphics/src/lib.rs
@@ -19,6 +19,7 @@ use crate::{
 		camera_parameters::CameraParameters,
 		depth_texture::{CopyDepthTexture, DepthTexture},
 		post_process_pipeline::SetupPostProcessPipeline,
+		standard_materials::StandardMaterials,
 	},
 	system_params::{
 		camera::{CameraParam, CameraParamMut},
@@ -112,13 +113,16 @@ where
 	}
 
 	fn shading(app: &mut App) {
-		app.add_plugins(MaterialPlugin::<EffectMaterial>::default())
+		app.init_resource::<StandardMaterials>()
+			.add_plugins(MaterialPlugin::<EffectMaterial>::default())
 			.add_plugins(MaterialPlugin::<StandardLitMaterial>::default())
 			.register_derived_component::<Essence, MaterialOverride>()
 			.register_shader::<EssenceMaterial>()
 			.add_observer(MaterialOverride::update_essence_shader)
 			.add_observer(EffectMaterialHandle::add_to::<TPhysics::TSkillContact>)
 			.add_observer(EffectMaterialHandle::add_to::<TPhysics::TSkillProjection>)
+			.add_observer(StandardMaterials::track_inserted)
+			.add_observer(StandardMaterials::track_discarded)
 			.add_systems(
 				Update,
 				(

--- a/src/plugins/graphics/src/materials.rs
+++ b/src/plugins/graphics/src/materials.rs
@@ -1,2 +1,3 @@
 pub(crate) mod effect_material;
 pub(crate) mod essence_material;
+pub(crate) mod lit_material;

--- a/src/plugins/graphics/src/materials/lit_material.rs
+++ b/src/plugins/graphics/src/materials/lit_material.rs
@@ -22,6 +22,13 @@ impl LitMaterial {
 	const SHADER: &str = asset_path!("shaders/lit_shader.wgsl");
 	const DEFAULT_FALLOFF: f32 = 0.1;
 	const DEFAULT_MIN_LIGHT: f32 = 0.01;
+
+	pub(crate) fn from_player_position(player_position: Vec3) -> Self {
+		Self {
+			player_position,
+			..default()
+		}
+	}
 }
 
 impl Default for LitMaterial {

--- a/src/plugins/graphics/src/materials/lit_material.rs
+++ b/src/plugins/graphics/src/materials/lit_material.rs
@@ -1,0 +1,29 @@
+use bevy::{
+	pbr::{ExtendedMaterial, MaterialExtension},
+	prelude::*,
+	render::render_resource::AsBindGroup,
+	shader::ShaderRef,
+};
+use macros::asset_path;
+
+pub(crate) type StandardLitMaterial = ExtendedMaterial<StandardMaterial, LitMaterial>;
+
+#[derive(Asset, AsBindGroup, Reflect, Debug, Clone, Default)]
+pub(crate) struct LitMaterial {
+	#[uniform(100)]
+	pub(crate) player_position: Vec3,
+}
+
+impl LitMaterial {
+	const SHADER: &str = asset_path!("shaders/lit_shader.wgsl");
+}
+
+impl MaterialExtension for LitMaterial {
+	fn fragment_shader() -> ShaderRef {
+		Self::SHADER.into()
+	}
+
+	fn deferred_fragment_shader() -> ShaderRef {
+		Self::SHADER.into()
+	}
+}

--- a/src/plugins/graphics/src/materials/lit_material.rs
+++ b/src/plugins/graphics/src/materials/lit_material.rs
@@ -8,14 +8,30 @@ use macros::asset_path;
 
 pub(crate) type StandardLitMaterial = ExtendedMaterial<StandardMaterial, LitMaterial>;
 
-#[derive(Asset, AsBindGroup, Reflect, Debug, Clone, Default)]
+#[derive(Asset, AsBindGroup, Reflect, Debug, PartialEq, Clone, Copy)]
 pub(crate) struct LitMaterial {
 	#[uniform(100)]
 	pub(crate) player_position: Vec3,
+	#[uniform(101)]
+	pub(crate) falloff: f32,
+	#[uniform(102)]
+	pub(crate) min_light: f32,
 }
 
 impl LitMaterial {
 	const SHADER: &str = asset_path!("shaders/lit_shader.wgsl");
+	const DEFAULT_FALLOFF: f32 = 0.1;
+	const DEFAULT_MIN_LIGHT: f32 = 0.01;
+}
+
+impl Default for LitMaterial {
+	fn default() -> Self {
+		Self {
+			player_position: Vec3::ZERO,
+			falloff: Self::DEFAULT_FALLOFF,
+			min_light: Self::DEFAULT_MIN_LIGHT,
+		}
+	}
 }
 
 impl MaterialExtension for LitMaterial {

--- a/src/plugins/graphics/src/observers.rs
+++ b/src/plugins/graphics/src/observers.rs
@@ -1,3 +1,4 @@
 pub(crate) mod add_effect_shader;
 pub(crate) mod insert_render_target;
+pub(crate) mod track_standard_material;
 pub(crate) mod update_essence_shader;

--- a/src/plugins/graphics/src/observers/track_standard_material.rs
+++ b/src/plugins/graphics/src/observers/track_standard_material.rs
@@ -1,0 +1,134 @@
+use crate::resources::standard_materials::StandardMaterials;
+use bevy::prelude::*;
+use std::collections::{HashSet, hash_map::Entry};
+
+impl StandardMaterials {
+	pub(crate) fn track_inserted(
+		on_add: On<Insert, MeshMaterial3d<StandardMaterial>>,
+		entities: Query<&MeshMaterial3d<StandardMaterial>>,
+		mut materials: ResMut<Self>,
+	) {
+		let Ok(MeshMaterial3d(handle)) = entities.get(on_add.entity) else {
+			return;
+		};
+
+		match materials.entities.entry(handle.id()) {
+			Entry::Occupied(mut entry) => {
+				entry.get_mut().insert(on_add.entity);
+			}
+			Entry::Vacant(entry) => {
+				entry.insert(HashSet::from([on_add.entity]));
+			}
+		};
+	}
+
+	pub(crate) fn track_discarded(
+		on_discard: On<Discard, MeshMaterial3d<StandardMaterial>>,
+		entities: Query<&MeshMaterial3d<StandardMaterial>>,
+		mut materials: ResMut<Self>,
+	) {
+		let Ok(MeshMaterial3d(handle)) = entities.get(on_discard.entity) else {
+			return;
+		};
+
+		let Entry::Occupied(mut entry) = materials.entities.entry(handle.id()) else {
+			return;
+		};
+
+		let entities = entry.get_mut();
+
+		entities.remove(&on_discard.entity);
+		if !entities.is_empty() {
+			return;
+		}
+
+		entry.remove();
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use std::collections::HashMap;
+	use testing::{SingleThreadedApp, new_handle};
+
+	fn setup() -> App {
+		let mut app = App::new().single_threaded(Update);
+
+		app.init_resource::<StandardMaterials>();
+		app.add_observer(StandardMaterials::track_inserted);
+		app.add_observer(StandardMaterials::track_discarded);
+
+		app
+	}
+
+	#[test]
+	fn track_added() {
+		let mut app = setup();
+		let handle = new_handle();
+
+		let entity = app.world_mut().spawn(MeshMaterial3d(handle.clone())).id();
+
+		assert_eq!(
+			&StandardMaterials {
+				entities: HashMap::from([(handle.id(), HashSet::from([entity]))])
+			},
+			app.world().resource::<StandardMaterials>()
+		);
+	}
+
+	#[test]
+	fn track_added_shared() {
+		let mut app = setup();
+		let handle = new_handle();
+
+		let entities = [
+			app.world_mut().spawn(MeshMaterial3d(handle.clone())).id(),
+			app.world_mut().spawn(MeshMaterial3d(handle.clone())).id(),
+		];
+
+		assert_eq!(
+			&StandardMaterials {
+				entities: HashMap::from([(handle.id(), HashSet::from(entities))])
+			},
+			app.world().resource::<StandardMaterials>()
+		);
+	}
+
+	#[test]
+	fn replace_on_insert() {
+		let mut app = setup();
+		let handle = new_handle();
+		let mut entity = app
+			.world_mut()
+			.spawn(MeshMaterial3d(new_handle::<StandardMaterial>()));
+
+		entity.insert(MeshMaterial3d(handle.clone()));
+
+		assert_eq!(
+			&StandardMaterials {
+				entities: HashMap::from([(handle.id(), HashSet::from([entity.id()]))])
+			},
+			app.world().resource::<StandardMaterials>()
+		);
+	}
+
+	#[test]
+	fn track_partially_removed() {
+		let mut app = setup();
+		let handle = new_handle();
+		let a = app.world_mut().spawn(MeshMaterial3d(handle.clone())).id();
+		let b = app.world_mut().spawn(MeshMaterial3d(handle.clone())).id();
+
+		app.world_mut()
+			.entity_mut(a)
+			.remove::<MeshMaterial3d<StandardMaterial>>();
+
+		assert_eq!(
+			&StandardMaterials {
+				entities: HashMap::from([(handle.id(), HashSet::from([b]))])
+			},
+			app.world().resource::<StandardMaterials>()
+		);
+	}
+}

--- a/src/plugins/graphics/src/resources.rs
+++ b/src/plugins/graphics/src/resources.rs
@@ -2,4 +2,5 @@ pub(crate) mod camera_parameters;
 pub(crate) mod camera_render_target;
 pub(crate) mod depth_texture;
 pub(crate) mod post_process_pipeline;
+pub(crate) mod standard_materials;
 pub(crate) mod window_size;

--- a/src/plugins/graphics/src/resources/standard_materials.rs
+++ b/src/plugins/graphics/src/resources/standard_materials.rs
@@ -1,0 +1,7 @@
+use bevy::prelude::*;
+use std::collections::{HashMap, HashSet};
+
+#[derive(Resource, Debug, PartialEq, Default)]
+pub(crate) struct StandardMaterials {
+	pub(crate) entities: HashMap<AssetId<StandardMaterial>, HashSet<Entity>>,
+}

--- a/src/plugins/graphics/src/systems.rs
+++ b/src/plugins/graphics/src/systems.rs
@@ -5,5 +5,6 @@ pub(crate) mod no_waiting_pipelines;
 pub(crate) mod process_new_ui_pass;
 pub(crate) mod propagate_effect_material;
 pub(crate) mod replace_with_lit_material;
+pub(crate) mod set_player_position;
 pub(crate) mod update_only_depth_prepass_render_target;
 pub(crate) mod update_target_ray;

--- a/src/plugins/graphics/src/systems.rs
+++ b/src/plugins/graphics/src/systems.rs
@@ -4,5 +4,6 @@ pub(crate) mod modify_material;
 pub(crate) mod no_waiting_pipelines;
 pub(crate) mod process_new_ui_pass;
 pub(crate) mod propagate_effect_material;
+pub(crate) mod replace_with_lit_material;
 pub(crate) mod update_only_depth_prepass_render_target;
 pub(crate) mod update_target_ray;

--- a/src/plugins/graphics/src/systems/propagate_effect_material.rs
+++ b/src/plugins/graphics/src/systems/propagate_effect_material.rs
@@ -1,4 +1,7 @@
-use crate::components::{child_meshes::ChildMeshes, effect_material_handle::EffectMaterialHandle};
+use crate::{
+	components::{child_meshes::ChildMeshes, effect_material_handle::EffectMaterialHandle},
+	materials::lit_material::StandardLitMaterial,
+};
 use bevy::prelude::*;
 use common::{traits::accessors::get::TryApplyOn, zyheeda_commands::ZyheedaCommands};
 
@@ -11,6 +14,7 @@ impl EffectMaterialHandle {
 			for entity in child_meshes.iter() {
 				commands.try_apply_on(&entity, |mut e| {
 					e.try_remove::<MeshMaterial3d<StandardMaterial>>();
+					e.try_remove::<MeshMaterial3d<StandardLitMaterial>>();
 					e.try_insert(MeshMaterial3d(material.clone()));
 				});
 			}
@@ -77,6 +81,28 @@ mod tests {
 			app.world()
 				.entity(child)
 				.get::<MeshMaterial3d<StandardMaterial>>(),
+		);
+	}
+
+	#[test]
+	fn remove_standard_lit_material() {
+		let mut app = setup();
+		let entity = app.world_mut().spawn(EffectMaterialHandle::default()).id();
+		let child = app
+			.world_mut()
+			.spawn((
+				ChildMeshOf(entity),
+				MeshMaterial3d(new_handle::<StandardLitMaterial>()),
+			))
+			.id();
+
+		app.update();
+
+		assert_eq!(
+			None,
+			app.world()
+				.entity(child)
+				.get::<MeshMaterial3d<StandardLitMaterial>>(),
 		);
 	}
 

--- a/src/plugins/graphics/src/systems/replace_with_lit_material.rs
+++ b/src/plugins/graphics/src/systems/replace_with_lit_material.rs
@@ -76,7 +76,10 @@ mod tests {
 		assert_eq!(
 			(
 				&StandardMaterials::default(),
-				Some(Color::LinearRgba(LinearRgba::new(4., 3., 2., 1.))),
+				Some((
+					Color::LinearRgba(LinearRgba::new(4., 3., 2., 1.)),
+					LitMaterial::default()
+				)),
 				None
 			),
 			(
@@ -88,7 +91,7 @@ mod tests {
 						.world()
 						.resource::<Assets<StandardLitMaterial>>()
 						.get(handle))
-					.map(|m| m.base.base_color),
+					.map(|m| (m.base.base_color, m.extension)),
 				app.world()
 					.entity(entity)
 					.get::<MeshMaterial3d<StandardMaterial>>()

--- a/src/plugins/graphics/src/systems/replace_with_lit_material.rs
+++ b/src/plugins/graphics/src/systems/replace_with_lit_material.rs
@@ -1,4 +1,5 @@
 use crate::{
+	components::roles::Player,
 	materials::lit_material::{LitMaterial, StandardLitMaterial},
 	resources::standard_materials::StandardMaterials,
 };
@@ -8,6 +9,7 @@ use common::{traits::accessors::get::TryApplyOn, zyheeda_commands::ZyheedaComman
 impl StandardMaterials {
 	pub(crate) fn replace_with_lit_material(
 		mut materials: ResMut<Self>,
+		players: Query<&Transform, With<Player>>,
 		standard_materials: Res<Assets<StandardMaterial>>,
 		mut lit_materials: ResMut<Assets<StandardLitMaterial>>,
 		mut commands: ZyheedaCommands,
@@ -17,9 +19,10 @@ impl StandardMaterials {
 				return true;
 			};
 
+			let player_position = players.single().map_or(Vec3::ZERO, |t| t.translation);
 			let lit_material = lit_materials.add(StandardLitMaterial {
 				base,
-				extension: LitMaterial::default(),
+				extension: LitMaterial::from_player_position(player_position),
 			});
 
 			for entity in entities.iter() {
@@ -37,7 +40,7 @@ impl StandardMaterials {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::materials::lit_material::StandardLitMaterial;
+	use crate::{components::roles::Player, materials::lit_material::StandardLitMaterial};
 	use std::collections::{HashMap, HashSet};
 	use testing::{SingleThreadedApp, new_handle};
 
@@ -96,6 +99,38 @@ mod tests {
 					.entity(entity)
 					.get::<MeshMaterial3d<StandardMaterial>>()
 			)
+		);
+	}
+
+	#[test]
+	fn replace_with_player_position() {
+		let handle = new_handle();
+		let mut app = setup([(
+			&handle,
+			StandardMaterial {
+				base_color: Color::LinearRgba(LinearRgba::new(4., 3., 2., 1.)),
+				..default()
+			},
+		)]);
+		let entity = app.world_mut().spawn(MeshMaterial3d(handle.clone())).id();
+		app.world_mut()
+			.spawn((Player, Transform::from_xyz(1., 2., 3.)));
+		app.insert_resource(StandardMaterials {
+			entities: HashMap::from([(handle.id(), HashSet::from([entity]))]),
+		});
+
+		app.update();
+
+		assert_eq!(
+			Some(LitMaterial::from_player_position(Vec3::new(1., 2., 3.))),
+			app.world()
+				.entity(entity)
+				.get::<MeshMaterial3d<StandardLitMaterial>>()
+				.and_then(|MeshMaterial3d(handle)| app
+					.world()
+					.resource::<Assets<StandardLitMaterial>>()
+					.get(handle))
+				.map(|m| m.extension),
 		);
 	}
 

--- a/src/plugins/graphics/src/systems/replace_with_lit_material.rs
+++ b/src/plugins/graphics/src/systems/replace_with_lit_material.rs
@@ -1,0 +1,201 @@
+use crate::{
+	materials::lit_material::{LitMaterial, StandardLitMaterial},
+	resources::standard_materials::StandardMaterials,
+};
+use bevy::prelude::*;
+use common::{traits::accessors::get::TryApplyOn, zyheeda_commands::ZyheedaCommands};
+
+impl StandardMaterials {
+	pub(crate) fn replace_with_lit_material(
+		mut materials: ResMut<Self>,
+		standard_materials: Res<Assets<StandardMaterial>>,
+		mut lit_materials: ResMut<Assets<StandardLitMaterial>>,
+		mut commands: ZyheedaCommands,
+	) {
+		materials.entities.retain(|id, entities| {
+			let Some(base) = standard_materials.get(*id).cloned() else {
+				return true;
+			};
+
+			let lit_material = lit_materials.add(StandardLitMaterial {
+				base,
+				extension: LitMaterial::default(),
+			});
+
+			for entity in entities.iter() {
+				commands.try_apply_on(entity, |mut e| {
+					e.try_remove::<MeshMaterial3d<StandardMaterial>>();
+					e.try_insert(MeshMaterial3d(lit_material.clone()));
+				});
+			}
+
+			false
+		});
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::materials::lit_material::StandardLitMaterial;
+	use std::collections::{HashMap, HashSet};
+	use testing::{SingleThreadedApp, new_handle};
+
+	fn setup<const N: usize>(materials: [(&Handle<StandardMaterial>, StandardMaterial); N]) -> App {
+		let mut app = App::new().single_threaded(Update);
+		let mut assets = Assets::default();
+
+		for (id, asset) in materials {
+			_ = assets.insert(id, asset);
+		}
+
+		app.insert_resource(assets);
+		app.init_resource::<Assets<StandardLitMaterial>>();
+		app.add_systems(Update, StandardMaterials::replace_with_lit_material);
+
+		app
+	}
+
+	#[test]
+	fn replace() {
+		let handle = new_handle();
+		let mut app = setup([(
+			&handle,
+			StandardMaterial {
+				base_color: Color::LinearRgba(LinearRgba::new(4., 3., 2., 1.)),
+				..default()
+			},
+		)]);
+		let entity = app.world_mut().spawn(MeshMaterial3d(handle.clone())).id();
+		app.insert_resource(StandardMaterials {
+			entities: HashMap::from([(handle.id(), HashSet::from([entity]))]),
+		});
+
+		app.update();
+
+		assert_eq!(
+			(
+				&StandardMaterials::default(),
+				Some(Color::LinearRgba(LinearRgba::new(4., 3., 2., 1.))),
+				None
+			),
+			(
+				app.world().resource::<StandardMaterials>(),
+				app.world()
+					.entity(entity)
+					.get::<MeshMaterial3d<StandardLitMaterial>>()
+					.and_then(|MeshMaterial3d(handle)| app
+						.world()
+						.resource::<Assets<StandardLitMaterial>>()
+						.get(handle))
+					.map(|m| m.base.base_color),
+				app.world()
+					.entity(entity)
+					.get::<MeshMaterial3d<StandardMaterial>>()
+			)
+		);
+	}
+
+	#[test]
+	fn replace_shared() {
+		let handle = new_handle();
+		let mut app = setup([(
+			&handle,
+			StandardMaterial {
+				base_color: Color::LinearRgba(LinearRgba::new(4., 3., 2., 1.)),
+				..default()
+			},
+		)]);
+		let a = app.world_mut().spawn(MeshMaterial3d(handle.clone())).id();
+		let b = app.world_mut().spawn(MeshMaterial3d(handle.clone())).id();
+		app.insert_resource(StandardMaterials {
+			entities: HashMap::from([(handle.id(), HashSet::from([a, b]))]),
+		});
+
+		app.update();
+
+		assert_eq!(
+			app.world()
+				.entity(a)
+				.get::<MeshMaterial3d<StandardLitMaterial>>(),
+			app.world()
+				.entity(b)
+				.get::<MeshMaterial3d<StandardLitMaterial>>(),
+		);
+	}
+
+	#[test]
+	fn replace_delayed() {
+		let handle = new_handle();
+		let mut app = setup([]);
+		let entity = app.world_mut().spawn(MeshMaterial3d(handle.clone())).id();
+		app.insert_resource(StandardMaterials {
+			entities: HashMap::from([(handle.id(), HashSet::from([entity]))]),
+		});
+
+		app.update();
+		_ = app
+			.world_mut()
+			.resource_mut::<Assets<StandardMaterial>>()
+			.insert(
+				&handle,
+				StandardMaterial {
+					base_color: Color::LinearRgba(LinearRgba::new(4., 3., 2., 1.)),
+					..default()
+				},
+			);
+		app.update();
+
+		assert_eq!(
+			(
+				&StandardMaterials::default(),
+				Some(Color::LinearRgba(LinearRgba::new(4., 3., 2., 1.))),
+				None
+			),
+			(
+				app.world().resource::<StandardMaterials>(),
+				app.world()
+					.entity(entity)
+					.get::<MeshMaterial3d<StandardLitMaterial>>()
+					.and_then(|MeshMaterial3d(handle)| app
+						.world()
+						.resource::<Assets<StandardLitMaterial>>()
+						.get(handle))
+					.map(|m| m.base.base_color),
+				app.world()
+					.entity(entity)
+					.get::<MeshMaterial3d<StandardMaterial>>()
+			)
+		);
+	}
+
+	#[test]
+	fn leave_standard_assets_untouched() {
+		let handle = new_handle();
+		let mut app = setup([(
+			&handle,
+			StandardMaterial {
+				base_color: Color::LinearRgba(LinearRgba::new(4., 3., 2., 1.)),
+				..default()
+			},
+		)]);
+		let entity = app.world_mut().spawn(MeshMaterial3d(handle.clone())).id();
+		app.insert_resource(StandardMaterials {
+			entities: HashMap::from([(handle.id(), HashSet::from([entity]))]),
+		});
+
+		app.update();
+
+		assert_eq!(
+			vec![(
+				handle.id(),
+				Color::LinearRgba(LinearRgba::new(4., 3., 2., 1.))
+			)],
+			app.world()
+				.resource::<Assets<StandardMaterial>>()
+				.iter()
+				.map(|(id, a)| (id, a.base_color))
+				.collect::<Vec<_>>(),
+		);
+	}
+}

--- a/src/plugins/graphics/src/systems/set_player_position.rs
+++ b/src/plugins/graphics/src/systems/set_player_position.rs
@@ -1,0 +1,126 @@
+use crate::{
+	components::roles::Player,
+	materials::lit_material::{LitMaterial, StandardLitMaterial},
+};
+use bevy::prelude::*;
+
+impl LitMaterial {
+	pub(crate) fn set_player_position(
+		mut materials: ResMut<Assets<StandardLitMaterial>>,
+		players: Query<&Transform, (With<Player>, Changed<Transform>)>,
+	) {
+		let Ok(Transform { translation, .. }) = players.single() else {
+			return;
+		};
+
+		for (_, materials) in materials.iter_mut() {
+			materials.extension.player_position = *translation;
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::{components::roles::Player, materials::lit_material::StandardLitMaterial};
+	use testing::SingleThreadedApp;
+
+	fn setup<const N: usize>(materials: [StandardLitMaterial; N]) -> App {
+		let mut app = App::new().single_threaded(Update);
+		let mut assets = Assets::<StandardLitMaterial>::default();
+
+		for asset in materials {
+			_ = assets.add(asset);
+		}
+
+		app.insert_resource(assets);
+		app.add_systems(Update, LitMaterial::set_player_position);
+
+		app
+	}
+
+	#[test]
+	fn set_position() {
+		let mut app = setup([StandardLitMaterial::default()]);
+		app.world_mut()
+			.spawn((Player, Transform::from_xyz(1., 2., 3.)));
+
+		app.update();
+
+		assert_eq!(
+			vec![Vec3::new(1., 2., 3.)],
+			app.world()
+				.resource::<Assets<StandardLitMaterial>>()
+				.iter()
+				.map(|(_, m)| m.extension.player_position)
+				.collect::<Vec<_>>()
+		);
+	}
+
+	#[test]
+	fn ignore_no_players() {
+		let mut app = setup([StandardLitMaterial::default()]);
+		app.world_mut().spawn(Transform::from_xyz(1., 2., 3.));
+
+		app.update();
+
+		assert_eq!(
+			vec![Vec3::ZERO],
+			app.world()
+				.resource::<Assets<StandardLitMaterial>>()
+				.iter()
+				.map(|(_, m)| m.extension.player_position)
+				.collect::<Vec<_>>()
+		);
+	}
+
+	#[test]
+	fn act_only_once() {
+		let mut app = setup([StandardLitMaterial::default()]);
+		app.world_mut()
+			.spawn((Player, Transform::from_xyz(1., 2., 3.)));
+
+		app.update();
+		for (_, m) in app
+			.world_mut()
+			.resource_mut::<Assets<StandardLitMaterial>>()
+			.iter_mut()
+		{
+			m.extension.player_position = Vec3::ZERO;
+		}
+		app.update();
+
+		assert_eq!(
+			vec![Vec3::ZERO],
+			app.world()
+				.resource::<Assets<StandardLitMaterial>>()
+				.iter()
+				.map(|(_, m)| m.extension.player_position)
+				.collect::<Vec<_>>()
+		);
+	}
+
+	#[test]
+	fn act_again_if_transform_changed() {
+		let mut app = setup([StandardLitMaterial::default()]);
+		let entity = app
+			.world_mut()
+			.spawn((Player, Transform::from_xyz(1., 2., 3.)))
+			.id();
+
+		app.update();
+		app.world_mut()
+			.entity_mut(entity)
+			.insert(Transform::from_xyz(3., 2., 3.));
+		app.update();
+
+		assert_eq!(
+			vec![Vec3::new(3., 2., 3.)],
+			app.world()
+				.resource::<Assets<StandardLitMaterial>>()
+				.iter()
+				.map(|(_, m)| m.extension.player_position)
+				.collect::<Vec<_>>()
+		);
+	}
+}


### PR DESCRIPTION
Added a selective lighting around the player. For now line of sight is not taken into account:
- added a new `LitMaterial` to extend `StandardMaterial` to `StandardLitMaterial`
- `MeshMaterial3d<StandardMaterial>` components are replaced by `MeshMaterial3d<StandardLitMaterial>` components
- a new `lit_shaders.wgsl` is used to extend the normal pbr shading with a linear falloff light around the player