### PR TITLE
Set `Invisible` material to `Visibility::Hidden`

### DIFF
--- a/src/plugins/graphics/src/lib.rs
+++ b/src/plugins/graphics/src/lib.rs
@@ -130,6 +130,7 @@ where
 			.add_observer(EffectMaterialHandle::add_to::<TPhysics::TSkillProjection>)
 			.add_observer(StandardMaterials::track_inserted)
 			.add_observer(StandardMaterials::track_discarded)
+			.add_observer(StandardMaterials::set_invisible_material("Invisible"))
 			.add_systems(
 				Update,
 				(

--- a/src/plugins/graphics/src/observers.rs
+++ b/src/plugins/graphics/src/observers.rs
@@ -1,4 +1,5 @@
 pub(crate) mod add_effect_shader;
 pub(crate) mod insert_render_target;
+pub(crate) mod set_invisible;
 pub(crate) mod track_standard_material;
 pub(crate) mod update_essence_shader;

--- a/src/plugins/graphics/src/observers/set_invisible.rs
+++ b/src/plugins/graphics/src/observers/set_invisible.rs
@@ -1,0 +1,79 @@
+use crate::resources::standard_materials::StandardMaterials;
+use bevy::{ecs::system::IntoObserverSystem, gltf::GltfMaterialName, prelude::*};
+use common::{traits::accessors::get::TryApplyOn, zyheeda_commands::ZyheedaCommands};
+
+impl StandardMaterials {
+	pub(crate) fn set_invisible_material(
+		invisible: &'static str,
+	) -> impl IntoObserverSystem<Add, GltfMaterialName, (), ()> {
+		#[rustfmt::skip]
+		let system = move |
+			on_add: On<Add, GltfMaterialName>,
+			mut commands: ZyheedaCommands,
+			names: Query<&GltfMaterialName>
+		| {
+			let Ok(GltfMaterialName(name)) = names.get(on_add.entity) else {
+				return;
+			};
+
+			if name != invisible {
+				return;
+			}
+
+			commands.try_apply_on(&on_add.entity, |mut e| {
+				e.try_insert(Visibility::Hidden);
+			});
+		};
+
+		IntoObserverSystem::into_system(system)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use testing::SingleThreadedApp;
+
+	fn setup(name: &'static str) -> App {
+		let mut app = App::new().single_threaded(Update);
+
+		app.add_observer(StandardMaterials::set_invisible_material(name));
+
+		app
+	}
+
+	#[test]
+	fn set_invisible() {
+		let mut app = setup("I hide");
+
+		let entity = app
+			.world_mut()
+			.spawn(GltfMaterialName(String::from("I hide")));
+
+		assert_eq!(Some(&Visibility::Hidden), entity.get::<Visibility>());
+	}
+
+	#[test]
+	fn do_not_set_invisible() {
+		let mut app = setup("I hide");
+
+		let entity = app
+			.world_mut()
+			.spawn(GltfMaterialName(String::from("I don't hide")));
+
+		assert_eq!(None, entity.get::<Visibility>());
+	}
+
+	#[test]
+	fn act_only_once() {
+		let mut app = setup("I hide");
+
+		let mut entity = app
+			.world_mut()
+			.spawn(GltfMaterialName(String::from("I hide")));
+		entity.remove::<Visibility>();
+		entity.insert(GltfMaterialName(String::from("I hide")));
+
+		assert_eq!(None, entity.get::<Visibility>());
+	}
+}


### PR DESCRIPTION
collider meshes in gltf assets have the material name "Invisible". To prevent interfering with depth shading we set those to `Visibility::Hidden`.