### PR TITLE
State transitions

### DIFF
--- a/src/plugins/common/src/traits/handles_game_states.rs
+++ b/src/plugins/common/src/traits/handles_game_states.rs
@@ -69,10 +69,13 @@ where
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		match self {
 			TransitionsConfigError::AlreadyConfigured(state) => {
-				write!(f, "{state:?}: Cannot be configure more than once")
+				write!(f, "{state:?}: Cannot be configured more than once")
 			}
 			TransitionsConfigError::MayNotTransitionToSelf(state) => {
-				write!(f, "{state:?}: May automatically transition back to itself")
+				write!(
+					f,
+					"{state:?}: May not automatically transition back to itself"
+				)
 			}
 		}
 	}

--- a/src/plugins/common/src/traits/handles_game_states.rs
+++ b/src/plugins/common/src/traits/handles_game_states.rs
@@ -1,6 +1,9 @@
 use crate::{
 	tools::is_not::IsNot,
-	traits::iteration::{Iter, IterFinite},
+	traits::{
+		iteration::{Iter, IterFinite},
+		thread_safe::ThreadSafe,
+	},
 };
 use bevy::{
 	ecs::system::{ScheduleSystem, SystemParam},
@@ -44,9 +47,10 @@ pub trait WithOptionalTransitions<T> {
 		transitions: HashMap<TResult, StateTransition<T>>,
 	) -> Result<(), TransitionsConfigError<T>>
 	where
-		TResult: PartialEq + Eq + Hash;
+		TResult: PartialEq + Eq + Hash + ThreadSafe;
 }
 
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub enum StateTransition<T> {
 	To(T),
 	ToPrevious,

--- a/src/plugins/common/src/traits/handles_game_states.rs
+++ b/src/plugins/common/src/traits/handles_game_states.rs
@@ -6,17 +6,72 @@ use bevy::{
 	ecs::system::{ScheduleSystem, SystemParam},
 	prelude::*,
 };
-use std::collections::HashSet;
+use std::{
+	collections::{HashMap, HashSet},
+	fmt::{Debug, Display},
+	hash::Hash,
+};
 
-pub trait HandlesGameStates {
+pub trait HandlesGameStates:
+	AddGameStateSystem + AutomaticGameStateTransitions<ActivityState>
+{
 	type TGameStates: SystemParam + GameStates;
 	type TGameStatesMut: SystemParam + GameStatesMut;
+}
 
-	fn add_systems<M>(
+pub trait AddGameStateSystem {
+	fn add_game_state_systems<M>(
 		app: &mut App,
 		on_state: OnGameState,
 		systems: impl IntoScheduleConfigs<ScheduleSystem, M>,
 	);
+}
+
+pub trait AutomaticGameStateTransitions<T> {
+	type TOptionalTransitions<'a>: WithOptionalTransitions<T>;
+
+	fn automatic_game_state_transitions(
+		app: &mut App,
+		from_state: T,
+		to_state: StateTransition<T>,
+	) -> Result<Self::TOptionalTransitions<'_>, TransitionsConfigError<T>>;
+}
+
+pub trait WithOptionalTransitions<T> {
+	fn with_optional_transitions<TResult, M>(
+		self,
+		check: impl IntoSystem<(), Option<TResult>, M>,
+		transitions: HashMap<TResult, StateTransition<T>>,
+	) -> Result<(), TransitionsConfigError<T>>
+	where
+		TResult: PartialEq + Eq + Hash;
+}
+
+pub enum StateTransition<T> {
+	To(T),
+	ToPrevious,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum TransitionsConfigError<TState> {
+	AlreadyConfigured(TState),
+	MayNotTransitionToSelf(TState),
+}
+
+impl<TState> Display for TransitionsConfigError<TState>
+where
+	TState: Debug,
+{
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			TransitionsConfigError::AlreadyConfigured(state) => {
+				write!(f, "{state:?}: Cannot be configure more than once")
+			}
+			TransitionsConfigError::MayNotTransitionToSelf(state) => {
+				write!(f, "{state:?}: May automatically transition back to itself")
+			}
+		}
+	}
 }
 
 pub trait GameStatesMut:

--- a/src/plugins/game_states/src/lib.rs
+++ b/src/plugins/game_states/src/lib.rs
@@ -88,7 +88,6 @@ impl Plugin for GameStatesPlugin {
 
 		app.init_state::<Activity>()
 			.init_resource::<GameStatesContext>()
-			.init_resource::<ActiveTransitions>()
 			.add_systems(
 				Update,
 				GameStatesContext::sync_states.in_set(GameStateSystems),
@@ -152,7 +151,7 @@ impl AutomaticGameStateTransitions<ActivityState> for GameStatesPlugin {
 
 		let ActiveTransitions(active_transitions) = app
 			.world_mut()
-			.resource_mut::<ActiveTransitions>()
+			.get_resource_or_init::<ActiveTransitions>()
 			.into_inner();
 		if active_transitions.contains(&from_state) {
 			return Err(TransitionsConfigError::AlreadyConfigured(from_state));
@@ -281,7 +280,6 @@ mod tests {
 		let mut app = App::new().single_threaded(Update);
 
 		app.add_plugins(StatesPlugin);
-		app.init_resource::<ActiveTransitions>();
 		app.init_state::<Activity>();
 
 		app

--- a/src/plugins/game_states/src/lib.rs
+++ b/src/plugins/game_states/src/lib.rs
@@ -3,10 +3,8 @@ mod states;
 mod system_params;
 mod systems;
 
-use std::collections::HashMap;
-
 use crate::{
-	resources::game_state_context::GameStatesContext,
+	resources::{active_transitions::ActiveTransitions, game_state_context::GameStatesContext},
 	states::activity::Activity,
 	system_params::{
 		game_states_read::GameStatesRead,
@@ -16,6 +14,8 @@ use crate::{
 };
 use bevy::{ecs::system::ScheduleSystem, prelude::*};
 use common::{
+	errors::{ErrorData, Level},
+	systems::log::OnError,
 	tools::plugin_system_set::PluginSystemSet,
 	traits::{
 		handles_game_states::{
@@ -30,17 +30,65 @@ use common::{
 			WithOptionalTransitions,
 		},
 		system_set_definition::SystemSetDefinition,
+		thread_safe::ThreadSafe,
 	},
+};
+use std::{
+	collections::HashMap,
+	fmt::{Debug, Display},
+	hash::Hash,
 };
 
 pub struct GameStatesPlugin;
+
+impl GameStatesPlugin {
+	fn apply_transition_from(
+		from_state: ActivityState,
+	) -> impl IntoSystem<
+		In<Option<StateTransition<ActivityState>>>,
+		Result<(), TransitionError<ActivityState>>,
+		(),
+	> {
+		#[rustfmt::skip]
+		let system = move |
+			In(to_state): In<Option<StateTransition<ActivityState>>>,
+			mut state_transitions: MessageReader<StateTransitionEvent<Activity>>,
+			mut state: ResMut<NextState<Activity>>
+		| {
+			let Some(to_state) = to_state else {
+				return Ok(());
+			};
+
+			match to_state {
+				StateTransition::To(to_state) => {
+					state.set(Activity::from(to_state));
+				}
+				StateTransition::ToPrevious => {
+					let Some(last_transition) = state_transitions.read().last() else {
+						return Err(TransitionError::NoStateTransitionsFor(from_state));
+					};
+					let Some(ref previous) = last_transition.exited else {
+						return Err(TransitionError::NoPreviousStateFor(from_state));
+					};
+
+					state.set(*previous);
+				}
+			};
+
+			Ok(())
+		};
+
+		IntoSystem::into_system(system)
+	}
+}
 
 impl Plugin for GameStatesPlugin {
 	fn build(&self, app: &mut App) {
 		UIStates::init(app);
 
-		app.init_resource::<GameStatesContext>()
-			.init_state::<Activity>()
+		app.init_state::<Activity>()
+			.init_resource::<GameStatesContext>()
+			.init_resource::<ActiveTransitions>()
 			.add_systems(
 				Update,
 				GameStatesContext::sync_states.in_set(GameStateSystems),
@@ -48,8 +96,11 @@ impl Plugin for GameStatesPlugin {
 	}
 }
 
-#[derive(SystemSet, Debug, PartialEq, Eq, Hash, Clone, Copy)]
-pub struct GameStateSystems;
+impl SystemSetDefinition for GameStatesPlugin {
+	type TSystemSet = GameStateSystems;
+
+	const SYSTEMS: PluginSystemSet<Self::TSystemSet> = PluginSystemSet::from_set(GameStateSystems);
+}
 
 impl HandlesGameStates for GameStatesPlugin {
 	type TGameStates = GameStatesRead<'static>;
@@ -90,30 +141,352 @@ impl AutomaticGameStateTransitions<ActivityState> for GameStatesPlugin {
 
 	fn automatic_game_state_transitions(
 		app: &mut App,
-		_: ActivityState,
-		_: StateTransition<ActivityState>,
+		from_state: ActivityState,
+		to_state: StateTransition<ActivityState>,
 	) -> Result<Self::TOptionalTransitions<'_>, TransitionsConfigError<ActivityState>> {
-		Ok(OptionalTransitions(app))
+		if matches!(to_state, StateTransition::To(to_state) if to_state == from_state) {
+			return Err(TransitionsConfigError::MayNotTransitionToSelf(from_state));
+		}
+
+		let ActiveTransitions(active_transitions) = app
+			.world_mut()
+			.resource_mut::<ActiveTransitions>()
+			.into_inner();
+		if active_transitions.contains(&from_state) {
+			return Err(TransitionsConfigError::AlreadyConfigured(from_state));
+		}
+
+		active_transitions.insert(from_state);
+
+		app.add_systems(
+			OnEnter(Activity::from(from_state)),
+			(move || Some(to_state))
+				.pipe(GameStatesPlugin::apply_transition_from(from_state))
+				.pipe(OnError::log)
+				.in_set(FallbackTransitions),
+		);
+
+		Ok(OptionalTransitions { from_state, app })
 	}
 }
 
-pub struct OptionalTransitions<'a>(&'a mut App);
+pub struct OptionalTransitions<'a> {
+	from_state: ActivityState,
+	app: &'a mut App,
+}
 
 impl WithOptionalTransitions<ActivityState> for OptionalTransitions<'_> {
 	fn with_optional_transitions<TResult, M>(
 		self,
-		_: impl IntoSystem<(), Option<TResult>, M>,
-		_: HashMap<TResult, StateTransition<ActivityState>>,
+		check: impl IntoSystem<(), Option<TResult>, M>,
+		transitions: HashMap<TResult, StateTransition<ActivityState>>,
 	) -> Result<(), TransitionsConfigError<ActivityState>>
 	where
-		TResult: PartialEq + Eq + std::hash::Hash,
+		TResult: PartialEq + Eq + Hash + ThreadSafe,
 	{
+		let any_self_transitions = transitions.values().any(
+			|to_state| matches!(to_state, StateTransition::To(to_state) if to_state == &self.from_state),
+		);
+		if any_self_transitions {
+			return Err(TransitionsConfigError::MayNotTransitionToSelf(
+				self.from_state,
+			));
+		}
+
+		self.app.add_systems(
+			OnEnter(Activity::from(self.from_state)),
+			check
+				.pipe(move |In(result)| transitions.get(&result?).copied())
+				.pipe(GameStatesPlugin::apply_transition_from(self.from_state))
+				.pipe(OnError::log)
+				.after(FallbackTransitions),
+		);
 		Ok(())
 	}
 }
 
-impl SystemSetDefinition for GameStatesPlugin {
-	type TSystemSet = GameStateSystems;
+#[derive(SystemSet, Debug, PartialEq, Eq, Hash, Clone, Copy)]
+struct FallbackTransitions;
 
-	const SYSTEMS: PluginSystemSet<Self::TSystemSet> = PluginSystemSet::from_set(GameStateSystems);
+#[derive(SystemSet, Debug, PartialEq, Eq, Hash, Clone, Copy)]
+pub struct GameStateSystems;
+
+#[derive(Debug, PartialEq)]
+enum TransitionError<T> {
+	NoStateTransitionsFor(T),
+	NoPreviousStateFor(T),
+}
+
+impl<T> Display for TransitionError<T>
+where
+	T: Debug,
+{
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			TransitionError::NoStateTransitionsFor(state) => {
+				write!(
+					f,
+					"{state:?}: Could not retrieve state transition messages to determine previous state"
+				)
+			}
+			TransitionError::NoPreviousStateFor(state) => {
+				write!(f, "{state:?}: Cannot detect previous state")
+			}
+		}
+	}
+}
+
+impl<T> ErrorData for TransitionError<T>
+where
+	T: Debug + 'static,
+{
+	fn level(&self) -> Level {
+		Level::Error
+	}
+
+	fn label() -> impl Display {
+		"Transition Error"
+	}
+
+	fn into_details(self) -> impl Display {
+		self
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	#![allow(clippy::unwrap_used)]
+	use super::*;
+	use bevy::{
+		ecs::system::{RunSystemError, RunSystemOnce},
+		state::app::StatesPlugin,
+	};
+	use test_case::test_case;
+	use testing::SingleThreadedApp;
+
+	fn setup() -> App {
+		let mut app = App::new().single_threaded(Update);
+
+		app.add_plugins(StatesPlugin);
+		app.init_resource::<ActiveTransitions>();
+		app.init_state::<Activity>();
+
+		app
+	}
+
+	#[test]
+	fn apply_transition() -> Result<(), RunSystemError> {
+		let mut app = setup();
+		_ = GameStatesPlugin::automatic_game_state_transitions(
+			&mut app,
+			ActivityState::Paused,
+			StateTransition::To(ActivityState::Play),
+		);
+
+		app.world_mut()
+			.run_system_once(|mut state: ResMut<NextState<Activity>>| {
+				state.set(Activity::Paused);
+			})?;
+		app.update();
+		app.update();
+
+		assert_eq!(
+			&Activity::Play,
+			app.world().resource::<State<Activity>>().get()
+		);
+		Ok(())
+	}
+
+	#[test]
+	fn apply_transition_to_previous() -> Result<(), RunSystemError> {
+		let mut app = setup();
+		_ = GameStatesPlugin::automatic_game_state_transitions(
+			&mut app,
+			ActivityState::Paused,
+			StateTransition::ToPrevious,
+		);
+
+		app.world_mut()
+			.run_system_once(|mut state: ResMut<NextState<Activity>>| {
+				state.set(Activity::Play);
+			})?;
+		app.update();
+		app.world_mut()
+			.run_system_once(|mut state: ResMut<NextState<Activity>>| {
+				state.set(Activity::Paused);
+			})?;
+		app.update();
+		app.update();
+
+		assert_eq!(
+			&Activity::Play,
+			app.world().resource::<State<Activity>>().get()
+		);
+		Ok(())
+	}
+
+	#[test]
+	fn apply_conditional_transition() -> Result<(), RunSystemError> {
+		let mut app = setup();
+		let transitions = GameStatesPlugin::automatic_game_state_transitions(
+			&mut app,
+			ActivityState::Paused,
+			StateTransition::To(ActivityState::Play),
+		)
+		.unwrap();
+		_ = transitions.with_optional_transitions(
+			|| Some("new game"),
+			HashMap::from([("new game", StateTransition::To(ActivityState::NewGame))]),
+		);
+
+		app.world_mut()
+			.run_system_once(|mut state: ResMut<NextState<Activity>>| {
+				state.set(Activity::Paused);
+			})?;
+		app.update();
+		app.update();
+
+		assert_eq!(
+			&Activity::NewGame,
+			app.world().resource::<State<Activity>>().get()
+		);
+		Ok(())
+	}
+
+	#[test]
+	fn apply_conditional_transition_to_previous() -> Result<(), RunSystemError> {
+		let mut app = setup();
+		let transitions = GameStatesPlugin::automatic_game_state_transitions(
+			&mut app,
+			ActivityState::Paused,
+			StateTransition::To(ActivityState::Play),
+		)
+		.unwrap();
+		_ = transitions.with_optional_transitions(
+			|| Some("previous"),
+			HashMap::from([("previous", StateTransition::ToPrevious)]),
+		);
+
+		app.world_mut()
+			.run_system_once(|mut state: ResMut<NextState<Activity>>| {
+				state.set(Activity::StartScreen);
+			})?;
+		app.update();
+		app.world_mut()
+			.run_system_once(|mut state: ResMut<NextState<Activity>>| {
+				state.set(Activity::Paused);
+			})?;
+		app.update();
+		app.update();
+
+		assert_eq!(
+			&Activity::StartScreen,
+			app.world().resource::<State<Activity>>().get()
+		);
+		Ok(())
+	}
+
+	#[test_case(Some("Muhaha, I'm an invalid, deal with it"); "on mismatch")]
+	#[test_case(None; "on check returning none")]
+	fn apply_fallback_when_conditional_transitions_do_not_match(
+		result: Option<&'static str>,
+	) -> Result<(), RunSystemError> {
+		let mut app = setup();
+		let transitions = GameStatesPlugin::automatic_game_state_transitions(
+			&mut app,
+			ActivityState::Paused,
+			StateTransition::To(ActivityState::Play),
+		)
+		.unwrap();
+		_ = transitions.with_optional_transitions(
+			move || result,
+			HashMap::from([("new game", StateTransition::To(ActivityState::NewGame))]),
+		);
+
+		app.world_mut()
+			.run_system_once(|mut state: ResMut<NextState<Activity>>| {
+				state.set(Activity::Paused);
+			})?;
+		app.update();
+		app.update();
+
+		assert_eq!(
+			&Activity::Play,
+			app.world().resource::<State<Activity>>().get()
+		);
+		Ok(())
+	}
+
+	#[test]
+	fn forbid_repeated_config() {
+		let mut app = setup();
+		_ = GameStatesPlugin::automatic_game_state_transitions(
+			&mut app,
+			ActivityState::Paused,
+			StateTransition::To(ActivityState::Play),
+		);
+
+		let result = GameStatesPlugin::automatic_game_state_transitions(
+			&mut app,
+			ActivityState::Paused,
+			StateTransition::To(ActivityState::Play),
+		);
+
+		let error = match result {
+			Ok(_) => panic!("Expected Error, but was value"),
+			Err(error) => error,
+		};
+		assert_eq!(
+			TransitionsConfigError::AlreadyConfigured(ActivityState::Paused),
+			error
+		);
+	}
+
+	#[test]
+	fn forbid_transitions_to_self() {
+		let mut app = setup();
+
+		let result = GameStatesPlugin::automatic_game_state_transitions(
+			&mut app,
+			ActivityState::Paused,
+			StateTransition::To(ActivityState::Paused),
+		);
+
+		let error = match result {
+			Ok(_) => panic!("Expected Error, but was value"),
+			Err(error) => error,
+		};
+		assert_eq!(
+			TransitionsConfigError::MayNotTransitionToSelf(ActivityState::Paused),
+			error
+		);
+	}
+
+	#[test]
+	fn forbid_transitions_to_self_in_optional_transitions() {
+		let mut app = setup();
+
+		let transitions = GameStatesPlugin::automatic_game_state_transitions(
+			&mut app,
+			ActivityState::Paused,
+			StateTransition::To(ActivityState::Play),
+		)
+		.unwrap();
+		let result = transitions.with_optional_transitions(
+			|| Some("foo"),
+			HashMap::from([
+				("foo", StateTransition::ToPrevious),
+				("bar", StateTransition::To(ActivityState::Paused)),
+			]),
+		);
+
+		let error = match result {
+			Ok(_) => panic!("Expected Error, but was value"),
+			Err(error) => error,
+		};
+		assert_eq!(
+			TransitionsConfigError::MayNotTransitionToSelf(ActivityState::Paused),
+			error
+		);
+	}
 }

--- a/src/plugins/game_states/src/lib.rs
+++ b/src/plugins/game_states/src/lib.rs
@@ -113,6 +113,8 @@ impl AddGameStateSystem for GameStatesPlugin {
 		on_state: OnGameState,
 		systems: impl IntoScheduleConfigs<ScheduleSystem, M>,
 	) {
+		let systems = systems.after(AutomaticTransitions::Override);
+
 		match on_state {
 			OnGameState::Enter(GameState::Activity(activity)) => {
 				app.add_systems(OnEnter(Activity::from(activity)), systems);
@@ -158,12 +160,20 @@ impl AutomaticGameStateTransitions<ActivityState> for GameStatesPlugin {
 
 		active_transitions.insert(from_state);
 
+		app.configure_sets(
+			OnEnter(Activity::from(from_state)),
+			(
+				AutomaticTransitions::Fallback,
+				AutomaticTransitions::Override,
+			)
+				.chain(),
+		);
 		app.add_systems(
 			OnEnter(Activity::from(from_state)),
 			(move || Some(to_state))
 				.pipe(GameStatesPlugin::apply_transition_from(from_state))
 				.pipe(OnError::log)
-				.in_set(FallbackTransitions),
+				.in_set(AutomaticTransitions::Fallback),
 		);
 
 		Ok(OptionalTransitions { from_state, app })
@@ -199,14 +209,17 @@ impl WithOptionalTransitions<ActivityState> for OptionalTransitions<'_> {
 				.pipe(move |In(result)| transitions.get(&result?).copied())
 				.pipe(GameStatesPlugin::apply_transition_from(self.from_state))
 				.pipe(OnError::log)
-				.after(FallbackTransitions),
+				.in_set(AutomaticTransitions::Override),
 		);
 		Ok(())
 	}
 }
 
 #[derive(SystemSet, Debug, PartialEq, Eq, Hash, Clone, Copy)]
-struct FallbackTransitions;
+enum AutomaticTransitions {
+	Fallback,
+	Override,
+}
 
 #[derive(SystemSet, Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub struct GameStateSystems;
@@ -412,6 +425,41 @@ mod tests {
 
 		assert_eq!(
 			&Activity::Play,
+			app.world().resource::<State<Activity>>().get()
+		);
+		Ok(())
+	}
+
+	#[test]
+	fn allow_automatic_transitions_to_be_overridden() -> Result<(), RunSystemError> {
+		let mut app = setup();
+		GameStatesPlugin::add_game_state_systems(
+			&mut app,
+			OnGameState::Enter(GameState::Activity(ActivityState::Paused)),
+			|mut state: ResMut<NextState<Activity>>| {
+				state.set(Activity::StartScreen);
+			},
+		);
+		let transitions = GameStatesPlugin::automatic_game_state_transitions(
+			&mut app,
+			ActivityState::Paused,
+			StateTransition::To(ActivityState::Play),
+		)
+		.unwrap();
+		_ = transitions.with_optional_transitions(
+			|| Some(true),
+			HashMap::from([(true, StateTransition::To(ActivityState::Save))]),
+		);
+
+		app.world_mut()
+			.run_system_once(|mut state: ResMut<NextState<Activity>>| {
+				state.set(Activity::Paused);
+			})?;
+		app.update();
+		app.update();
+
+		assert_eq!(
+			&Activity::StartScreen,
 			app.world().resource::<State<Activity>>().get()
 		);
 		Ok(())

--- a/src/plugins/game_states/src/lib.rs
+++ b/src/plugins/game_states/src/lib.rs
@@ -3,6 +3,8 @@ mod states;
 mod system_params;
 mod systems;
 
+use std::collections::HashMap;
+
 use crate::{
 	resources::game_state_context::GameStatesContext,
 	states::activity::Activity,
@@ -16,7 +18,17 @@ use bevy::{ecs::system::ScheduleSystem, prelude::*};
 use common::{
 	tools::plugin_system_set::PluginSystemSet,
 	traits::{
-		handles_game_states::{GameState, HandlesGameStates, OnGameState},
+		handles_game_states::{
+			ActivityState,
+			AddGameStateSystem,
+			AutomaticGameStateTransitions,
+			GameState,
+			HandlesGameStates,
+			OnGameState,
+			StateTransition,
+			TransitionsConfigError,
+			WithOptionalTransitions,
+		},
 		system_set_definition::SystemSetDefinition,
 	},
 };
@@ -42,8 +54,10 @@ pub struct GameStateSystems;
 impl HandlesGameStates for GameStatesPlugin {
 	type TGameStates = GameStatesRead<'static>;
 	type TGameStatesMut = GameStatesWrite<'static>;
+}
 
-	fn add_systems<M>(
+impl AddGameStateSystem for GameStatesPlugin {
+	fn add_game_state_systems<M>(
 		app: &mut App,
 		on_state: OnGameState,
 		systems: impl IntoScheduleConfigs<ScheduleSystem, M>,
@@ -68,6 +82,33 @@ impl HandlesGameStates for GameStatesPlugin {
 				UIStates::on_exit(app, ui, systems);
 			}
 		}
+	}
+}
+
+impl AutomaticGameStateTransitions<ActivityState> for GameStatesPlugin {
+	type TOptionalTransitions<'a> = OptionalTransitions<'a>;
+
+	fn automatic_game_state_transitions(
+		app: &mut App,
+		_: ActivityState,
+		_: StateTransition<ActivityState>,
+	) -> Result<Self::TOptionalTransitions<'_>, TransitionsConfigError<ActivityState>> {
+		Ok(OptionalTransitions(app))
+	}
+}
+
+pub struct OptionalTransitions<'a>(&'a mut App);
+
+impl WithOptionalTransitions<ActivityState> for OptionalTransitions<'_> {
+	fn with_optional_transitions<TResult, M>(
+		self,
+		_: impl IntoSystem<(), Option<TResult>, M>,
+		_: HashMap<TResult, StateTransition<ActivityState>>,
+	) -> Result<(), TransitionsConfigError<ActivityState>>
+	where
+		TResult: PartialEq + Eq + std::hash::Hash,
+	{
+		Ok(())
 	}
 }
 

--- a/src/plugins/game_states/src/lib.rs
+++ b/src/plugins/game_states/src/lib.rs
@@ -4,7 +4,10 @@ mod system_params;
 mod systems;
 
 use crate::{
-	resources::{active_transitions::ActiveTransitions, game_state_context::GameStatesContext},
+	resources::{
+		configured_transitions::ConfiguredTransitions,
+		game_state_context::GameStatesContext,
+	},
 	states::activity::Activity,
 	system_params::{
 		game_states_read::GameStatesRead,
@@ -149,15 +152,15 @@ impl AutomaticGameStateTransitions<ActivityState> for GameStatesPlugin {
 			return Err(TransitionsConfigError::MayNotTransitionToSelf(from_state));
 		}
 
-		let ActiveTransitions(active_transitions) = app
+		let ConfiguredTransitions(configured_transitions) = app
 			.world_mut()
-			.get_resource_or_init::<ActiveTransitions>()
+			.get_resource_or_init::<ConfiguredTransitions>()
 			.into_inner();
-		if active_transitions.contains(&from_state) {
+		if configured_transitions.contains(&from_state) {
 			return Err(TransitionsConfigError::AlreadyConfigured(from_state));
 		}
 
-		active_transitions.insert(from_state);
+		configured_transitions.insert(from_state);
 
 		app.configure_sets(
 			OnEnter(Activity::from(from_state)),

--- a/src/plugins/game_states/src/resources.rs
+++ b/src/plugins/game_states/src/resources.rs
@@ -1,2 +1,2 @@
-pub(crate) mod active_transitions;
+pub(crate) mod configured_transitions;
 pub(crate) mod game_state_context;

--- a/src/plugins/game_states/src/resources.rs
+++ b/src/plugins/game_states/src/resources.rs
@@ -1,1 +1,2 @@
+pub(crate) mod active_transitions;
 pub(crate) mod game_state_context;

--- a/src/plugins/game_states/src/resources/active_transitions.rs
+++ b/src/plugins/game_states/src/resources/active_transitions.rs
@@ -1,0 +1,6 @@
+use bevy::prelude::*;
+use common::traits::handles_game_states::ActivityState;
+use std::collections::HashSet;
+
+#[derive(Resource, Debug, PartialEq, Default)]
+pub(crate) struct ActiveTransitions(pub(crate) HashSet<ActivityState>);

--- a/src/plugins/game_states/src/resources/configured_transitions.rs
+++ b/src/plugins/game_states/src/resources/configured_transitions.rs
@@ -3,4 +3,4 @@ use common::traits::handles_game_states::ActivityState;
 use std::collections::HashSet;
 
 #[derive(Resource, Debug, PartialEq, Default)]
-pub(crate) struct ActiveTransitions(pub(crate) HashSet<ActivityState>);
+pub(crate) struct ConfiguredTransitions(pub(crate) HashSet<ActivityState>);


### PR DESCRIPTION
Added a way to configure automatic state transitions in the `GameStatePlugin`:
- each state can be only configure once with target transitions
- each state cannot transition back to itself (at least not within one transition step)
- each state can be defined with additional transitions

It is likely that direct access to state mutation could be further limited in the future, but this should be decided once we have integrated this plugin with the rest of the app.