### PR TITLE
Render distances in prepass

### DIFF
--- a/src/plugins/graphics/src/components.rs
+++ b/src/plugins/graphics/src/components.rs
@@ -1,5 +1,6 @@
 pub(crate) mod camera_labels;
 pub(crate) mod child_meshes;
+pub(crate) mod distance_texture;
 pub(crate) mod effect_material_handle;
 pub(crate) mod los;
 pub(crate) mod material_override;

--- a/src/plugins/graphics/src/components/distance_texture.rs
+++ b/src/plugins/graphics/src/components/distance_texture.rs
@@ -1,0 +1,4 @@
+use bevy::{prelude::*, render::extract_component::ExtractComponent};
+
+#[derive(Component, ExtractComponent, Debug, PartialEq, Clone)]
+pub(crate) struct DistanceTexture(pub(crate) Handle<Image>);

--- a/src/plugins/graphics/src/components/los.rs
+++ b/src/plugins/graphics/src/components/los.rs
@@ -1,11 +1,11 @@
 use crate::{
 	components::{camera_labels::WorldPass, distance_texture::DistanceTexture},
 	materials::lit_material::LitMaterial,
-	resources::los_image::{LoSImageAtlas, LoSImageCubemap},
+	resources::los_image::{LoSImageCubemap, LoSImageShared},
 };
 use bevy::{
 	asset::RenderAssetUsages,
-	camera::{RenderTarget, Viewport, visibility::RenderLayers},
+	camera::{RenderTarget, visibility::RenderLayers},
 	ecs::{entity::EntityHashSet, system::StaticSystemParam},
 	image::TextureFormatPixelInfo,
 	prelude::*,
@@ -38,7 +38,9 @@ pub(crate) struct LoSCameras(EntityHashSet);
 #[require(Transform)]
 pub(crate) struct LoSCameraOf(pub(crate) Entity);
 
-/// Basis for LoS cubemap using the following atlas layout
+/// Basis for LoS cubemap assuming the following layout
+///
+/// # As Atlas
 /// ```css
 ///     ┌───┐
 ///     │ U │
@@ -48,6 +50,15 @@ pub(crate) struct LoSCameraOf(pub(crate) Entity);
 ///     │ D │
 ///     └───┘
 /// ```
+///
+/// # Cubemap layers
+/// 0. [`LoS::Right`]
+/// 1. [`LoS::Left`]
+/// 2. [`LoS::Up`]
+/// 3. [`LoS::Down`]
+/// 4. [`LoS::Forward`]
+/// 5. [`LoS::Backward`]
+///
 #[derive(Component, ExtractComponent, Debug, PartialEq, Clone, Copy)]
 #[component(immutable)]
 #[require(
@@ -70,9 +81,7 @@ pub(crate) enum LoS {
 }
 
 impl LoS {
-	pub(crate) const SUB_VIEW: u32 = 1024;
-	pub(crate) const FULL_WIDTH: u32 = LoS::SUB_VIEW * 4;
-	pub(crate) const FULL_HEIGHT: u32 = LoS::SUB_VIEW * 3;
+	pub(crate) const SIDE: u32 = 1024;
 	pub(crate) const FMT: TextureFormat = TextureFormat::R32Float;
 
 	fn looking_to(&self) -> LookingTo {
@@ -104,35 +113,6 @@ impl LoS {
 		}
 	}
 
-	pub(crate) fn atlas_offset(&self) -> UVec2 {
-		match self {
-			LoS::Right => UVec2 {
-				x: LoS::SUB_VIEW * 2,
-				y: LoS::SUB_VIEW,
-			},
-			LoS::Left => UVec2 {
-				x: 0,
-				y: LoS::SUB_VIEW,
-			},
-			LoS::Up => UVec2 {
-				x: LoS::SUB_VIEW,
-				y: 0,
-			},
-			LoS::Down => UVec2 {
-				x: LoS::SUB_VIEW,
-				y: LoS::SUB_VIEW * 2,
-			},
-			LoS::Forward => UVec2 {
-				x: LoS::SUB_VIEW,
-				y: LoS::SUB_VIEW,
-			},
-			LoS::Backward => UVec2 {
-				x: LoS::SUB_VIEW * 3,
-				y: LoS::SUB_VIEW,
-			},
-		}
-	}
-
 	pub(crate) fn cubemap_depth(&self) -> u32 {
 		match self {
 			LoS::Right => 0,
@@ -158,17 +138,19 @@ impl LoS {
 	pub(crate) fn sub_view_data_size() -> Option<usize> {
 		let pixel_size = LoS::FMT.pixel_size().ok()?;
 
-		Some(pixel_size * (LoS::SUB_VIEW * LoS::SUB_VIEW) as usize)
+		Some(pixel_size * (LoS::SIDE * LoS::SIDE) as usize)
 	}
 
-	pub(crate) fn init_atlas(mut commands: ZyheedaCommands, mut images: ResMut<Assets<Image>>) {
-		let mut image =
-			Image::new_target_texture(LoS::FULL_WIDTH, LoS::FULL_HEIGHT, LoS::FMT, None);
+	pub(crate) fn init_shared_depth(
+		mut commands: ZyheedaCommands,
+		mut images: ResMut<Assets<Image>>,
+	) {
+		let mut image = Image::new_target_texture(LoS::SIDE, LoS::SIDE, LoS::FMT, None);
 
 		image.texture_descriptor.usage |= TextureUsages::COPY_SRC;
 		image.texture_descriptor.usage &= !TextureUsages::COPY_DST;
 
-		commands.insert_resource(LoSImageAtlas {
+		commands.insert_resource(LoSImageShared {
 			handle: images.add(image),
 		});
 	}
@@ -176,8 +158,8 @@ impl LoS {
 	pub(crate) fn init_cubemap(mut commands: ZyheedaCommands, mut images: ResMut<Assets<Image>>) {
 		let usage = TextureUsages::TEXTURE_BINDING | TextureUsages::COPY_DST;
 		let size = Extent3d {
-			width: LoS::SUB_VIEW,
-			height: LoS::SUB_VIEW,
+			width: LoS::SIDE,
+			height: LoS::SIDE,
 			depth_or_array_layers: 6,
 		};
 		let data = LoS::sub_view_data_size()
@@ -212,35 +194,26 @@ impl LoS {
 
 impl Prefab<()> for LoS {
 	type TError = Unreachable;
-	type TSystemParam = Res<'static, LoSImageAtlas>;
+	type TSystemParam = Res<'static, LoSImageShared>;
 
 	fn insert_prefab_components(
 		&self,
 		entity: &mut impl PrefabEntityCommands,
-		los_image: StaticSystemParam<Self::TSystemParam>,
+		shared: StaticSystemParam<Self::TSystemParam>,
 	) -> Result<(), Self::TError> {
 		let LookingTo { direction, up } = self.looking_to();
 
 		entity.try_insert((
 			RenderTarget::None {
 				size: UVec2 {
-					x: LoS::FULL_WIDTH,
-					y: LoS::FULL_HEIGHT,
+					x: LoS::SIDE,
+					y: LoS::SIDE,
 				},
 			},
-			DistanceTexture(los_image.handle.clone()),
+			DistanceTexture(shared.handle.clone()),
 			RenderLayers::from(WorldPass),
 			Camera {
 				order: self.order(),
-				viewport: Some(Viewport {
-					physical_position: self.atlas_offset(),
-					physical_size: UVec2 {
-						x: LoS::SUB_VIEW,
-						y: LoS::SUB_VIEW,
-					},
-					..default()
-				}),
-				clear_color: ClearColorConfig::Custom(Color::WHITE),
 				..default()
 			},
 			Transform::default().looking_to(direction, up),

--- a/src/plugins/graphics/src/components/los.rs
+++ b/src/plugins/graphics/src/components/los.rs
@@ -1,11 +1,11 @@
 use crate::{
-	components::camera_labels::WorldPass,
+	components::{camera_labels::WorldPass, distance_texture::DistanceTexture},
 	materials::lit_material::LitMaterial,
 	resources::los_image::{LoSImageAtlas, LoSImageCubemap},
 };
 use bevy::{
 	asset::RenderAssetUsages,
-	camera::{ImageRenderTarget, RenderTarget, Viewport, visibility::RenderLayers},
+	camera::{RenderTarget, Viewport, visibility::RenderLayers},
 	ecs::{entity::EntityHashSet, system::StaticSystemParam},
 	image::TextureFormatPixelInfo,
 	prelude::*,
@@ -73,8 +73,7 @@ impl LoS {
 	pub(crate) const SUB_VIEW: u32 = 1024;
 	pub(crate) const FULL_WIDTH: u32 = LoS::SUB_VIEW * 4;
 	pub(crate) const FULL_HEIGHT: u32 = LoS::SUB_VIEW * 3;
-
-	const FMT: TextureFormat = TextureFormat::R32Float;
+	pub(crate) const FMT: TextureFormat = TextureFormat::R32Float;
 
 	fn looking_to(&self) -> LookingTo {
 		match self {
@@ -223,10 +222,13 @@ impl Prefab<()> for LoS {
 		let LookingTo { direction, up } = self.looking_to();
 
 		entity.try_insert((
-			RenderTarget::Image(ImageRenderTarget {
-				handle: los_image.handle.clone(),
-				scale_factor: 1.,
-			}),
+			RenderTarget::None {
+				size: UVec2 {
+					x: LoS::FULL_WIDTH,
+					y: LoS::FULL_HEIGHT,
+				},
+			},
+			DistanceTexture(los_image.handle.clone()),
 			RenderLayers::from(WorldPass),
 			Camera {
 				order: self.order(),

--- a/src/plugins/graphics/src/lib.rs
+++ b/src/plugins/graphics/src/lib.rs
@@ -170,7 +170,7 @@ where
 			.add_prefab_observer::<LoS, ()>()
 			.add_systems(
 				PostStartup,
-				(UiPass::spawn, LoS::init_atlas, LoS::init_cubemap),
+				(UiPass::spawn, LoS::init_shared_depth, LoS::init_cubemap),
 			)
 			.add_systems(
 				Update,

--- a/src/plugins/graphics/src/resources/distance_pipeline.rs
+++ b/src/plugins/graphics/src/resources/distance_pipeline.rs
@@ -1,7 +1,7 @@
 use crate::{
 	components::{distance_texture::DistanceTexture, los::LoS},
 	materials::lit_material::LitMaterial,
-	resources::los_image::{LoSImageAtlas, LoSImageCubemap},
+	resources::los_image::LoSImageCubemap,
 };
 use bevy::{
 	asset::UntypedAssetId,
@@ -119,7 +119,6 @@ pub(crate) trait SetupDistancePipeline {
 impl SetupDistancePipeline for App {
 	fn setup_distance_pipeline(&mut self) -> &mut Self {
 		self.add_plugins((
-			ExtractResourcePlugin::<LoSImageAtlas>::default(),
 			ExtractResourcePlugin::<LoSImageCubemap>::default(),
 			ExtractComponentPlugin::<DistanceTexture>::default(),
 			ExtractComponentPlugin::<LoS>::default(),
@@ -363,15 +362,14 @@ impl DistancePipeline {
 	}
 
 	fn copy_atlas_to_cubemap(
-		view: ViewQuery<&LoS>,
-		atlas: Res<LoSImageAtlas>,
+		view: ViewQuery<(&LoS, &DistanceTexture)>,
 		cubemap: Res<LoSImageCubemap>,
 		images: Res<RenderAssets<GpuImage>>,
 		mut ctx: RenderContext,
 	) {
-		let los = view.into_inner();
+		let (los, DistanceTexture(src)) = view.into_inner();
 
-		let Some(src) = images.get(&atlas.handle) else {
+		let Some(src) = images.get(src) else {
 			return;
 		};
 
@@ -379,18 +377,13 @@ impl DistancePipeline {
 			return;
 		};
 
-		let offset = los.atlas_offset();
 		let depth = los.cubemap_depth();
 
 		ctx.command_encoder().copy_texture_to_texture(
 			TexelCopyTextureInfo {
 				texture: &src.texture,
 				mip_level: 0,
-				origin: Origin3d {
-					x: offset.x,
-					y: offset.y,
-					z: 0,
-				},
+				origin: Origin3d::default(),
 				aspect: TextureAspect::All,
 			},
 			TexelCopyTextureInfo {
@@ -404,8 +397,8 @@ impl DistancePipeline {
 				aspect: TextureAspect::All,
 			},
 			Extent3d {
-				width: LoS::SUB_VIEW,
-				height: LoS::SUB_VIEW,
+				width: LoS::SIDE,
+				height: LoS::SIDE,
 				depth_or_array_layers: 1,
 			},
 		);

--- a/src/plugins/graphics/src/resources/distance_pipeline.rs
+++ b/src/plugins/graphics/src/resources/distance_pipeline.rs
@@ -1,5 +1,5 @@
 use crate::{
-	components::los::LoS,
+	components::{distance_texture::DistanceTexture, los::LoS},
 	materials::lit_material::LitMaterial,
 	resources::los_image::{LoSImageAtlas, LoSImageCubemap},
 };
@@ -8,7 +8,8 @@ use bevy::{
 	camera::{MainPassResolutionOverride, Viewport},
 	core_pipeline::{
 		Core3dSystems,
-		core_3d::{Opaque3d, Opaque3dBatchSetKey, Opaque3dBinKey, main_opaque_pass_3d},
+		core_3d::{Opaque3d, Opaque3dBatchSetKey, Opaque3dBinKey},
+		deferred::node::late_deferred_prepass,
 		schedule::Core3d,
 	},
 	ecs::system::{StaticSystemParam, SystemParamItem},
@@ -70,14 +71,16 @@ use bevy::{
 			CachedRenderPipelineId,
 			ColorTargetState,
 			ColorWrites,
-			CommandEncoderDescriptor,
 			Extent3d,
 			Face,
 			FragmentState,
+			LoadOp,
+			Operations,
 			Origin3d,
 			PipelineCache,
 			PreparedBindGroup,
 			PrimitiveState,
+			RenderPassColorAttachment,
 			RenderPassDescriptor,
 			RenderPipelineDescriptor,
 			SpecializedMeshPipeline,
@@ -87,7 +90,7 @@ use bevy::{
 			TexelCopyTextureInfo,
 			TextureAspect,
 		},
-		renderer::{RenderContext, RenderDevice, RenderQueue, ViewQuery},
+		renderer::{RenderContext, RenderDevice, ViewQuery},
 		sync_world::MainEntity,
 		texture::GpuImage,
 		view::{
@@ -96,7 +99,6 @@ use bevy::{
 			RenderVisibleEntities,
 			RetainedViewEntity,
 			ViewDepthTexture,
-			ViewTarget,
 		},
 	},
 	shader::ShaderDefVal,
@@ -119,6 +121,7 @@ impl SetupDistancePipeline for App {
 		self.add_plugins((
 			ExtractResourcePlugin::<LoSImageAtlas>::default(),
 			ExtractResourcePlugin::<LoSImageCubemap>::default(),
+			ExtractComponentPlugin::<DistanceTexture>::default(),
 			ExtractComponentPlugin::<LoS>::default(),
 			BinnedRenderPhasePlugin::<Distance, DistancePipeline>::new(RenderDebugFlags::default()),
 		));
@@ -146,75 +149,15 @@ impl SetupDistancePipeline for App {
 				Core3d,
 				(
 					DistancePipeline::draw.pipe(OnError::log),
-					copy_atlas_to_cubemap,
+					DistancePipeline::copy_atlas_to_cubemap,
 				)
 					.chain()
-					.after(main_opaque_pass_3d)
-					.in_set(Core3dSystems::MainPass),
+					.after(late_deferred_prepass)
+					.in_set(Core3dSystems::Prepass),
 			);
 
 		self
 	}
-}
-
-fn copy_atlas_to_cubemap(
-	view: ViewQuery<&LoS>,
-	atlas: Res<LoSImageAtlas>,
-	cubemap: Res<LoSImageCubemap>,
-	images: Res<RenderAssets<GpuImage>>,
-	render_device: Res<RenderDevice>,
-	pending: Res<RenderQueue>,
-) {
-	let los = view.into_inner();
-
-	let Some(src) = images.get(&atlas.handle) else {
-		return;
-	};
-
-	let Some(dst) = images.get(&cubemap.handle) else {
-		return;
-	};
-
-	let offset = los.atlas_offset();
-	let depth = los.cubemap_depth();
-
-	// Immediately copy this texture sub view, otherwise it might not be ready for
-	// cameras rendering `LitMaterial`.
-	// TODO: Find a better way to ensure this.
-
-	let mut commands = render_device.create_command_encoder(&CommandEncoderDescriptor {
-		label: Some("copy_los_atlas_to_cubemap"),
-	});
-
-	commands.copy_texture_to_texture(
-		TexelCopyTextureInfo {
-			texture: &src.texture,
-			mip_level: 0,
-			origin: Origin3d {
-				x: offset.x,
-				y: offset.y,
-				z: 0,
-			},
-			aspect: TextureAspect::All,
-		},
-		TexelCopyTextureInfo {
-			texture: &dst.texture,
-			mip_level: 0,
-			origin: Origin3d {
-				x: 0,
-				y: 0,
-				z: depth,
-			},
-			aspect: TextureAspect::All,
-		},
-		Extent3d {
-			width: LoS::SUB_VIEW,
-			height: LoS::SUB_VIEW,
-			depth_or_array_layers: 1,
-		},
-	);
-
-	pending.submit([commands.finish()]);
 }
 
 #[derive(Resource)]
@@ -373,25 +316,37 @@ impl DistancePipeline {
 			(
 				&ExtractedCamera,
 				&ExtractedView,
-				&ViewTarget,
+				&DistanceTexture,
 				&ViewDepthTexture,
 				Option<&MainPassResolutionOverride>,
 			),
 			With<LoS>,
 		>,
 		phases: Res<ViewBinnedRenderPhases<Distance>>,
+		images: Res<RenderAssets<GpuImage>>,
 		mut ctx: RenderContext,
 	) -> Result<(), RenderError> {
 		let entity = view.entity();
-		let (camera, view, target, depth, resolution_override) = view.into_inner();
+		let (camera, view, DistanceTexture(image), depth, resolution_override) = view.into_inner();
 
+		let Some(image) = images.get(image) else {
+			return Ok(());
+		};
 		let Some(phase) = phases.get(&view.retained_view_entity) else {
 			return Ok(());
 		};
 		let depth_stencil_attachment = Some(depth.get_attachment(StoreOp::Store));
 		let mut render_pass = ctx.begin_tracked_render_pass(RenderPassDescriptor {
 			label: Some("distance pass"),
-			color_attachments: &[Some(target.get_color_attachment())],
+			color_attachments: &[Some(RenderPassColorAttachment {
+				view: &image.texture_view,
+				resolve_target: None,
+				depth_slice: None,
+				ops: Operations {
+					load: LoadOp::Clear(Color::WHITE.to_linear().into()),
+					store: StoreOp::Store,
+				},
+			})],
 			depth_stencil_attachment,
 			..default()
 		});
@@ -405,6 +360,55 @@ impl DistancePipeline {
 		phase
 			.render(&mut render_pass, world, entity)
 			.map_err(RenderError::Draw)
+	}
+
+	fn copy_atlas_to_cubemap(
+		view: ViewQuery<&LoS>,
+		atlas: Res<LoSImageAtlas>,
+		cubemap: Res<LoSImageCubemap>,
+		images: Res<RenderAssets<GpuImage>>,
+		mut ctx: RenderContext,
+	) {
+		let los = view.into_inner();
+
+		let Some(src) = images.get(&atlas.handle) else {
+			return;
+		};
+
+		let Some(dst) = images.get(&cubemap.handle) else {
+			return;
+		};
+
+		let offset = los.atlas_offset();
+		let depth = los.cubemap_depth();
+
+		ctx.command_encoder().copy_texture_to_texture(
+			TexelCopyTextureInfo {
+				texture: &src.texture,
+				mip_level: 0,
+				origin: Origin3d {
+					x: offset.x,
+					y: offset.y,
+					z: 0,
+				},
+				aspect: TextureAspect::All,
+			},
+			TexelCopyTextureInfo {
+				texture: &dst.texture,
+				mip_level: 0,
+				origin: Origin3d {
+					x: 0,
+					y: 0,
+					z: depth,
+				},
+				aspect: TextureAspect::All,
+			},
+			Extent3d {
+				width: LoS::SUB_VIEW,
+				height: LoS::SUB_VIEW,
+				depth_or_array_layers: 1,
+			},
+		);
 	}
 }
 
@@ -501,7 +505,7 @@ impl SpecializedMeshPipeline for DistancePipelineSpecializer {
 			fragment: Some(FragmentState {
 				shader: self.shader.clone(),
 				targets: vec![Some(ColorTargetState {
-					format: key.target_format(),
+					format: LoS::FMT,
 					blend: None,
 					write_mask: ColorWrites::ALL,
 				})],

--- a/src/plugins/graphics/src/resources/los_image.rs
+++ b/src/plugins/graphics/src/resources/los_image.rs
@@ -1,7 +1,7 @@
 use bevy::{prelude::*, render::extract_resource::ExtractResource};
 
-#[derive(Resource, ExtractResource, Debug, PartialEq, Clone)]
-pub(crate) struct LoSImageAtlas {
+#[derive(Resource, Debug, PartialEq, Clone)]
+pub(crate) struct LoSImageShared {
 	pub(crate) handle: Handle<Image>,
 }
 


### PR DESCRIPTION
fixes: #848

Moved rendering of distance cubemap into prepass. To do so the camera received `RenderTarget::None` and the `RenderPassDescriptor`'s `color_attachments` is now set manually. This allows:
- copying of distance atlas to cubemap with the normal bevy gpu render schedule scheme (issue #848)
- removal of render artifacts during movement
- 
Acceptance criteria for #848
- [ok] All LoS cubemap faces are populated reliably in a frame.
- [ok] Lit-material shaders observe the intended cubemap data for every relevant face.
- [fail] The chosen command-buffer ordering is documented and covered by an appropriate validation strategy.
  - No explicit validation done.  The pipeline works correctly by observing the correct shader behavior after moving to the normal bevy copy texture strategy.
  - No additional documentation done, because we use the normal approach used within bevy itself.
- [ok] No regressions in the current line-of-sight obstruction behavior.
