### PR TITLE
Game state pause

### DIFF
--- a/src/plugins/common/src/traits/handles_game_states.rs
+++ b/src/plugins/common/src/traits/handles_game_states.rs
@@ -16,7 +16,7 @@ use std::{
 };
 
 pub trait HandlesGameStates:
-	AddGameStateSystem + AutomaticGameStateTransitions<ActivityState>
+	AddGameStateSystem + AutomaticGameStateTransitions<ActivityState> + NonPausedStates
 {
 	type TGameStates: SystemParam + GameStates;
 	type TGameStatesMut: SystemParam + GameStatesMut;
@@ -79,6 +79,12 @@ where
 			}
 		}
 	}
+}
+
+pub trait NonPausedStates {
+	const NEVER_PAUSE: &[GameState] = &[GameState::Activity(ActivityState::Play)];
+
+	fn add_non_pause_state(app: &mut App, state: impl Into<GameState>);
 }
 
 pub trait GameStates {

--- a/src/plugins/common/src/traits/handles_game_states.rs
+++ b/src/plugins/common/src/traits/handles_game_states.rs
@@ -36,7 +36,7 @@ pub trait AutomaticGameStateTransitions<T> {
 	fn automatic_game_state_transitions(
 		app: &mut App,
 		from_state: T,
-		to_state: StateTransition<T>,
+		to_state: GameStateTransition<T>,
 	) -> Result<Self::TOptionalTransitions<'_>, TransitionsConfigError<T>>;
 }
 
@@ -44,14 +44,14 @@ pub trait WithOptionalTransitions<T> {
 	fn with_optional_transitions<TResult, M>(
 		self,
 		check: impl IntoSystem<(), Option<TResult>, M>,
-		transitions: HashMap<TResult, StateTransition<T>>,
+		transitions: HashMap<TResult, GameStateTransition<T>>,
 	) -> Result<(), TransitionsConfigError<T>>
 	where
 		TResult: PartialEq + Eq + Hash + ThreadSafe;
 }
 
 #[derive(Debug, PartialEq, Clone, Copy)]
-pub enum StateTransition<T> {
+pub enum GameStateTransition<T> {
 	To(T),
 	ToPrevious,
 }
@@ -82,7 +82,7 @@ where
 }
 
 pub trait NonPausedStates {
-	const NEVER_PAUSE: &[GameState] = &[GameState::Activity(ActivityState::Play)];
+	const DOES_NOT_PAUSE: &[ActivityState] = &[ActivityState::Play];
 
 	fn add_non_pause_state(app: &mut App, state: impl Into<GameState>);
 }

--- a/src/plugins/common/src/traits/handles_game_states.rs
+++ b/src/plugins/common/src/traits/handles_game_states.rs
@@ -82,7 +82,7 @@ where
 }
 
 pub trait NonPausedStates {
-	const DOES_NOT_PAUSE: &[ActivityState] = &[ActivityState::Play];
+	const DEFAULT: &[ActivityState] = &[ActivityState::Play];
 
 	fn add_non_pause_state(app: &mut App, state: impl Into<GameState>);
 }

--- a/src/plugins/game_states/src/lib.rs
+++ b/src/plugins/game_states/src/lib.rs
@@ -7,6 +7,7 @@ use crate::{
 	resources::{
 		configured_transitions::ConfiguredTransitions,
 		game_state_context::GameStateContext,
+		game_state_roles::GameStateRoles,
 	},
 	states::activity::Activity,
 	system_params::{
@@ -27,6 +28,7 @@ use common::{
 			AutomaticGameStateTransitions,
 			GameState,
 			HandlesGameStates,
+			NonPausedStates,
 			OnGameState,
 			StateTransition,
 			TransitionsConfigError,
@@ -91,6 +93,7 @@ impl Plugin for GameStatesPlugin {
 
 		app.init_state::<Activity>()
 			.init_resource::<GameStateContext>()
+			.init_resource::<GameStateRoles>()
 			.add_systems(
 				Update,
 				GameStateContext::sync_states.in_set(GameStateSystems),
@@ -131,6 +134,17 @@ impl AddGameStateSystem for GameStatesPlugin {
 				UIStates::on_exit(app, ui, systems);
 			}
 		}
+	}
+}
+
+impl NonPausedStates for GameStatesPlugin {
+	fn add_non_pause_state(app: &mut App, state: impl Into<GameState>) {
+		let GameStateRoles { non_pause_states } = app
+			.world_mut()
+			.get_resource_or_init::<GameStateRoles>()
+			.into_inner();
+
+		non_pause_states.insert(state.into());
 	}
 }
 

--- a/src/plugins/game_states/src/lib.rs
+++ b/src/plugins/game_states/src/lib.rs
@@ -16,7 +16,7 @@ use crate::{
 		ui_states::UIStates,
 	},
 };
-use bevy::{ecs::system::ScheduleSystem, prelude::*};
+use bevy::{ecs::system::ScheduleSystem, prelude::*, state::state::StateTransitionSystems};
 use common::{
 	errors::{ErrorData, Level},
 	systems::log::OnError,
@@ -27,10 +27,10 @@ use common::{
 			AddGameStateSystem,
 			AutomaticGameStateTransitions,
 			GameState,
+			GameStateTransition,
 			HandlesGameStates,
 			NonPausedStates,
 			OnGameState,
-			StateTransition,
 			TransitionsConfigError,
 			WithOptionalTransitions,
 		},
@@ -50,13 +50,13 @@ impl GameStatesPlugin {
 	fn apply_transition_from(
 		from_state: ActivityState,
 	) -> impl IntoSystem<
-		In<Option<StateTransition<ActivityState>>>,
+		In<Option<GameStateTransition<ActivityState>>>,
 		Result<(), TransitionError<ActivityState>>,
 		(),
 	> {
 		#[rustfmt::skip]
 		let system = move |
-			In(to_state): In<Option<StateTransition<ActivityState>>>,
+			In(to_state): In<Option<GameStateTransition<ActivityState>>>,
 			mut state_transitions: MessageReader<StateTransitionEvent<Activity>>,
 			mut state: ResMut<NextState<Activity>>
 		| {
@@ -65,10 +65,10 @@ impl GameStatesPlugin {
 			};
 
 			match to_state {
-				StateTransition::To(to_state) => {
+				GameStateTransition::To(to_state) => {
 					state.set(Activity::from(to_state));
 				}
-				StateTransition::ToPrevious => {
+				GameStateTransition::ToPrevious => {
 					let Some(last_transition) = state_transitions.read().last() else {
 						return Err(TransitionError::NoStateTransitionsFor(from_state));
 					};
@@ -95,8 +95,11 @@ impl Plugin for GameStatesPlugin {
 			.init_resource::<GameStateContext>()
 			.init_resource::<GameStateRoles>()
 			.add_systems(
-				Update,
-				GameStateContext::sync_states.in_set(GameStateSystems),
+				StateTransition,
+				(GameStateContext::sync_states, GameStateRoles::pause)
+					.chain()
+					.in_set(GameStateSystems)
+					.after(StateTransitionSystems::EnterSchedules),
 			);
 	}
 }
@@ -154,9 +157,9 @@ impl AutomaticGameStateTransitions<ActivityState> for GameStatesPlugin {
 	fn automatic_game_state_transitions(
 		app: &mut App,
 		from_state: ActivityState,
-		to_state: StateTransition<ActivityState>,
+		to_state: GameStateTransition<ActivityState>,
 	) -> Result<Self::TOptionalTransitions<'_>, TransitionsConfigError<ActivityState>> {
-		if matches!(to_state, StateTransition::To(to_state) if to_state == from_state) {
+		if matches!(to_state, GameStateTransition::To(to_state) if to_state == from_state) {
 			return Err(TransitionsConfigError::MayNotTransitionToSelf(from_state));
 		}
 
@@ -199,13 +202,13 @@ impl WithOptionalTransitions<ActivityState> for OptionalTransitions<'_> {
 	fn with_optional_transitions<TResult, M>(
 		self,
 		check: impl IntoSystem<(), Option<TResult>, M>,
-		transitions: HashMap<TResult, StateTransition<ActivityState>>,
+		transitions: HashMap<TResult, GameStateTransition<ActivityState>>,
 	) -> Result<(), TransitionsConfigError<ActivityState>>
 	where
 		TResult: PartialEq + Eq + Hash + ThreadSafe,
 	{
 		let any_self_transitions = transitions.values().any(
-			|to_state| matches!(to_state, StateTransition::To(to_state) if to_state == &self.from_state),
+			|to_state| matches!(to_state, GameStateTransition::To(to_state) if to_state == &self.from_state),
 		);
 		if any_self_transitions {
 			return Err(TransitionsConfigError::MayNotTransitionToSelf(
@@ -302,7 +305,7 @@ mod tests {
 		_ = GameStatesPlugin::automatic_game_state_transitions(
 			&mut app,
 			ActivityState::Paused,
-			StateTransition::To(ActivityState::Play),
+			GameStateTransition::To(ActivityState::Play),
 		);
 
 		app.world_mut()
@@ -325,7 +328,7 @@ mod tests {
 		_ = GameStatesPlugin::automatic_game_state_transitions(
 			&mut app,
 			ActivityState::Paused,
-			StateTransition::ToPrevious,
+			GameStateTransition::ToPrevious,
 		);
 
 		app.world_mut()
@@ -353,12 +356,12 @@ mod tests {
 		let transitions = GameStatesPlugin::automatic_game_state_transitions(
 			&mut app,
 			ActivityState::Paused,
-			StateTransition::To(ActivityState::Play),
+			GameStateTransition::To(ActivityState::Play),
 		)
 		.unwrap();
 		_ = transitions.with_optional_transitions(
 			|| Some("new game"),
-			HashMap::from([("new game", StateTransition::To(ActivityState::NewGame))]),
+			HashMap::from([("new game", GameStateTransition::To(ActivityState::NewGame))]),
 		);
 
 		app.world_mut()
@@ -381,12 +384,12 @@ mod tests {
 		let transitions = GameStatesPlugin::automatic_game_state_transitions(
 			&mut app,
 			ActivityState::Paused,
-			StateTransition::To(ActivityState::Play),
+			GameStateTransition::To(ActivityState::Play),
 		)
 		.unwrap();
 		_ = transitions.with_optional_transitions(
 			|| Some("previous"),
-			HashMap::from([("previous", StateTransition::ToPrevious)]),
+			HashMap::from([("previous", GameStateTransition::ToPrevious)]),
 		);
 
 		app.world_mut()
@@ -417,12 +420,12 @@ mod tests {
 		let transitions = GameStatesPlugin::automatic_game_state_transitions(
 			&mut app,
 			ActivityState::Paused,
-			StateTransition::To(ActivityState::Play),
+			GameStateTransition::To(ActivityState::Play),
 		)
 		.unwrap();
 		_ = transitions.with_optional_transitions(
 			move || result,
-			HashMap::from([("new game", StateTransition::To(ActivityState::NewGame))]),
+			HashMap::from([("new game", GameStateTransition::To(ActivityState::NewGame))]),
 		);
 
 		app.world_mut()
@@ -452,12 +455,12 @@ mod tests {
 		let transitions = GameStatesPlugin::automatic_game_state_transitions(
 			&mut app,
 			ActivityState::Paused,
-			StateTransition::To(ActivityState::Play),
+			GameStateTransition::To(ActivityState::Play),
 		)
 		.unwrap();
 		_ = transitions.with_optional_transitions(
 			|| Some(true),
-			HashMap::from([(true, StateTransition::To(ActivityState::Save))]),
+			HashMap::from([(true, GameStateTransition::To(ActivityState::Save))]),
 		);
 
 		app.world_mut()
@@ -480,13 +483,13 @@ mod tests {
 		_ = GameStatesPlugin::automatic_game_state_transitions(
 			&mut app,
 			ActivityState::Paused,
-			StateTransition::To(ActivityState::Play),
+			GameStateTransition::To(ActivityState::Play),
 		);
 
 		let result = GameStatesPlugin::automatic_game_state_transitions(
 			&mut app,
 			ActivityState::Paused,
-			StateTransition::To(ActivityState::Play),
+			GameStateTransition::To(ActivityState::Play),
 		);
 
 		let error = match result {
@@ -506,7 +509,7 @@ mod tests {
 		let result = GameStatesPlugin::automatic_game_state_transitions(
 			&mut app,
 			ActivityState::Paused,
-			StateTransition::To(ActivityState::Paused),
+			GameStateTransition::To(ActivityState::Paused),
 		);
 
 		let error = match result {
@@ -526,14 +529,14 @@ mod tests {
 		let transitions = GameStatesPlugin::automatic_game_state_transitions(
 			&mut app,
 			ActivityState::Paused,
-			StateTransition::To(ActivityState::Play),
+			GameStateTransition::To(ActivityState::Play),
 		)
 		.unwrap();
 		let result = transitions.with_optional_transitions(
 			|| Some("foo"),
 			HashMap::from([
-				("foo", StateTransition::ToPrevious),
-				("bar", StateTransition::To(ActivityState::Paused)),
+				("foo", GameStateTransition::ToPrevious),
+				("bar", GameStateTransition::To(ActivityState::Paused)),
 			]),
 		);
 

--- a/src/plugins/game_states/src/resources.rs
+++ b/src/plugins/game_states/src/resources.rs
@@ -1,2 +1,3 @@
 pub(crate) mod configured_transitions;
 pub(crate) mod game_state_context;
+pub(crate) mod game_state_roles;

--- a/src/plugins/game_states/src/resources/game_state_roles.rs
+++ b/src/plugins/game_states/src/resources/game_state_roles.rs
@@ -1,0 +1,17 @@
+use crate::GameStatesPlugin;
+use bevy::prelude::*;
+use common::traits::handles_game_states::{GameState, NonPausedStates};
+use std::collections::HashSet;
+
+#[derive(Resource, Debug, PartialEq)]
+pub(crate) struct GameStateRoles {
+	pub(crate) non_pause_states: HashSet<GameState>,
+}
+
+impl Default for GameStateRoles {
+	fn default() -> Self {
+		Self {
+			non_pause_states: HashSet::from_iter(GameStatesPlugin::NEVER_PAUSE.iter().copied()),
+		}
+	}
+}

--- a/src/plugins/game_states/src/resources/game_state_roles.rs
+++ b/src/plugins/game_states/src/resources/game_state_roles.rs
@@ -18,7 +18,7 @@ impl Default for GameStateRoles {
 	fn default() -> Self {
 		Self {
 			non_pause_states: HashSet::from_iter(
-				GameStatesPlugin::DOES_NOT_PAUSE
+				GameStatesPlugin::DEFAULT
 					.iter()
 					.copied()
 					.map(GameState::Activity),

--- a/src/plugins/game_states/src/resources/game_state_roles.rs
+++ b/src/plugins/game_states/src/resources/game_state_roles.rs
@@ -8,10 +8,21 @@ pub(crate) struct GameStateRoles {
 	pub(crate) non_pause_states: HashSet<GameState>,
 }
 
+impl GameStateRoles {
+	pub(crate) fn is_pause_state(&self, state: impl Into<GameState>) -> bool {
+		!self.non_pause_states.contains(&state.into())
+	}
+}
+
 impl Default for GameStateRoles {
 	fn default() -> Self {
 		Self {
-			non_pause_states: HashSet::from_iter(GameStatesPlugin::NEVER_PAUSE.iter().copied()),
+			non_pause_states: HashSet::from_iter(
+				GameStatesPlugin::DOES_NOT_PAUSE
+					.iter()
+					.copied()
+					.map(GameState::Activity),
+			),
 		}
 	}
 }

--- a/src/plugins/game_states/src/systems.rs
+++ b/src/plugins/game_states/src/systems.rs
@@ -1,1 +1,2 @@
+pub(crate) mod pause;
 pub(crate) mod sync_states;

--- a/src/plugins/game_states/src/systems/pause.rs
+++ b/src/plugins/game_states/src/systems/pause.rs
@@ -80,7 +80,7 @@ mod tests {
 	fn default_non_pause_states_do_not_pause() {
 		let mut app = setup();
 
-		for state in GameStatesPlugin::DOES_NOT_PAUSE {
+		for state in GameStatesPlugin::DEFAULT {
 			app.world_mut().resource_mut::<Time<Virtual>>().pause();
 			app.world_mut().resource_mut::<GameStateContext>().activity = *state;
 

--- a/src/plugins/game_states/src/systems/pause.rs
+++ b/src/plugins/game_states/src/systems/pause.rs
@@ -1,0 +1,132 @@
+use crate::{
+	resources::game_state_roles::GameStateRoles,
+	system_params::game_states_read::GameStatesRead,
+};
+use bevy::prelude::*;
+use common::traits::handles_game_states::GameStates;
+
+impl GameStateRoles {
+	pub(crate) fn pause(
+		mut time: ResMut<Time<Virtual>>,
+		current: GameStatesRead,
+		roles: Res<GameStateRoles>,
+	) {
+		let any_pauses = current
+			.game_states()
+			.iter()
+			.any(|state| roles.is_pause_state(state));
+
+		if any_pauses {
+			time.pause();
+		} else {
+			time.unpause();
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::{
+		GameStatesPlugin,
+		resources::game_state_context::GameStateContext,
+		states::activity::Activity,
+		system_params::ui_states::UIStates,
+	};
+	use bevy::{state::app::StatesPlugin, time::TimePlugin};
+	use common::traits::handles_game_states::{ActivityState, GameState, NonPausedStates, UIState};
+	use testing::SingleThreadedApp;
+
+	fn setup() -> App {
+		let mut app = App::new().single_threaded(Update);
+
+		app.add_plugins(StatesPlugin);
+		app.add_plugins(TimePlugin);
+		UIStates::init(&mut app);
+		app.init_state::<Activity>();
+		app.init_resource::<GameStateContext>();
+		app.init_resource::<GameStateRoles>();
+		app.add_systems(Update, GameStateRoles::pause);
+
+		app
+	}
+
+	#[test]
+	fn pause() {
+		let mut app = setup();
+		app.world_mut().resource_mut::<GameStateContext>().activity = ActivityState::Paused;
+
+		app.update();
+
+		assert!(app.world().resource::<Time<Virtual>>().is_paused());
+	}
+
+	#[test]
+	fn un_pause_if_state_excluded_from_pause() {
+		let mut app = setup();
+		app.world_mut().resource_mut::<Time<Virtual>>().pause();
+		app.world_mut()
+			.resource_mut::<GameStateRoles>()
+			.non_pause_states
+			.insert(GameState::Activity(ActivityState::Paused));
+		app.world_mut().resource_mut::<GameStateContext>().activity = ActivityState::Paused;
+
+		app.update();
+
+		assert!(!app.world().resource::<Time<Virtual>>().is_paused());
+	}
+
+	#[test]
+	fn default_non_pause_states_do_not_pause() {
+		let mut app = setup();
+
+		for state in GameStatesPlugin::DOES_NOT_PAUSE {
+			app.world_mut().resource_mut::<Time<Virtual>>().pause();
+			app.world_mut().resource_mut::<GameStateContext>().activity = *state;
+
+			app.update();
+
+			assert!(!app.world().resource::<Time<Virtual>>().is_paused());
+		}
+	}
+
+	#[test]
+	fn pause_on_ui_state() {
+		let mut app = setup();
+		app.world_mut()
+			.resource_mut::<GameStateRoles>()
+			.non_pause_states
+			.insert(GameState::Activity(ActivityState::Paused));
+		app.world_mut().resource_mut::<GameStateContext>().activity = ActivityState::Paused;
+		app.world_mut()
+			.resource_mut::<GameStateContext>()
+			.ui
+			.insert(UIState::Hud);
+
+		app.update();
+
+		assert!(app.world().resource::<Time<Virtual>>().is_paused());
+	}
+
+	#[test]
+	fn un_pause_if_ui_state_excluded_from_pause() {
+		let mut app = setup();
+		app.world_mut().resource_mut::<Time<Virtual>>().pause();
+		app.world_mut()
+			.resource_mut::<GameStateRoles>()
+			.non_pause_states
+			.extend([
+				GameState::Activity(ActivityState::Paused),
+				GameState::IngameUI(UIState::Hud),
+			]);
+		app.world_mut().resource_mut::<GameStateContext>().activity = ActivityState::Paused;
+		app.world_mut()
+			.resource_mut::<GameStateContext>()
+			.ui
+			.insert(UIState::Hud);
+
+		app.update();
+
+		assert!(!app.world().resource::<Time<Virtual>>().is_paused());
+	}
+}


### PR DESCRIPTION
Added interface to make game state not pause the game:
- `GameState::Play` is added by default
- all other states are treated as pausing the game
- interface is implemented by `GameStatePlugin`