### PR TITLE
Add States plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3036,6 +3036,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "game_states"
+version = "0.1.0"
+dependencies = [
+ "bevy",
+ "common",
+ "test-case",
+ "testing",
+ "zyheeda_core",
+]
+
+[[package]]
 name = "gethostname"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5165,6 +5176,7 @@ dependencies = [
  "fluent",
  "fluent-syntax",
  "frame_limiter",
+ "game_states",
  "graphics",
  "input",
  "interactive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,13 +69,14 @@ bars = { path = "src/plugins/bars" }
 camera_control = { path = "src/plugins/camera_control" }
 common.workspace = true
 frame_limiter = { path = "src/plugins/frame_limiter" }
+game_states = { path = "src/plugins/game_states" }
+graphics = { path = "src/plugins/graphics" }
 loading = { path = "src/plugins/loading" }
 loadout = { path = "src/plugins/loadout" }
 localization = { path = "src/plugins/localization" }
 map_generation = { path = "src/plugins/map_generation" }
 menu = { path = "src/plugins/menu" }
 movement = { path = "src/plugins/movement" }
-graphics = { path = "src/plugins/graphics" }
 input = { path = "src/plugins/input" }
 interactive = { path = "src/plugins/interactive" }
 path_finding = { path = "src/plugins/path_finding" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use bevy::prelude::*;
 use camera_control::CameraControlPlugin;
 use common::CommonPlugin;
 use frame_limiter::FrameLimiterPlugin;
+use game_states::GameStatesPlugin;
 use graphics::GraphicsPlugin;
 use input::InputPlugin;
 use interactive::InteractivePlugin;
@@ -43,6 +44,7 @@ fn prepare_game(app: &mut App) -> Result<(), ZyheedaAppError> {
 	};
 	let game_dir = home.join("Games").join("Project Zyheeda");
 
+	let game_states = GameStatesPlugin;
 	let loading = LoadingPlugin;
 	let input = InputPlugin::from_plugin(&loading);
 	let localization = LocalizationPlugin::from_plugin(&loading);
@@ -104,6 +106,7 @@ fn prepare_game(app: &mut App) -> Result<(), ZyheedaAppError> {
 		.add_plugins(camera_control)
 		.add_plugins(common)
 		.add_plugins(frame_limiter)
+		.add_plugins(game_states)
 		.add_plugins(graphics)
 		.add_plugins(input)
 		.add_plugins(interactive)

--- a/src/plugins/common/src/traits.rs
+++ b/src/plugins/common/src/traits.rs
@@ -15,6 +15,7 @@ pub mod handles_animations;
 pub mod handles_asset_resource_loading;
 pub mod handles_custom_assets;
 pub mod handles_enemies;
+pub mod handles_game_states;
 pub mod handles_graphics;
 pub mod handles_input;
 pub mod handles_interactive;

--- a/src/plugins/common/src/traits/handles_game_states.rs
+++ b/src/plugins/common/src/traits/handles_game_states.rs
@@ -1,0 +1,64 @@
+use bevy::{
+	ecs::system::{ScheduleSystem, SystemParam},
+	prelude::*,
+};
+use std::collections::HashSet;
+
+pub trait HandlesGameStates:
+	HandlesGameState<ActivityState> + HandlesGameState<SaveState> + HandlesGameState<MenuState>
+{
+}
+
+impl<T> HandlesGameStates for T where
+	T: HandlesGameState<ActivityState> + HandlesGameState<SaveState> + HandlesGameState<MenuState>
+{
+}
+
+pub trait HandlesGameState<T> {
+	type TGameStates: SystemParam + GameStates<T>;
+	type TGameStatesMut: SystemParam + GameStatesMut<T>;
+
+	fn add_systems<M>(
+		app: &mut App,
+		on_state: OnState<T>,
+		systems: impl IntoScheduleConfigs<ScheduleSystem, M>,
+	);
+}
+
+pub trait GameStates<T> {
+	fn game_states(&self) -> &HashSet<T>;
+}
+
+pub trait GameStatesMut<T>: GameStates<T> {
+	fn game_states_mut(&mut self) -> &mut HashSet<T>;
+}
+
+#[derive(Debug, PartialEq)]
+pub enum OnState<T> {
+	Enter(T),
+	Exit(T),
+}
+
+#[derive(Debug, PartialEq)]
+pub enum ActivityState {
+	LoadingEssentialAssets,
+	LoadDependencies,
+	NewGame,
+	Play,
+	Paused,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum SaveState {
+	Save,
+	LoadAttempt,
+	Load,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum MenuState {
+	StartMenu,
+	Inventory,
+	ComboOverview,
+	Settings,
+}

--- a/src/plugins/common/src/traits/handles_game_states.rs
+++ b/src/plugins/common/src/traits/handles_game_states.rs
@@ -1,3 +1,4 @@
+use crate::tools::is_not::IsNot;
 use bevy::{
 	ecs::system::{ScheduleSystem, SystemParam},
 	prelude::*,
@@ -15,27 +16,26 @@ pub trait HandlesGameStates {
 	);
 }
 
-pub trait GameStatesMut: GameStates + AddGameState + RemoveGameState {}
+pub trait GameStatesMut:
+	GameStates + AddGameState<ActivityState> + AddGameState<UIState> + RemoveGameState<UIState>
+{
+}
 
-impl<T> GameStatesMut for T where T: GameStates + AddGameState + RemoveGameState {}
-
-pub trait IntoGameStateAdd: Into<GameState> + game_state::CanAdd {}
-pub trait IntoGameStateRemove: Into<GameState> + game_state::CanRemove {}
+impl<T> GameStatesMut for T where
+	T: GameStates + AddGameState<ActivityState> + AddGameState<UIState> + RemoveGameState<UIState>
+{
+}
 
 pub trait GameStates {
 	fn game_states(&self) -> &HashSet<GameState>;
 }
 
-pub trait AddGameState {
-	fn add_game_state<T>(&mut self, state: T)
-	where
-		T: IntoGameStateAdd;
+pub trait AddGameState<T> {
+	fn add_game_state(&mut self, state: T);
 }
 
-pub trait RemoveGameState {
-	fn remove_game_state<T>(&mut self, state: &T)
-	where
-		T: IntoGameStateRemove + Copy;
+pub trait RemoveGameState<T> {
+	fn remove_game_state(&mut self, state: &T);
 }
 
 #[derive(Debug, PartialEq)]
@@ -51,19 +51,30 @@ pub enum GameState {
 	Read(ReadState),
 }
 
-macro_rules! impl_into_game_state {
-	($wrapper:ident($ty:ty)) => {
-		impl From<$ty> for GameState {
-			fn from(value: $ty) -> Self {
+macro_rules! game_state_conversions {
+	($wrapper:ident($inner:ty)) => {
+		impl From<$inner> for GameState {
+			fn from(value: $inner) -> Self {
 				Self::$wrapper(value)
+			}
+		}
+
+		impl TryFrom<GameState> for $inner {
+			type Error = IsNot<$inner>;
+
+			fn try_from(game_state: GameState) -> Result<$inner, Self::Error> {
+				match game_state {
+					GameState::$wrapper(inner) => Ok(inner),
+					_ => Err(IsNot::target_type()),
+				}
 			}
 		}
 	};
 }
 
-impl_into_game_state!(Activity(ActivityState));
-impl_into_game_state!(IngameUI(UIState));
-impl_into_game_state!(Read(ReadState));
+game_state_conversions!(Activity(ActivityState));
+game_state_conversions!(IngameUI(UIState));
+game_state_conversions!(Read(ReadState));
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum ActivityState {
@@ -88,21 +99,4 @@ pub enum UIState {
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum ReadState {
 	Loading,
-}
-
-mod game_state {
-	use super::*;
-
-	pub trait CanAdd {}
-
-	impl<T> IntoGameStateAdd for T where T: Into<GameState> + CanAdd {}
-
-	impl CanAdd for ActivityState {}
-	impl CanAdd for UIState {}
-
-	pub trait CanRemove {}
-
-	impl<T> IntoGameStateRemove for T where T: Into<GameState> + CanRemove {}
-
-	impl CanRemove for UIState {}
 }

--- a/src/plugins/common/src/traits/handles_game_states.rs
+++ b/src/plugins/common/src/traits/handles_game_states.rs
@@ -4,51 +4,70 @@ use bevy::{
 };
 use std::collections::HashSet;
 
-use crate::traits::thread_safe::ThreadSafe;
-
-pub trait HandlesGameStates:
-	HandlesGameState<ActivityState> + HandlesGameState<SaveState> + HandlesGameState<MenuState>
-{
-}
-
-impl<T> HandlesGameStates for T where
-	T: HandlesGameState<ActivityState> + HandlesGameState<SaveState> + HandlesGameState<MenuState>
-{
-}
-
-pub trait HandlesGameState<T>
-where
-	T: ThreadSafe,
-{
-	type TGameStates: SystemParam + GameStates<T>;
-	type TGameStatesMut: SystemParam + GameStatesMut<T>;
+pub trait HandlesGameStates {
+	type TGameStates: SystemParam + GameStates;
+	type TGameStatesMut: SystemParam + GameStatesMut;
 
 	fn add_systems<M>(
 		app: &mut App,
-		on_state: OnState<T>,
+		on_state: OnGameState,
 		systems: impl IntoScheduleConfigs<ScheduleSystem, M>,
 	);
 }
 
-pub trait GameStates<T>
-where
-	T: ThreadSafe,
-{
-	fn game_states(&self) -> &HashSet<T>;
+pub trait GameStatesMut: GameStates + AddGameState + RemoveGameState {}
+
+impl<T> GameStatesMut for T where T: GameStates + AddGameState + RemoveGameState {}
+
+pub trait IntoGameStateAdd: Into<GameState> + game_state::CanAdd {}
+pub trait IntoGameStateRemove: Into<GameState> + game_state::CanRemove {}
+
+pub trait GameStates {
+	fn game_states(&self) -> &HashSet<GameState>;
 }
 
-pub trait GameStatesMut<T>: GameStates<T>
-where
-	T: ThreadSafe,
-{
-	fn game_states_mut(&mut self) -> &mut HashSet<T>;
+pub trait AddGameState {
+	fn add_game_state<T>(&mut self, state: T)
+	where
+		T: IntoGameStateAdd;
+}
+
+pub trait RemoveGameState {
+	fn remove_game_state<T>(&mut self, state: &T)
+	where
+		T: IntoGameStateRemove;
 }
 
 #[derive(Debug, PartialEq)]
-pub enum OnState<T> {
-	Enter(T),
-	Exit(T),
+pub enum OnGameState {
+	Enter(GameState),
+	Exit(GameState),
 }
+
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
+pub enum GameState {
+	Activity(ActivityState),
+	Save(SaveState),
+	StartUI(StartUIState),
+	IngameUI(IngameUIState),
+	Read(ReadState),
+}
+
+macro_rules! impl_into_game_state {
+	($wrapper:ident($ty:ty)) => {
+		impl From<$ty> for GameState {
+			fn from(value: $ty) -> Self {
+				Self::$wrapper(value)
+			}
+		}
+	};
+}
+
+impl_into_game_state!(Activity(ActivityState));
+impl_into_game_state!(Save(SaveState));
+impl_into_game_state!(StartUI(StartUIState));
+impl_into_game_state!(IngameUI(IngameUIState));
+impl_into_game_state!(Read(ReadState));
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum ActivityState {
@@ -60,16 +79,45 @@ pub enum ActivityState {
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
+pub enum StartUIState {
+	StartMenu,
+	Settings,
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
+pub enum IngameUIState {
+	Hud,
+	Inventory,
+	ComboOverview,
+	Settings,
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum SaveState {
 	Save,
-	LoadAttempt,
 	Load,
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
-pub enum MenuState {
-	StartMenu,
-	Inventory,
-	ComboOverview,
-	Settings,
+pub enum ReadState {
+	Load,
+}
+
+mod game_state {
+	use super::*;
+
+	pub trait CanAdd {}
+
+	impl<T> IntoGameStateAdd for T where T: Into<GameState> + CanAdd {}
+
+	impl CanAdd for ActivityState {}
+	impl CanAdd for SaveState {}
+	impl CanAdd for StartUIState {}
+	impl CanAdd for IngameUIState {}
+
+	pub trait CanRemove {}
+
+	impl<T> IntoGameStateRemove for T where T: Into<GameState> + CanRemove {}
+
+	impl CanRemove for IngameUIState {}
 }

--- a/src/plugins/common/src/traits/handles_game_states.rs
+++ b/src/plugins/common/src/traits/handles_game_states.rs
@@ -1,4 +1,7 @@
-use crate::tools::is_not::IsNot;
+use crate::{
+	tools::is_not::IsNot,
+	traits::iteration::{Iter, IterFinite},
+};
 use bevy::{
 	ecs::system::{ScheduleSystem, SystemParam},
 	prelude::*,
@@ -96,7 +99,40 @@ pub enum UIState {
 	Settings,
 }
 
+impl IterFinite for UIState {
+	fn iterator() -> Iter<Self> {
+		Iter(Some(UIState::Hud))
+	}
+
+	fn next(current: &Iter<Self>) -> Option<Self> {
+		match current.0? {
+			UIState::Hud => Some(UIState::Inventory),
+			UIState::Inventory => Some(UIState::ComboOverview),
+			UIState::ComboOverview => Some(UIState::Settings),
+			UIState::Settings => None,
+		}
+	}
+}
+
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum ReadState {
 	Loading,
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn iter_ui_states() {
+		assert_eq!(
+			vec![
+				UIState::Hud,
+				UIState::Inventory,
+				UIState::ComboOverview,
+				UIState::Settings,
+			],
+			UIState::iterator().take(100).collect::<Vec<_>>()
+		);
+	}
 }

--- a/src/plugins/common/src/traits/handles_game_states.rs
+++ b/src/plugins/common/src/traits/handles_game_states.rs
@@ -4,6 +4,8 @@ use bevy::{
 };
 use std::collections::HashSet;
 
+use crate::traits::thread_safe::ThreadSafe;
+
 pub trait HandlesGameStates:
 	HandlesGameState<ActivityState> + HandlesGameState<SaveState> + HandlesGameState<MenuState>
 {
@@ -14,7 +16,10 @@ impl<T> HandlesGameStates for T where
 {
 }
 
-pub trait HandlesGameState<T> {
+pub trait HandlesGameState<T>
+where
+	T: ThreadSafe,
+{
 	type TGameStates: SystemParam + GameStates<T>;
 	type TGameStatesMut: SystemParam + GameStatesMut<T>;
 
@@ -25,11 +30,17 @@ pub trait HandlesGameState<T> {
 	);
 }
 
-pub trait GameStates<T> {
+pub trait GameStates<T>
+where
+	T: ThreadSafe,
+{
 	fn game_states(&self) -> &HashSet<T>;
 }
 
-pub trait GameStatesMut<T>: GameStates<T> {
+pub trait GameStatesMut<T>: GameStates<T>
+where
+	T: ThreadSafe,
+{
 	fn game_states_mut(&mut self) -> &mut HashSet<T>;
 }
 
@@ -39,7 +50,7 @@ pub enum OnState<T> {
 	Exit(T),
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum ActivityState {
 	LoadingEssentialAssets,
 	LoadDependencies,
@@ -48,14 +59,14 @@ pub enum ActivityState {
 	Paused,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum SaveState {
 	Save,
 	LoadAttempt,
 	Load,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum MenuState {
 	StartMenu,
 	Inventory,

--- a/src/plugins/common/src/traits/handles_game_states.rs
+++ b/src/plugins/common/src/traits/handles_game_states.rs
@@ -35,7 +35,7 @@ pub trait AddGameState {
 pub trait RemoveGameState {
 	fn remove_game_state<T>(&mut self, state: &T)
 	where
-		T: IntoGameStateRemove;
+		T: IntoGameStateRemove + Copy;
 }
 
 #[derive(Debug, PartialEq)]
@@ -47,9 +47,7 @@ pub enum OnGameState {
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum GameState {
 	Activity(ActivityState),
-	Save(SaveState),
-	StartUI(StartUIState),
-	IngameUI(IngameUIState),
+	IngameUI(UIState),
 	Read(ReadState),
 }
 
@@ -64,28 +62,23 @@ macro_rules! impl_into_game_state {
 }
 
 impl_into_game_state!(Activity(ActivityState));
-impl_into_game_state!(Save(SaveState));
-impl_into_game_state!(StartUI(StartUIState));
-impl_into_game_state!(IngameUI(IngameUIState));
+impl_into_game_state!(IngameUI(UIState));
 impl_into_game_state!(Read(ReadState));
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum ActivityState {
 	LoadingEssentialAssets,
 	LoadDependencies,
+	StartScreen,
 	NewGame,
 	Play,
 	Paused,
+	Save,
+	Load,
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
-pub enum StartUIState {
-	StartMenu,
-	Settings,
-}
-
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
-pub enum IngameUIState {
+pub enum UIState {
 	Hud,
 	Inventory,
 	ComboOverview,
@@ -93,14 +86,8 @@ pub enum IngameUIState {
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
-pub enum SaveState {
-	Save,
-	Load,
-}
-
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum ReadState {
-	Load,
+	Loading,
 }
 
 mod game_state {
@@ -111,13 +98,11 @@ mod game_state {
 	impl<T> IntoGameStateAdd for T where T: Into<GameState> + CanAdd {}
 
 	impl CanAdd for ActivityState {}
-	impl CanAdd for SaveState {}
-	impl CanAdd for StartUIState {}
-	impl CanAdd for IngameUIState {}
+	impl CanAdd for UIState {}
 
 	pub trait CanRemove {}
 
 	impl<T> IntoGameStateRemove for T where T: Into<GameState> + CanRemove {}
 
-	impl CanRemove for IngameUIState {}
+	impl CanRemove for UIState {}
 }

--- a/src/plugins/game_states/Cargo.toml
+++ b/src/plugins/game_states/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "game_states"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+# external
+bevy.workspace = true
+
+# internal
+common.workspace = true
+zyheeda_core.workspace = true
+
+[dev-dependencies]
+# external
+test-case.workspace = true
+
+# internal
+testing.workspace = true

--- a/src/plugins/game_states/src/lib.rs
+++ b/src/plugins/game_states/src/lib.rs
@@ -4,18 +4,24 @@ mod system_params;
 
 use crate::{
 	resources::game_state_context::GameStatesContext,
-	states::GameStateInternal,
-	system_params::{game_states_read::GameStatesRead, game_states_write::GameStatesWrite},
+	states::activity::Activity,
+	system_params::{
+		game_states_read::GameStatesRead,
+		game_states_write::GameStatesWrite,
+		ui_states::UIStates,
+	},
 };
 use bevy::{ecs::system::ScheduleSystem, prelude::*};
-use common::traits::handles_game_states::{HandlesGameStates, OnGameState};
+use common::traits::handles_game_states::{GameState, HandlesGameStates, OnGameState};
 
 pub struct GameStatesPlugin;
 
 impl Plugin for GameStatesPlugin {
 	fn build(&self, app: &mut App) {
 		app.init_resource::<GameStatesContext>()
-			.init_state::<GameStateInternal>();
+			.init_state::<Activity>();
+
+		UIStates::init(app);
 	}
 }
 
@@ -29,11 +35,23 @@ impl HandlesGameStates for GameStatesPlugin {
 		systems: impl IntoScheduleConfigs<ScheduleSystem, M>,
 	) {
 		match on_state {
-			OnGameState::Enter(state) => {
-				app.add_systems(OnEnter(GameStateInternal(state)), systems);
+			OnGameState::Enter(GameState::Activity(activity)) => {
+				app.add_systems(OnEnter(Activity::from(activity)), systems);
 			}
-			OnGameState::Exit(state) => {
-				app.add_systems(OnExit(GameStateInternal(state)), systems);
+			OnGameState::Exit(GameState::Activity(activity)) => {
+				app.add_systems(OnExit(Activity::from(activity)), systems);
+			}
+			OnGameState::Enter(GameState::Read(read)) => {
+				app.add_systems(OnEnter(Activity::from(read)), systems);
+			}
+			OnGameState::Exit(GameState::Read(read)) => {
+				app.add_systems(OnExit(Activity::from(read)), systems);
+			}
+			OnGameState::Enter(GameState::IngameUI(ui)) => {
+				UIStates::on_enter(app, ui, systems);
+			}
+			OnGameState::Exit(GameState::IngameUI(ui)) => {
+				UIStates::on_exit(app, ui, systems);
 			}
 		}
 	}

--- a/src/plugins/game_states/src/lib.rs
+++ b/src/plugins/game_states/src/lib.rs
@@ -1,6 +1,7 @@
 mod resources;
 mod states;
 mod system_params;
+mod systems;
 
 use crate::{
 	resources::game_state_context::GameStatesContext,
@@ -12,18 +13,31 @@ use crate::{
 	},
 };
 use bevy::{ecs::system::ScheduleSystem, prelude::*};
-use common::traits::handles_game_states::{GameState, HandlesGameStates, OnGameState};
+use common::{
+	tools::plugin_system_set::PluginSystemSet,
+	traits::{
+		handles_game_states::{GameState, HandlesGameStates, OnGameState},
+		system_set_definition::SystemSetDefinition,
+	},
+};
 
 pub struct GameStatesPlugin;
 
 impl Plugin for GameStatesPlugin {
 	fn build(&self, app: &mut App) {
-		app.init_resource::<GameStatesContext>()
-			.init_state::<Activity>();
-
 		UIStates::init(app);
+
+		app.init_resource::<GameStatesContext>()
+			.init_state::<Activity>()
+			.add_systems(
+				Update,
+				GameStatesContext::sync_states.in_set(GameStateSystems),
+			);
 	}
 }
+
+#[derive(SystemSet, Debug, PartialEq, Eq, Hash, Clone, Copy)]
+pub struct GameStateSystems;
 
 impl HandlesGameStates for GameStatesPlugin {
 	type TGameStates = GameStatesRead<'static>;
@@ -55,4 +69,10 @@ impl HandlesGameStates for GameStatesPlugin {
 			}
 		}
 	}
+}
+
+impl SystemSetDefinition for GameStatesPlugin {
+	type TSystemSet = GameStateSystems;
+
+	const SYSTEMS: PluginSystemSet<Self::TSystemSet> = PluginSystemSet::from_set(GameStateSystems);
 }

--- a/src/plugins/game_states/src/lib.rs
+++ b/src/plugins/game_states/src/lib.rs
@@ -3,41 +3,37 @@ mod states;
 mod system_params;
 
 use crate::{
-	states::GameState,
+	resources::game_state_context::GameStatesContext,
+	states::GameStateInternal,
 	system_params::{game_states_read::GameStatesRead, game_states_write::GameStatesWrite},
 };
 use bevy::{ecs::system::ScheduleSystem, prelude::*};
-use common::traits::{
-	handles_game_states::{HandlesGameState, OnState},
-	thread_safe::ThreadSafe,
-};
+use common::traits::handles_game_states::{HandlesGameStates, OnGameState};
 
 pub struct GameStatesPlugin;
 
 impl Plugin for GameStatesPlugin {
 	fn build(&self, app: &mut App) {
-		app.init_state::<GameState>();
+		app.init_resource::<GameStatesContext>()
+			.init_state::<GameStateInternal>();
 	}
 }
 
-impl<T> HandlesGameState<T> for GameStatesPlugin
-where
-	T: ThreadSafe + Into<GameState>,
-{
-	type TGameStates = GameStatesRead<'static, T>;
-	type TGameStatesMut = GameStatesWrite<'static, T>;
+impl HandlesGameStates for GameStatesPlugin {
+	type TGameStates = GameStatesRead<'static>;
+	type TGameStatesMut = GameStatesWrite<'static>;
 
 	fn add_systems<M>(
 		app: &mut App,
-		on_state: OnState<T>,
+		on_state: OnGameState,
 		systems: impl IntoScheduleConfigs<ScheduleSystem, M>,
 	) {
 		match on_state {
-			OnState::Enter(state) => {
-				app.add_systems(OnEnter(state.into()), systems);
+			OnGameState::Enter(state) => {
+				app.add_systems(OnEnter(GameStateInternal(state)), systems);
 			}
-			OnState::Exit(state) => {
-				app.add_systems(OnExit(state.into()), systems);
+			OnGameState::Exit(state) => {
+				app.add_systems(OnExit(GameStateInternal(state)), systems);
 			}
 		}
 	}

--- a/src/plugins/game_states/src/lib.rs
+++ b/src/plugins/game_states/src/lib.rs
@@ -1,7 +1,44 @@
-use bevy::prelude::*;
+mod resources;
+mod states;
+mod system_params;
+
+use crate::{
+	states::GameState,
+	system_params::{game_states_read::GameStatesRead, game_states_write::GameStatesWrite},
+};
+use bevy::{ecs::system::ScheduleSystem, prelude::*};
+use common::traits::{
+	handles_game_states::{HandlesGameState, OnState},
+	thread_safe::ThreadSafe,
+};
 
 pub struct GameStatesPlugin;
 
 impl Plugin for GameStatesPlugin {
-	fn build(&self, _: &mut App) {}
+	fn build(&self, app: &mut App) {
+		app.init_state::<GameState>();
+	}
+}
+
+impl<T> HandlesGameState<T> for GameStatesPlugin
+where
+	T: ThreadSafe + Into<GameState>,
+{
+	type TGameStates = GameStatesRead<'static, T>;
+	type TGameStatesMut = GameStatesWrite<'static, T>;
+
+	fn add_systems<M>(
+		app: &mut App,
+		on_state: OnState<T>,
+		systems: impl IntoScheduleConfigs<ScheduleSystem, M>,
+	) {
+		match on_state {
+			OnState::Enter(state) => {
+				app.add_systems(OnEnter(state.into()), systems);
+			}
+			OnState::Exit(state) => {
+				app.add_systems(OnExit(state.into()), systems);
+			}
+		}
+	}
 }

--- a/src/plugins/game_states/src/lib.rs
+++ b/src/plugins/game_states/src/lib.rs
@@ -1,0 +1,7 @@
+use bevy::prelude::*;
+
+pub struct GameStatesPlugin;
+
+impl Plugin for GameStatesPlugin {
+	fn build(&self, _: &mut App) {}
+}

--- a/src/plugins/game_states/src/resources.rs
+++ b/src/plugins/game_states/src/resources.rs
@@ -1,0 +1,1 @@
+pub(crate) mod game_state_context;

--- a/src/plugins/game_states/src/resources/game_state_context.rs
+++ b/src/plugins/game_states/src/resources/game_state_context.rs
@@ -1,0 +1,11 @@
+use bevy::prelude::*;
+use common::traits::thread_safe::ThreadSafe;
+use std::collections::HashSet;
+
+#[derive(Resource, Default)]
+pub(crate) struct GameStatesContext<T>
+where
+	T: ThreadSafe,
+{
+	pub(crate) states: HashSet<T>,
+}

--- a/src/plugins/game_states/src/resources/game_state_context.rs
+++ b/src/plugins/game_states/src/resources/game_state_context.rs
@@ -1,11 +1,8 @@
 use bevy::prelude::*;
-use common::traits::thread_safe::ThreadSafe;
+use common::traits::handles_game_states::GameState;
 use std::collections::HashSet;
 
 #[derive(Resource, Default)]
-pub(crate) struct GameStatesContext<T>
-where
-	T: ThreadSafe,
-{
-	pub(crate) states: HashSet<T>,
+pub(crate) struct GameStatesContext {
+	pub(crate) states: HashSet<GameState>,
 }

--- a/src/plugins/game_states/src/states.rs
+++ b/src/plugins/game_states/src/states.rs
@@ -1,33 +1,11 @@
 use bevy::prelude::*;
-use common::traits::handles_game_states::{ActivityState, MenuState, SaveState};
+use common::traits::handles_game_states::{ActivityState, GameState};
 
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, States)]
-pub(crate) enum GameState {
-	Activity(ActivityState),
-	Save(SaveState),
-	Menu(MenuState),
-}
+#[derive(States, Debug, PartialEq, Eq, Hash, Clone, Copy)]
+pub(crate) struct GameStateInternal(pub(crate) GameState);
 
-impl Default for GameState {
+impl Default for GameStateInternal {
 	fn default() -> Self {
-		Self::Activity(ActivityState::LoadingEssentialAssets)
-	}
-}
-
-impl From<ActivityState> for GameState {
-	fn from(state: ActivityState) -> Self {
-		Self::Activity(state)
-	}
-}
-
-impl From<SaveState> for GameState {
-	fn from(state: SaveState) -> Self {
-		Self::Save(state)
-	}
-}
-
-impl From<MenuState> for GameState {
-	fn from(state: MenuState) -> Self {
-		Self::Menu(state)
+		Self(GameState::Activity(ActivityState::LoadingEssentialAssets))
 	}
 }

--- a/src/plugins/game_states/src/states.rs
+++ b/src/plugins/game_states/src/states.rs
@@ -1,11 +1,2 @@
-use bevy::prelude::*;
-use common::traits::handles_game_states::{ActivityState, GameState};
-
-#[derive(States, Debug, PartialEq, Eq, Hash, Clone, Copy)]
-pub(crate) struct GameStateInternal(pub(crate) GameState);
-
-impl Default for GameStateInternal {
-	fn default() -> Self {
-		Self(GameState::Activity(ActivityState::LoadingEssentialAssets))
-	}
-}
+pub(crate) mod activity;
+pub(crate) mod ui;

--- a/src/plugins/game_states/src/states.rs
+++ b/src/plugins/game_states/src/states.rs
@@ -1,0 +1,33 @@
+use bevy::prelude::*;
+use common::traits::handles_game_states::{ActivityState, MenuState, SaveState};
+
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, States)]
+pub(crate) enum GameState {
+	Activity(ActivityState),
+	Save(SaveState),
+	Menu(MenuState),
+}
+
+impl Default for GameState {
+	fn default() -> Self {
+		Self::Activity(ActivityState::LoadingEssentialAssets)
+	}
+}
+
+impl From<ActivityState> for GameState {
+	fn from(state: ActivityState) -> Self {
+		Self::Activity(state)
+	}
+}
+
+impl From<SaveState> for GameState {
+	fn from(state: SaveState) -> Self {
+		Self::Save(state)
+	}
+}
+
+impl From<MenuState> for GameState {
+	fn from(state: MenuState) -> Self {
+		Self::Menu(state)
+	}
+}

--- a/src/plugins/game_states/src/states/activity.rs
+++ b/src/plugins/game_states/src/states/activity.rs
@@ -1,0 +1,39 @@
+use bevy::prelude::*;
+use common::traits::handles_game_states::{ActivityState, ReadState};
+
+#[derive(States, Debug, PartialEq, Eq, Hash, Clone, Copy, Default)]
+pub(crate) enum Activity {
+	#[default]
+	LoadingEssentialAssets,
+	LoadDependencies,
+	StartScreen,
+	NewGame,
+	Play,
+	Paused,
+	Save,
+	Load,
+	Loading,
+}
+
+impl From<ActivityState> for Activity {
+	fn from(value: ActivityState) -> Self {
+		match value {
+			ActivityState::LoadingEssentialAssets => Self::LoadingEssentialAssets,
+			ActivityState::LoadDependencies => Self::LoadDependencies,
+			ActivityState::StartScreen => Self::StartScreen,
+			ActivityState::NewGame => Self::NewGame,
+			ActivityState::Play => Self::Play,
+			ActivityState::Paused => Self::Paused,
+			ActivityState::Save => Self::Save,
+			ActivityState::Load => Self::Load,
+		}
+	}
+}
+
+impl From<ReadState> for Activity {
+	fn from(value: ReadState) -> Self {
+		match value {
+			ReadState::Loading => Self::Loading,
+		}
+	}
+}

--- a/src/plugins/game_states/src/states/activity.rs
+++ b/src/plugins/game_states/src/states/activity.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use common::traits::handles_game_states::{ActivityState, ReadState};
+use common::traits::handles_game_states::{ActivityState, GameState, ReadState};
 
 #[derive(States, Debug, PartialEq, Eq, Hash, Clone, Copy, Default)]
 pub(crate) enum Activity {
@@ -16,8 +16,8 @@ pub(crate) enum Activity {
 }
 
 impl From<ActivityState> for Activity {
-	fn from(value: ActivityState) -> Self {
-		match value {
+	fn from(activity: ActivityState) -> Self {
+		match activity {
 			ActivityState::LoadingEssentialAssets => Self::LoadingEssentialAssets,
 			ActivityState::LoadDependencies => Self::LoadDependencies,
 			ActivityState::StartScreen => Self::StartScreen,
@@ -31,9 +31,28 @@ impl From<ActivityState> for Activity {
 }
 
 impl From<ReadState> for Activity {
-	fn from(value: ReadState) -> Self {
-		match value {
+	fn from(read: ReadState) -> Self {
+		match read {
 			ReadState::Loading => Self::Loading,
+		}
+	}
+}
+
+impl From<&Activity> for GameState {
+	fn from(activity: &Activity) -> Self {
+		use ActivityState::*;
+		use ReadState::*;
+
+		match activity {
+			Activity::LoadingEssentialAssets => Self::Activity(LoadingEssentialAssets),
+			Activity::LoadDependencies => Self::Activity(LoadDependencies),
+			Activity::StartScreen => Self::Activity(StartScreen),
+			Activity::NewGame => Self::Activity(NewGame),
+			Activity::Play => Self::Activity(Play),
+			Activity::Paused => Self::Activity(Paused),
+			Activity::Save => Self::Activity(Save),
+			Activity::Load => Self::Activity(Load),
+			Activity::Loading => Self::Read(Loading),
 		}
 	}
 }

--- a/src/plugins/game_states/src/states/ui.rs
+++ b/src/plugins/game_states/src/states/ui.rs
@@ -1,0 +1,29 @@
+use bevy::prelude::*;
+
+#[derive(States, Debug, PartialEq, Eq, Hash, Clone, Default)]
+pub(crate) enum Hud {
+	#[default]
+	Off,
+	On,
+}
+
+#[derive(States, Debug, PartialEq, Eq, Hash, Clone, Default)]
+pub(crate) enum Inventory {
+	#[default]
+	Off,
+	On,
+}
+
+#[derive(States, Debug, PartialEq, Eq, Hash, Clone, Default)]
+pub(crate) enum ComboOverview {
+	#[default]
+	Off,
+	On,
+}
+
+#[derive(States, Debug, PartialEq, Eq, Hash, Clone, Default)]
+pub(crate) enum Settings {
+	#[default]
+	Off,
+	On,
+}

--- a/src/plugins/game_states/src/system_params.rs
+++ b/src/plugins/game_states/src/system_params.rs
@@ -1,0 +1,2 @@
+pub(crate) mod game_states_read;
+pub(crate) mod game_states_write;

--- a/src/plugins/game_states/src/system_params.rs
+++ b/src/plugins/game_states/src/system_params.rs
@@ -1,2 +1,3 @@
 pub(crate) mod game_states_read;
 pub(crate) mod game_states_write;
+pub(crate) mod ui_states;

--- a/src/plugins/game_states/src/system_params/game_states_read.rs
+++ b/src/plugins/game_states/src/system_params/game_states_read.rs
@@ -1,0 +1,21 @@
+use crate::resources::game_state_context::GameStatesContext;
+use bevy::{ecs::system::SystemParam, prelude::*};
+use common::traits::{handles_game_states::GameStates, thread_safe::ThreadSafe};
+use std::collections::HashSet;
+
+#[derive(SystemParam)]
+pub struct GameStatesRead<'w, T>
+where
+	T: ThreadSafe,
+{
+	ctx: ResMut<'w, GameStatesContext<T>>,
+}
+
+impl<T> GameStates<T> for GameStatesRead<'_, T>
+where
+	T: ThreadSafe,
+{
+	fn game_states(&self) -> &HashSet<T> {
+		&self.ctx.states
+	}
+}

--- a/src/plugins/game_states/src/system_params/game_states_read.rs
+++ b/src/plugins/game_states/src/system_params/game_states_read.rs
@@ -1,21 +1,15 @@
 use crate::resources::game_state_context::GameStatesContext;
 use bevy::{ecs::system::SystemParam, prelude::*};
-use common::traits::{handles_game_states::GameStates, thread_safe::ThreadSafe};
+use common::traits::handles_game_states::{GameState, GameStates};
 use std::collections::HashSet;
 
 #[derive(SystemParam)]
-pub struct GameStatesRead<'w, T>
-where
-	T: ThreadSafe,
-{
-	ctx: ResMut<'w, GameStatesContext<T>>,
+pub struct GameStatesRead<'w> {
+	ctx: Res<'w, GameStatesContext>,
 }
 
-impl<T> GameStates<T> for GameStatesRead<'_, T>
-where
-	T: ThreadSafe,
-{
-	fn game_states(&self) -> &HashSet<T> {
+impl GameStates for GameStatesRead<'_> {
+	fn game_states(&self) -> &HashSet<GameState> {
 		&self.ctx.states
 	}
 }

--- a/src/plugins/game_states/src/system_params/game_states_write.rs
+++ b/src/plugins/game_states/src/system_params/game_states_write.rs
@@ -1,0 +1,33 @@
+use crate::resources::game_state_context::GameStatesContext;
+use bevy::{ecs::system::SystemParam, prelude::*};
+use common::traits::{
+	handles_game_states::{GameStates, GameStatesMut},
+	thread_safe::ThreadSafe,
+};
+use std::collections::HashSet;
+
+#[derive(SystemParam)]
+pub struct GameStatesWrite<'w, T>
+where
+	T: ThreadSafe,
+{
+	ctx: ResMut<'w, GameStatesContext<T>>,
+}
+
+impl<T> GameStates<T> for GameStatesWrite<'_, T>
+where
+	T: ThreadSafe,
+{
+	fn game_states(&self) -> &HashSet<T> {
+		&self.ctx.states
+	}
+}
+
+impl<T> GameStatesMut<T> for GameStatesWrite<'_, T>
+where
+	T: ThreadSafe,
+{
+	fn game_states_mut(&mut self) -> &mut HashSet<T> {
+		&mut self.ctx.states
+	}
+}

--- a/src/plugins/game_states/src/system_params/game_states_write.rs
+++ b/src/plugins/game_states/src/system_params/game_states_write.rs
@@ -5,12 +5,12 @@ use crate::{
 };
 use bevy::{ecs::system::SystemParam, prelude::*};
 use common::traits::handles_game_states::{
+	ActivityState,
 	AddGameState,
 	GameState,
 	GameStates,
-	IntoGameStateAdd,
-	IntoGameStateRemove,
 	RemoveGameState,
+	UIState,
 };
 use std::collections::HashSet;
 
@@ -27,32 +27,21 @@ impl GameStates for GameStatesWrite<'_> {
 	}
 }
 
-const REMOVE_ACTIVITY_NOT_ALLOWED: &str = "Activity game state cannot be removed";
-const MODIFY_READ_NOT_ALLOWED: &str = "Read game state cannot be set via public interface";
-
-impl AddGameState for GameStatesWrite<'_> {
-	fn add_game_state<T>(&mut self, state: T)
-	where
-		T: IntoGameStateAdd,
-	{
-		match state.into() {
-			GameState::Activity(activity) => self.activity.set(Activity::from(activity)),
-			GameState::IngameUI(ui) => self.ui.set_on(ui),
-			GameState::Read(_) => unreachable!("{MODIFY_READ_NOT_ALLOWED}"),
-		}
+impl AddGameState<ActivityState> for GameStatesWrite<'_> {
+	fn add_game_state(&mut self, activity: ActivityState) {
+		self.activity.set(Activity::from(activity));
 	}
 }
 
-impl RemoveGameState for GameStatesWrite<'_> {
-	fn remove_game_state<T>(&mut self, state: &T)
-	where
-		T: IntoGameStateRemove + Copy,
-	{
-		match (*state).into() {
-			GameState::Activity(_) => unreachable!("{REMOVE_ACTIVITY_NOT_ALLOWED}"),
-			GameState::IngameUI(ui) => self.ui.set_off(ui),
-			GameState::Read(_) => unreachable!("{MODIFY_READ_NOT_ALLOWED}"),
-		}
+impl AddGameState<UIState> for GameStatesWrite<'_> {
+	fn add_game_state(&mut self, ui: UIState) {
+		self.ui.set_on(ui);
+	}
+}
+
+impl RemoveGameState<UIState> for GameStatesWrite<'_> {
+	fn remove_game_state(&mut self, ui: &UIState) {
+		self.ui.set_off(ui);
 	}
 }
 
@@ -106,7 +95,8 @@ mod tests {
 	#[test_case(UIState::Settings, Settings::On; "settings")]
 	fn add_state<T, U>(state: T, expected: U) -> Result<(), RunSystemError>
 	where
-		T: IntoGameStateAdd + Copy + ThreadSafe,
+		for<'w> GameStatesWrite<'w>: AddGameState<T>,
+		T: Copy + ThreadSafe,
 		U: FreelyMutableState,
 	{
 		let mut app = setup();
@@ -127,9 +117,8 @@ mod tests {
 	#[test_case(UIState::Inventory, Inventory::Off; "inventory")]
 	#[test_case(UIState::ComboOverview, ComboOverview::Off; "combos")]
 	#[test_case(UIState::Settings, Settings::Off; "settings")]
-	fn remove_state<T, U>(state: T, expected: U) -> Result<(), RunSystemError>
+	fn remove_state<U>(state: UIState, expected: U) -> Result<(), RunSystemError>
 	where
-		T: IntoGameStateRemove + Copy + ThreadSafe,
 		U: FreelyMutableState,
 	{
 		let mut app = setup();

--- a/src/plugins/game_states/src/system_params/game_states_write.rs
+++ b/src/plugins/game_states/src/system_params/game_states_write.rs
@@ -1,7 +1,7 @@
 use crate::{
 	resources::game_state_context::GameStatesContext,
 	states::activity::Activity,
-	system_params::ui_states::UIStates,
+	system_params::ui_states::UIStatesMut,
 };
 use bevy::{ecs::system::SystemParam, prelude::*};
 use common::traits::handles_game_states::{
@@ -18,7 +18,7 @@ use std::collections::HashSet;
 pub struct GameStatesWrite<'w> {
 	ctx: ResMut<'w, GameStatesContext>,
 	activity: ResMut<'w, NextState<Activity>>,
-	ui: UIStates<'w>,
+	ui: UIStatesMut<'w>,
 }
 
 impl GameStates for GameStatesWrite<'_> {
@@ -48,7 +48,10 @@ impl RemoveGameState<UIState> for GameStatesWrite<'_> {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::states::ui::{ComboOverview, Hud, Inventory, Settings};
+	use crate::{
+		states::ui::{ComboOverview, Hud, Inventory, Settings},
+		system_params::ui_states::UIStates,
+	};
 	use bevy::{
 		ecs::system::{RunSystemError, RunSystemOnce},
 		state::{app::StatesPlugin, state::FreelyMutableState},

--- a/src/plugins/game_states/src/system_params/game_states_write.rs
+++ b/src/plugins/game_states/src/system_params/game_states_write.rs
@@ -1,33 +1,38 @@
 use crate::resources::game_state_context::GameStatesContext;
 use bevy::{ecs::system::SystemParam, prelude::*};
-use common::traits::{
-	handles_game_states::{GameStates, GameStatesMut},
-	thread_safe::ThreadSafe,
+use common::traits::handles_game_states::{
+	AddGameState,
+	GameState,
+	GameStates,
+	IntoGameStateAdd,
+	IntoGameStateRemove,
+	RemoveGameState,
 };
 use std::collections::HashSet;
 
 #[derive(SystemParam)]
-pub struct GameStatesWrite<'w, T>
-where
-	T: ThreadSafe,
-{
-	ctx: ResMut<'w, GameStatesContext<T>>,
+pub struct GameStatesWrite<'w> {
+	ctx: ResMut<'w, GameStatesContext>,
 }
 
-impl<T> GameStates<T> for GameStatesWrite<'_, T>
-where
-	T: ThreadSafe,
-{
-	fn game_states(&self) -> &HashSet<T> {
+impl GameStates for GameStatesWrite<'_> {
+	fn game_states(&self) -> &HashSet<GameState> {
 		&self.ctx.states
 	}
 }
 
-impl<T> GameStatesMut<T> for GameStatesWrite<'_, T>
-where
-	T: ThreadSafe,
-{
-	fn game_states_mut(&mut self) -> &mut HashSet<T> {
-		&mut self.ctx.states
+impl AddGameState for GameStatesWrite<'_> {
+	fn add_game_state<T>(&mut self, _: T)
+	where
+		T: IntoGameStateAdd,
+	{
+	}
+}
+
+impl RemoveGameState for GameStatesWrite<'_> {
+	fn remove_game_state<T>(&mut self, _: &T)
+	where
+		T: IntoGameStateRemove,
+	{
 	}
 }

--- a/src/plugins/game_states/src/system_params/game_states_write.rs
+++ b/src/plugins/game_states/src/system_params/game_states_write.rs
@@ -1,4 +1,8 @@
-use crate::resources::game_state_context::GameStatesContext;
+use crate::{
+	resources::game_state_context::GameStatesContext,
+	states::activity::Activity,
+	system_params::ui_states::UIStates,
+};
 use bevy::{ecs::system::SystemParam, prelude::*};
 use common::traits::handles_game_states::{
 	AddGameState,
@@ -13,6 +17,8 @@ use std::collections::HashSet;
 #[derive(SystemParam)]
 pub struct GameStatesWrite<'w> {
 	ctx: ResMut<'w, GameStatesContext>,
+	activity: ResMut<'w, NextState<Activity>>,
+	ui: UIStates<'w>,
 }
 
 impl GameStates for GameStatesWrite<'_> {
@@ -21,18 +27,122 @@ impl GameStates for GameStatesWrite<'_> {
 	}
 }
 
+const REMOVE_ACTIVITY_NOT_ALLOWED: &str = "Activity game state cannot be removed";
+const MODIFY_READ_NOT_ALLOWED: &str = "Read game state cannot be set via public interface";
+
 impl AddGameState for GameStatesWrite<'_> {
-	fn add_game_state<T>(&mut self, _: T)
+	fn add_game_state<T>(&mut self, state: T)
 	where
 		T: IntoGameStateAdd,
 	{
+		match state.into() {
+			GameState::Activity(activity) => self.activity.set(Activity::from(activity)),
+			GameState::IngameUI(ui) => self.ui.set_on(ui),
+			GameState::Read(_) => unreachable!("{MODIFY_READ_NOT_ALLOWED}"),
+		}
 	}
 }
 
 impl RemoveGameState for GameStatesWrite<'_> {
-	fn remove_game_state<T>(&mut self, _: &T)
+	fn remove_game_state<T>(&mut self, state: &T)
 	where
-		T: IntoGameStateRemove,
+		T: IntoGameStateRemove + Copy,
 	{
+		match (*state).into() {
+			GameState::Activity(_) => unreachable!("{REMOVE_ACTIVITY_NOT_ALLOWED}"),
+			GameState::IngameUI(ui) => self.ui.set_off(ui),
+			GameState::Read(_) => unreachable!("{MODIFY_READ_NOT_ALLOWED}"),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::states::ui::{ComboOverview, Hud, Inventory, Settings};
+	use bevy::{
+		ecs::system::{RunSystemError, RunSystemOnce},
+		state::{app::StatesPlugin, state::FreelyMutableState},
+	};
+	use common::traits::{
+		handles_game_states::{ActivityState, UIState},
+		thread_safe::ThreadSafe,
+	};
+	use test_case::test_case;
+	use testing::SingleThreadedApp;
+
+	fn setup() -> App {
+		let mut app = App::new().single_threaded(Update);
+
+		app.add_plugins(StatesPlugin);
+		app.init_state::<Activity>();
+		UIStates::init(&mut app);
+		app.init_resource::<GameStatesContext>();
+
+		app
+	}
+
+	macro_rules! assert_state_eq {
+		($left:expr, $right:expr) => {{
+			use NextState::*;
+
+			match ($left, $right) {
+				(Unchanged, Unchanged) => {}
+				(Pending(left), Pending(right)) => assert_eq!(left, right),
+				(PendingIfNeq(left), PendingIfNeq(right)) => {
+					assert_eq!(left, right)
+				}
+				(left, right) => {
+					panic!("assertion: `left == right` failed\n  left: {left:?}\n right: {right:?}")
+				}
+			}
+		}};
+	}
+
+	#[test_case(ActivityState::Paused, Activity::Paused; "paused")]
+	#[test_case(UIState::Hud, Hud::On; "hud")]
+	#[test_case(UIState::Inventory, Inventory::On; "inventory")]
+	#[test_case(UIState::ComboOverview, ComboOverview::On; "combos")]
+	#[test_case(UIState::Settings, Settings::On; "settings")]
+	fn add_state<T, U>(state: T, expected: U) -> Result<(), RunSystemError>
+	where
+		T: IntoGameStateAdd + Copy + ThreadSafe,
+		U: FreelyMutableState,
+	{
+		let mut app = setup();
+
+		app.world_mut()
+			.run_system_once(move |mut w: GameStatesWrite| {
+				w.add_game_state(state);
+			})?;
+
+		assert_state_eq!(
+			&NextState::Pending(expected),
+			app.world().resource::<NextState<U>>()
+		);
+		Ok(())
+	}
+
+	#[test_case(UIState::Hud, Hud::Off; "hud")]
+	#[test_case(UIState::Inventory, Inventory::Off; "inventory")]
+	#[test_case(UIState::ComboOverview, ComboOverview::Off; "combos")]
+	#[test_case(UIState::Settings, Settings::Off; "settings")]
+	fn remove_state<T, U>(state: T, expected: U) -> Result<(), RunSystemError>
+	where
+		T: IntoGameStateRemove + Copy + ThreadSafe,
+		U: FreelyMutableState,
+	{
+		let mut app = setup();
+
+		app.world_mut()
+			.run_system_once(move |mut w: GameStatesWrite| {
+				w.remove_game_state(&state);
+			})?;
+
+		assert_state_eq!(
+			&NextState::Pending(expected),
+			app.world().resource::<NextState<U>>()
+		);
+		Ok(())
 	}
 }

--- a/src/plugins/game_states/src/system_params/ui_states.rs
+++ b/src/plugins/game_states/src/system_params/ui_states.rs
@@ -4,32 +4,33 @@ use bevy::{
 	prelude::*,
 };
 use common::traits::handles_game_states::UIState;
+use zyheeda_core::prelude::*;
 
 #[derive(SystemParam)]
 pub(crate) struct UIStates<'w> {
-	hud: ResMut<'w, NextState<Hud>>,
-	inventory: ResMut<'w, NextState<Inventory>>,
-	combos: ResMut<'w, NextState<ComboOverview>>,
-	settings: ResMut<'w, NextState<Settings>>,
+	hud: Res<'w, State<Hud>>,
+	inventory: Res<'w, State<Inventory>>,
+	combos: Res<'w, State<ComboOverview>>,
+	settings: Res<'w, State<Settings>>,
 }
 
 impl UIStates<'_> {
-	pub(crate) fn set_on(&mut self, ui: UIState) {
-		match ui {
-			UIState::Hud => self.hud.set(Hud::On),
-			UIState::Inventory => self.inventory.set(Inventory::On),
-			UIState::ComboOverview => self.combos.set(ComboOverview::On),
-			UIState::Settings => self.settings.set(Settings::On),
+	pub(crate) fn is_on(&self, state: &UIState) -> bool {
+		match state {
+			UIState::Hud => self.hud.get() == &Hud::On,
+			UIState::Inventory => self.inventory.get() == &Inventory::On,
+			UIState::ComboOverview => self.combos.get() == &ComboOverview::On,
+			UIState::Settings => self.settings.get() == &Settings::On,
 		}
 	}
 
-	pub(crate) fn set_off(&mut self, ui: &UIState) {
-		match ui {
-			UIState::Hud => self.hud.set(Hud::Off),
-			UIState::Inventory => self.inventory.set(Inventory::Off),
-			UIState::ComboOverview => self.combos.set(ComboOverview::Off),
-			UIState::Settings => self.settings.set(Settings::Off),
-		}
+	pub(crate) fn is_changed(&self) -> bool {
+		any!(is_changed(
+			self.hud,
+			self.inventory,
+			self.combos,
+			self.settings
+		))
 	}
 }
 
@@ -65,5 +66,33 @@ impl UIStates<'static> {
 			UIState::ComboOverview => app.add_systems(OnExit(ComboOverview::On), systems),
 			UIState::Settings => app.add_systems(OnExit(Settings::On), systems),
 		};
+	}
+}
+
+#[derive(SystemParam)]
+pub(crate) struct UIStatesMut<'w> {
+	hud: ResMut<'w, NextState<Hud>>,
+	inventory: ResMut<'w, NextState<Inventory>>,
+	combos: ResMut<'w, NextState<ComboOverview>>,
+	settings: ResMut<'w, NextState<Settings>>,
+}
+
+impl UIStatesMut<'_> {
+	pub(crate) fn set_on(&mut self, ui: UIState) {
+		match ui {
+			UIState::Hud => self.hud.set(Hud::On),
+			UIState::Inventory => self.inventory.set(Inventory::On),
+			UIState::ComboOverview => self.combos.set(ComboOverview::On),
+			UIState::Settings => self.settings.set(Settings::On),
+		}
+	}
+
+	pub(crate) fn set_off(&mut self, ui: &UIState) {
+		match ui {
+			UIState::Hud => self.hud.set(Hud::Off),
+			UIState::Inventory => self.inventory.set(Inventory::Off),
+			UIState::ComboOverview => self.combos.set(ComboOverview::Off),
+			UIState::Settings => self.settings.set(Settings::Off),
+		}
 	}
 }

--- a/src/plugins/game_states/src/system_params/ui_states.rs
+++ b/src/plugins/game_states/src/system_params/ui_states.rs
@@ -1,0 +1,69 @@
+use crate::states::ui::{ComboOverview, Hud, Inventory, Settings};
+use bevy::{
+	ecs::system::{ScheduleSystem, SystemParam},
+	prelude::*,
+};
+use common::traits::handles_game_states::UIState;
+
+#[derive(SystemParam)]
+pub(crate) struct UIStates<'w> {
+	hud: ResMut<'w, NextState<Hud>>,
+	inventory: ResMut<'w, NextState<Inventory>>,
+	combos: ResMut<'w, NextState<ComboOverview>>,
+	settings: ResMut<'w, NextState<Settings>>,
+}
+
+impl UIStates<'_> {
+	pub(crate) fn set_on(&mut self, ui: UIState) {
+		match ui {
+			UIState::Hud => self.hud.set(Hud::On),
+			UIState::Inventory => self.inventory.set(Inventory::On),
+			UIState::ComboOverview => self.combos.set(ComboOverview::On),
+			UIState::Settings => self.settings.set(Settings::On),
+		}
+	}
+
+	pub(crate) fn set_off(&mut self, ui: UIState) {
+		match ui {
+			UIState::Hud => self.hud.set(Hud::Off),
+			UIState::Inventory => self.inventory.set(Inventory::Off),
+			UIState::ComboOverview => self.combos.set(ComboOverview::Off),
+			UIState::Settings => self.settings.set(Settings::Off),
+		}
+	}
+}
+
+impl UIStates<'static> {
+	pub(crate) fn init(app: &mut App) {
+		app.init_state::<Hud>();
+		app.init_state::<Inventory>();
+		app.init_state::<ComboOverview>();
+		app.init_state::<Settings>();
+	}
+
+	pub(crate) fn on_enter<M>(
+		app: &mut App,
+		ui_state: UIState,
+		systems: impl IntoScheduleConfigs<ScheduleSystem, M>,
+	) {
+		match ui_state {
+			UIState::Hud => app.add_systems(OnEnter(Hud::On), systems),
+			UIState::Inventory => app.add_systems(OnEnter(Inventory::On), systems),
+			UIState::ComboOverview => app.add_systems(OnEnter(ComboOverview::On), systems),
+			UIState::Settings => app.add_systems(OnEnter(Settings::On), systems),
+		};
+	}
+
+	pub(crate) fn on_exit<M>(
+		app: &mut App,
+		ui_state: UIState,
+		systems: impl IntoScheduleConfigs<ScheduleSystem, M>,
+	) {
+		match ui_state {
+			UIState::Hud => app.add_systems(OnExit(Hud::On), systems),
+			UIState::Inventory => app.add_systems(OnExit(Inventory::On), systems),
+			UIState::ComboOverview => app.add_systems(OnExit(ComboOverview::On), systems),
+			UIState::Settings => app.add_systems(OnExit(Settings::On), systems),
+		};
+	}
+}

--- a/src/plugins/game_states/src/system_params/ui_states.rs
+++ b/src/plugins/game_states/src/system_params/ui_states.rs
@@ -23,7 +23,7 @@ impl UIStates<'_> {
 		}
 	}
 
-	pub(crate) fn set_off(&mut self, ui: UIState) {
+	pub(crate) fn set_off(&mut self, ui: &UIState) {
 		match ui {
 			UIState::Hud => self.hud.set(Hud::Off),
 			UIState::Inventory => self.inventory.set(Inventory::Off),

--- a/src/plugins/game_states/src/systems.rs
+++ b/src/plugins/game_states/src/systems.rs
@@ -1,0 +1,1 @@
+pub(crate) mod sync_states;

--- a/src/plugins/game_states/src/systems/sync_states.rs
+++ b/src/plugins/game_states/src/systems/sync_states.rs
@@ -1,0 +1,144 @@
+use crate::{
+	resources::game_state_context::GameStatesContext,
+	states::activity::Activity,
+	system_params::ui_states::UIStates,
+};
+use bevy::prelude::*;
+use common::traits::{
+	handles_game_states::{GameState, UIState},
+	iteration::IterFinite,
+};
+use std::{collections::HashSet, iter::once};
+
+impl GameStatesContext {
+	pub(crate) fn sync_states(mut ctx: ResMut<Self>, activity: Res<State<Activity>>, ui: UIStates) {
+		if !activity.is_changed() && !ui.is_changed() {
+			return;
+		}
+
+		let states = UIState::iterator()
+			.filter(|ui_state| ui.is_on(ui_state))
+			.map(GameState::IngameUI)
+			.chain(once(GameState::from(activity.get())));
+
+		ctx.states = HashSet::from_iter(states);
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::{
+		states::{
+			activity::Activity,
+			ui::{ComboOverview, Hud, Inventory, Settings},
+		},
+		system_params::ui_states::UIStates,
+	};
+	use bevy::state::{app::StatesPlugin, state::FreelyMutableState};
+	use common::traits::handles_game_states::{ActivityState, GameState, ReadState, UIState};
+	use test_case::test_case;
+	use testing::SingleThreadedApp;
+
+	fn setup() -> App {
+		let mut app = App::new().single_threaded(Update);
+
+		app.add_plugins(StatesPlugin);
+		UIStates::init(&mut app);
+		app.init_state::<Activity>();
+		app.init_resource::<GameStatesContext>();
+		app.add_systems(Update, GameStatesContext::sync_states);
+
+		app
+	}
+
+	#[test_case(Activity::Play, GameState::Activity(ActivityState::Play); "play")]
+	#[test_case(Activity::Loading, GameState::Read(ReadState::Loading); "loading")]
+	fn sync_activity(state: Activity, game_state: GameState) {
+		let mut app = setup();
+		app.insert_state(state);
+
+		app.update();
+
+		assert_eq!(
+			HashSet::from([game_state]),
+			app.world().resource::<GameStatesContext>().states,
+		);
+	}
+
+	#[test_case(Hud::On, GameState::IngameUI(UIState::Hud); "hud")]
+	#[test_case(Inventory::On, GameState::IngameUI(UIState::Inventory); "inventory")]
+	#[test_case(ComboOverview::On, GameState::IngameUI(UIState::ComboOverview); "combos")]
+	#[test_case(Settings::On, GameState::IngameUI(UIState::Settings); "settings")]
+	fn sync_ui<T>(state: T, game_state: GameState)
+	where
+		T: FreelyMutableState,
+	{
+		let mut app = setup();
+		app.insert_state(state);
+
+		app.update();
+
+		assert_eq!(
+			HashSet::from([
+				GameState::Activity(ActivityState::LoadingEssentialAssets),
+				game_state
+			]),
+			app.world().resource::<GameStatesContext>().states,
+		);
+	}
+
+	#[test]
+	fn act_only_once() {
+		let mut app = setup();
+		app.insert_state(Activity::Play);
+
+		app.update();
+		app.world_mut()
+			.resource_mut::<GameStatesContext>()
+			.states
+			.clear();
+		app.update();
+
+		assert_eq!(
+			HashSet::from([]),
+			app.world().resource::<GameStatesContext>().states,
+		);
+	}
+
+	#[test]
+	fn act_again_if_activity_changed() {
+		let mut app = setup();
+		app.insert_state(Activity::Play);
+
+		app.update();
+		app.insert_state(Activity::Paused);
+		app.update();
+
+		assert_eq!(
+			HashSet::from([GameState::Activity(ActivityState::Paused)]),
+			app.world().resource::<GameStatesContext>().states,
+		);
+	}
+
+	#[test_case(Hud::On, GameState::IngameUI(UIState::Hud); "hud")]
+	#[test_case(Inventory::On, GameState::IngameUI(UIState::Inventory); "inventory")]
+	#[test_case(ComboOverview::On, GameState::IngameUI(UIState::ComboOverview); "combos")]
+	#[test_case(Settings::On, GameState::IngameUI(UIState::Settings); "settings")]
+	fn act_again_if_ui_changed<T>(state: T, game_state: GameState)
+	where
+		T: FreelyMutableState,
+	{
+		let mut app = setup();
+		app.insert_state(Activity::Play);
+
+		app.update();
+		app.insert_state(state);
+		app.update();
+
+		assert_eq!(
+			HashSet::from([GameState::Activity(ActivityState::Play), game_state]),
+			app.world().resource::<GameStatesContext>().states,
+		);
+	}
+}


### PR DESCRIPTION
Added a new states plugin. It is not ready to be used yet, but we have the basic interface layout and internal state design figured out:
- added interface to read and update states
  - some states are designed to be only added
  - ui states can be removed (representing toggling on and off of the related ui windows)
  - a read state exists, that is not to be set from outside (this might change, depending on how we set up automatic state transitions)
- added interface to register systems that run on state transitions